### PR TITLE
Allow periodic accumulation of variables

### DIFF
--- a/inst/examples/sir.cpp
+++ b/inst/examples/sir.cpp
@@ -57,7 +57,7 @@ public:
     const auto I = state[1];
     const auto R = state[2];
     const auto cases_cumul = state[3];
-    // const auto cases_inc = state[4];
+    const auto cases_inc = state[4];
     const auto p_SI = 1 - mcstate::math::exp(-shared.beta * I / shared.N * dt);
     const auto p_IR = 1 - mcstate::math::exp(-shared.gamma * dt);
     const auto n_SI = mcstate::random::binomial<real_type>(rng_state, S, p_SI);
@@ -66,8 +66,7 @@ public:
     state_next[1] = I + n_SI - n_IR;
     state_next[2] = R + n_IR;
     state_next[3] = cases_cumul + n_SI;
-    // state_next[4] = (time % shared.freq == 0) ? n_SI : (cases_inc + n_SI);
-    state_next[4] = n_SI;
+    state_next[4] = dust2::tools::accumulate_periodic(time, static_cast<real_type>(1), cases_inc, n_SI);
   }
 
   static shared_state build_shared(cpp11::list pars) {

--- a/inst/include/dust2/common.hpp
+++ b/inst/include/dust2/common.hpp
@@ -4,6 +4,7 @@
 // choice of directory here.
 #include <mcstate/random/random.hpp>
 #include <mcstate/random/density.hpp>
+#include <dust2/tools.hpp>
 
 namespace dust2 {
 

--- a/inst/include/dust2/tools.hpp
+++ b/inst/include/dust2/tools.hpp
@@ -11,7 +11,7 @@ template <>
 inline bool is_evenly_divisible_by(double num, double by) {
   // This eps is chosen to be less than machine precision, though more
   // than sqrt(precision) and is consistent with the maximum expected
-  // accumulation of rounding error for pathalogical choices of dt.
+  // accumulation of rounding error for pathological choices of dt.
   constexpr double eps = 1e-13;
   return std::abs(std::fmod(num, by)) < eps;
 }

--- a/inst/include/dust2/tools.hpp
+++ b/inst/include/dust2/tools.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+namespace dust2 {
+namespace tools {
+
+namespace {
+template <typename T>
+bool is_evenly_divisible_by(T num, T by);
+
+template <>
+inline bool is_evenly_divisible_by(double num, double by) {
+  // This eps is chosen to be less than machine precision, though more
+  // than sqrt(precision) and is consistent with the maximum expected
+  // accumulation of rounding error for pathalogical choices of dt.
+  constexpr double eps = 1e-13;
+  return std::abs(std::fmod(num, by)) < eps;
+}
+
+}
+
+template <typename T, typename U>
+T accumulate_periodic(T time, T period, U previous, U value) {
+  return is_evenly_divisible_by(time, period) ? value : previous + value;
+}
+
+}
+}


### PR DESCRIPTION
Merge after #2, contains those commits

This PR adds a helper for accumulation of periodic incidence (e.g., case over a day).  It is stateless - in that it requires no additional state to be stored in the object - which makes it easy to use.  We'll need a better trick to do this for ODE models once we support those.