### PR TITLE
Export state with dimension attribute

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -21,3 +21,5 @@
 ^\.covrignore$
 ^\.github$
 \.*gcov$
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/R/cpp11.R
+++ b/R/cpp11.R
@@ -8,8 +8,8 @@ dust2_cpu_walk_run_steps <- function(ptr, r_n_steps) {
   .Call(`_dust2_dust2_cpu_walk_run_steps`, ptr, r_n_steps)
 }
 
-dust2_cpu_walk_state <- function(ptr) {
-  .Call(`_dust2_dust2_cpu_walk_state`, ptr)
+dust2_cpu_walk_state <- function(ptr, grouped) {
+  .Call(`_dust2_dust2_cpu_walk_state`, ptr, grouped)
 }
 
 dust2_cpu_walk_time <- function(ptr) {

--- a/inst/include/dust2/cpu.hpp
+++ b/inst/include/dust2/cpu.hpp
@@ -101,6 +101,18 @@ public:
     return time_;
   }
 
+  auto n_state() const {
+    return n_state_;
+  }
+
+  auto n_particles() const {
+    return n_particles_;
+  }
+
+  auto n_groups() const {
+    return n_groups_;
+  }
+
   void set_time(real_type time) {
     time_ = time;
   }

--- a/inst/include/dust2/cpu.hpp
+++ b/inst/include/dust2/cpu.hpp
@@ -132,10 +132,6 @@ public:
     fn(shared_[i]);
   }
 
-  auto n_groups() const {
-    return n_groups_;
-  }
-
 private:
   size_t n_state_;
   size_t n_particles_;

--- a/inst/include/dust2/cpu.hpp
+++ b/inst/include/dust2/cpu.hpp
@@ -90,7 +90,7 @@ public:
     std::copy_n(it, state_.size(), state_.begin());
   }
 
-  auto state() const {
+  auto& state() const {
     return state_;
   }
 

--- a/inst/include/dust2/r/cpu.hpp
+++ b/inst/include/dust2/r/cpu.hpp
@@ -83,14 +83,16 @@ SEXP dust2_cpu_run_steps(cpp11::sexp ptr, cpp11::sexp r_n_steps) {
 template <typename T>
 SEXP dust2_cpu_state(cpp11::sexp ptr, bool grouped) {
   auto *obj = cpp11::as_cpp<cpp11::external_pointer<dust_cpu<T>>>(ptr).get();
-  const auto state = obj->state().begin();
+  cpp11::sexp ret = R_NilValue;
+  const auto it = obj->state().begin();
   if (grouped) {
-    return export_array_n(state,
-                          {obj->n_state(), obj->n_particles(), obj->n_groups()});
+    ret = export_array_n(it,
+                         {obj->n_state(), obj->n_particles(), obj->n_groups()});
   } else {
-    return export_array_n(state,
-                          {obj->n_state(), obj->n_particles() * obj->n_groups()});
+    ret = export_array_n(it,
+                         {obj->n_state(), obj->n_particles() * obj->n_groups()});
   }
+  return ret;
 }
 
 template <typename T>

--- a/inst/include/dust2/r/cpu.hpp
+++ b/inst/include/dust2/r/cpu.hpp
@@ -81,10 +81,16 @@ SEXP dust2_cpu_run_steps(cpp11::sexp ptr, cpp11::sexp r_n_steps) {
 }
 
 template <typename T>
-SEXP dust2_cpu_state(cpp11::sexp ptr) {
+SEXP dust2_cpu_state(cpp11::sexp ptr, bool grouped) {
   auto *obj = cpp11::as_cpp<cpp11::external_pointer<dust_cpu<T>>>(ptr).get();
-  // return to_matrix(obj->state(), obj->n_state, obj->n_particles);
-  return cpp11::as_sexp(obj->state());
+  const auto state = obj->state().begin();
+  if (grouped) {
+    return export_array_n(state,
+                          {obj->n_state(), obj->n_particles(), obj->n_groups()});
+  } else {
+    return export_array_n(state,
+                          {obj->n_state(), obj->n_particles() * obj->n_groups()});
+  }
 }
 
 template <typename T>
@@ -93,6 +99,18 @@ SEXP dust2_cpu_time(cpp11::sexp ptr) {
   return cpp11::as_sexp(obj->time());
 }
 
+// If this is a grouped model then we will return a matrix with
+// dimensions )(state x particle x group) and if we are ungrouped
+// (state x particle); the difference is really only apparent in the
+// case where we have a single group to drop.  In dust1 we had the
+// option for (state x group) for simulations too.
+//
+// For now perhaps lets just ignore this detail and always return the
+// 3d version as the code to do grouped/ungrouped switching is deep
+// within one of the many in-progress branches and I can't find it
+// yet.
+//
+// In the case where we have time, that goes in the last position
 template <typename T>
 SEXP dust2_cpu_set_state_initial(cpp11::sexp ptr) {
   auto *obj = cpp11::as_cpp<cpp11::external_pointer<dust_cpu<T>>>(ptr).get();

--- a/inst/include/dust2/r/helpers.hpp
+++ b/inst/include/dust2/r/helpers.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <numeric>
+
 namespace dust2 {
 namespace r {
 
@@ -83,14 +85,21 @@ inline double check_dt(cpp11::sexp r_dt) {
   return dt;
 }
 
-// template <typename real_type>
-// inline cpp11::sexp to_matrix(std::vector<real_type> x, size_t nr, size_t nc) {
-//   cpp11::writable::integers dim{static_cast<int>(nr), static_cast<int>(nc)};
-//   cpp11::writable::doubles ret(x.size());
-//   std::copy(x.begin(), x.end(), REAL(ret));
-//   ret.attr("dim") = dim;
-//   return ret;
-// }
+// The initializer_list is a type-safe variadic-like approach.
+template <typename It>
+cpp11::sexp export_array_n(It it, std::initializer_list<size_t> dims) {
+  const auto len =
+    std::accumulate(dims.begin(), dims.end(), 1, std::multiplies<>{});
+  cpp11::writable::integers r_dim(dims.size());
+  auto dim_i = dims.begin();
+  for (size_t i = 0; i < dims.size(); ++i, ++dim_i) {
+    r_dim[i] = *dim_i;
+  }
+  cpp11::writable::doubles ret(len);
+  std::copy_n(it, len, ret.begin());
+  ret.attr("dim") = r_dim;
+  return ret;
+}
 
 }
 }

--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -20,10 +20,10 @@ extern "C" SEXP _dust2_dust2_cpu_walk_run_steps(SEXP ptr, SEXP r_n_steps) {
   END_CPP11
 }
 // walk.cpp
-SEXP dust2_cpu_walk_state(cpp11::sexp ptr);
-extern "C" SEXP _dust2_dust2_cpu_walk_state(SEXP ptr) {
+SEXP dust2_cpu_walk_state(cpp11::sexp ptr, bool grouped);
+extern "C" SEXP _dust2_dust2_cpu_walk_state(SEXP ptr, SEXP grouped) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust2_cpu_walk_state(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr)));
+    return cpp11::as_sexp(dust2_cpu_walk_state(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<bool>>(grouped)));
   END_CPP11
 }
 // walk.cpp
@@ -77,7 +77,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_dust2_dust2_cpu_walk_set_state",         (DL_FUNC) &_dust2_dust2_cpu_walk_set_state,         2},
     {"_dust2_dust2_cpu_walk_set_state_initial", (DL_FUNC) &_dust2_dust2_cpu_walk_set_state_initial, 1},
     {"_dust2_dust2_cpu_walk_set_time",          (DL_FUNC) &_dust2_dust2_cpu_walk_set_time,          2},
-    {"_dust2_dust2_cpu_walk_state",             (DL_FUNC) &_dust2_dust2_cpu_walk_state,             1},
+    {"_dust2_dust2_cpu_walk_state",             (DL_FUNC) &_dust2_dust2_cpu_walk_state,             2},
     {"_dust2_dust2_cpu_walk_time",              (DL_FUNC) &_dust2_dust2_cpu_walk_time,              1},
     {"_dust2_dust2_cpu_walk_update_pars",       (DL_FUNC) &_dust2_dust2_cpu_walk_update_pars,       3},
     {NULL, NULL, 0}

--- a/src/walk.cpp
+++ b/src/walk.cpp
@@ -26,8 +26,8 @@ SEXP dust2_cpu_walk_run_steps(cpp11::sexp ptr, cpp11::sexp r_n_steps) {
 }
 
 [[cpp11::register]]
-SEXP dust2_cpu_walk_state(cpp11::sexp ptr) {
-  return dust2::r::dust2_cpu_state<walk>(ptr);
+SEXP dust2_cpu_walk_state(cpp11::sexp ptr, bool grouped) {
+  return dust2::r::dust2_cpu_state<walk>(ptr, grouped);
 }
 
 [[cpp11::register]]

--- a/tests/testthat/test-walk.R
+++ b/tests/testthat/test-walk.R
@@ -240,15 +240,15 @@ test_that("can update parameters", {
   ptr <- obj[[1]]
 
   expect_null(dust2_cpu_walk_run_steps(ptr, 1))
-  s1 <- dust2_cpu_walk_state(ptr)
+  s1 <- dust2_cpu_walk_state(ptr, FALSE)
 
   expect_null(dust2_cpu_walk_update_pars(ptr, pars2, FALSE))
   expect_null(dust2_cpu_walk_run_steps(ptr, 1))
-  s2 <- dust2_cpu_walk_state(ptr)
+  s2 <- dust2_cpu_walk_state(ptr, FALSE)
 
   r <- mcstate2::mcstate_rng$new(seed = 42, n_streams = 10)
-  expect_equal(s1, drop(r$normal(1, 0, 1)))
-  expect_equal(s2, s1 + drop(r$normal(1, 0, 10)))
+  expect_equal(s1, r$normal(1, 0, 1))
+  expect_equal(s2, s1 + r$normal(1, 0, 10))
 })
 
 
@@ -260,15 +260,15 @@ test_that("can update parameters for grouped models", {
   ptr <- obj[[1]]
 
   expect_null(dust2_cpu_walk_run_steps(ptr, 1))
-  s1 <- dust2_cpu_walk_state(ptr)
+  s1 <- dust2_cpu_walk_state(ptr, FALSE)
 
   expect_null(dust2_cpu_walk_update_pars(ptr, pars2, TRUE))
   expect_null(dust2_cpu_walk_run_steps(ptr, 1))
-  s2 <- dust2_cpu_walk_state(ptr)
+  s2 <- dust2_cpu_walk_state(ptr, FALSE)
 
   r <- mcstate2::mcstate_rng$new(seed = 42, n_streams = 40)
-  expect_equal(s1, drop(r$normal(1, 0, 1)) * rep(1:4, each = 10))
-  expect_equal(s2, s1 + drop(r$normal(1, 0, 10)) * rep(1:4, each = 10))
+  expect_equal(s1, r$normal(1, 0, 1) * rep(1:4, each = 10))
+  expect_equal(s2, s1 + r$normal(1, 0, 10) * rep(1:4, each = 10))
 })
 
 


### PR DESCRIPTION
~Merge after #3, contains those commits.~

This PR allows export of state as a multidimensional matrix.  The export code potentially fairly interesting, using the c++ initializer list in place of a variadic arg which is new to me, but seems to be fairly concise and easy to read.  We'll use this approach for saving the trajectories over time too.