### PR TITLE
Allow reordering state

### DIFF
--- a/R/cpp11.R
+++ b/R/cpp11.R
@@ -56,6 +56,10 @@ dust2_cpu_walk_set_state <- function(ptr, r_state, grouped) {
   .Call(`_dust2_dust2_cpu_walk_set_state`, ptr, r_state, grouped)
 }
 
+dust2_cpu_walk_reorder <- function(ptr, r_index) {
+  .Call(`_dust2_dust2_cpu_walk_reorder`, ptr, r_index)
+}
+
 dust2_cpu_walk_rng_state <- function(ptr) {
   .Call(`_dust2_dust2_cpu_walk_rng_state`, ptr)
 }

--- a/inst/include/dust2/cpu.hpp
+++ b/inst/include/dust2/cpu.hpp
@@ -104,6 +104,20 @@ public:
     }
   }
 
+  template <typename It>
+  void reorder(It it) {
+    for (size_t i = 0; i < n_groups_; ++i) {
+      for (size_t j = 0; j < n_particles_; ++j) {
+        const auto k_to = n_particles_ * i + j;
+        const auto k_from = n_particles_ * i + *(it + k_to);
+        std::copy_n(state_.begin() + k_from * n_state_,
+                    n_state_,
+                    state_next_.begin() + k_to * n_state_);
+      }
+    }
+    std::swap(state_, state_next_);
+  }
+
   auto& state() const {
     return state_;
   }

--- a/inst/include/dust2/cpu.hpp
+++ b/inst/include/dust2/cpu.hpp
@@ -85,8 +85,8 @@ public:
     }
   }
 
-  template <typename It>
-  void set_state(It it, bool recycle_particle, bool recycle_group) {
+  template <typename Iter>
+  void set_state(Iter iter, bool recycle_particle, bool recycle_group) {
     const auto offset_read_group = recycle_group ? 0 :
       (n_state_ * (recycle_particle ? 1 : n_particles_));
     const auto offset_read_particle = recycle_particle ? 0 : n_state_;
@@ -97,19 +97,19 @@ public:
         const auto offset_read =
           i * offset_read_group + j * offset_read_particle;
         const auto offset_write = (n_particles_ * i + j) * n_state_;
-        std::copy_n(it + offset_read,
+        std::copy_n(iter + offset_read,
                     n_state_,
                     state_data + offset_write);
       }
     }
   }
 
-  template <typename It>
-  void reorder(It it) {
+  template <typename Iter>
+  void reorder(Iter iter) {
     for (size_t i = 0; i < n_groups_; ++i) {
       for (size_t j = 0; j < n_particles_; ++j) {
         const auto k_to = n_particles_ * i + j;
-        const auto k_from = n_particles_ * i + *(it + k_to);
+        const auto k_from = n_particles_ * i + *(iter + k_to);
         std::copy_n(state_.begin() + k_from * n_state_,
                     n_state_,
                     state_next_.begin() + k_to * n_state_);
@@ -160,15 +160,15 @@ public:
     fn(shared_[i]);
   }
 
-  template <typename It>
-  void compare_data(const std::vector<data_type>& data, It it) {
+  template <typename Iter>
+  void compare_data(const std::vector<data_type>& data, Iter iter) {
     const real_type * state_data = state_.data();
     for (size_t i = 0; i < n_groups_; ++i) {
-      for (size_t j = 0; j < n_particles_; ++j, ++it) {
+      for (size_t j = 0; j < n_particles_; ++j, ++iter) {
         const auto k = n_particles_ * i + j;
         const auto offset = k * n_state_;
-        *it = T::compare_data(time_, dt_, state_data + offset, data[i],
-                              shared_[i], internal_[i], rng_.state(k));
+        *iter = T::compare_data(time_, dt_, state_data + offset, data[i],
+                                shared_[i], internal_[i], rng_.state(k));
       }
     }
   }

--- a/inst/include/dust2/r/cpu.hpp
+++ b/inst/include/dust2/r/cpu.hpp
@@ -154,6 +154,31 @@ SEXP dust2_cpu_set_state(cpp11::sexp ptr, cpp11::sexp r_state, bool grouped) {
   return R_NilValue;
 }
 
+// Not really intended to be called by users, this just helps us test
+// bookkeeping really.
+template <typename T>
+SEXP dust2_cpu_reorder(cpp11::sexp ptr, cpp11::integers r_index) {
+  auto *obj = cpp11::as_cpp<cpp11::external_pointer<dust_cpu<T>>>(ptr).get();
+  const auto n_particles = obj->n_particles();
+  const auto n_groups = obj->n_groups();
+  const int len = n_particles * n_groups;
+  // We really should expect a matrix perhaps, but this test will
+  // catch that confusingly at least.  Users won't actually call this.
+  if (r_index.size() != len) {
+    cpp11::stop("Expected an index of length %d", len);
+  }
+  std::vector<size_t> index;
+  index.reserve(len);
+  for (auto i : r_index) {
+    if (i < 1 || i > len) {
+      cpp11::stop("Expected 'index' values to lie in [1, %d]", n_particles);
+    }
+    index.push_back(i - 1);
+  }
+  obj->reorder(index.begin());
+  return R_NilValue;
+}
+
 template <typename T>
 SEXP dust2_cpu_rng_state(cpp11::sexp ptr) {
   using rng_state_type = typename T::rng_state_type;

--- a/inst/include/dust2/r/cpu.hpp
+++ b/inst/include/dust2/r/cpu.hpp
@@ -84,12 +84,12 @@ template <typename T>
 SEXP dust2_cpu_state(cpp11::sexp ptr, bool grouped) {
   auto *obj = cpp11::as_cpp<cpp11::external_pointer<dust_cpu<T>>>(ptr).get();
   cpp11::sexp ret = R_NilValue;
-  const auto it = obj->state().begin();
+  const auto iter = obj->state().begin();
   if (grouped) {
-    ret = export_array_n(it,
+    ret = export_array_n(iter,
                          {obj->n_state(), obj->n_particles(), obj->n_groups()});
   } else {
-    ret = export_array_n(it,
+    ret = export_array_n(iter,
                          {obj->n_state(), obj->n_particles() * obj->n_groups()});
   }
   return ret;

--- a/inst/include/dust2/r/helpers.hpp
+++ b/inst/include/dust2/r/helpers.hpp
@@ -102,12 +102,12 @@ inline void set_array_dims(cpp11::sexp data,
   data.attr("dim") = r_dim;
 }
 
-template <typename It>
-cpp11::sexp export_array_n(It it, std::initializer_list<size_t> dims) {
+template <typename Iter>
+cpp11::sexp export_array_n(Iter iter, std::initializer_list<size_t> dims) {
   const auto len =
     std::accumulate(dims.begin(), dims.end(), 1, std::multiplies<>{});
   cpp11::writable::doubles ret(len);
-  std::copy_n(it, len, ret.begin());
+  std::copy_n(iter, len, ret.begin());
   set_array_dims(ret, dims);
   return ret;
 }

--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -104,6 +104,13 @@ extern "C" SEXP _dust2_dust2_cpu_walk_set_state(SEXP ptr, SEXP r_state, SEXP gro
   END_CPP11
 }
 // walk.cpp
+SEXP dust2_cpu_walk_reorder(cpp11::sexp ptr, cpp11::integers r_index);
+extern "C" SEXP _dust2_dust2_cpu_walk_reorder(SEXP ptr, SEXP r_index) {
+  BEGIN_CPP11
+    return cpp11::as_sexp(dust2_cpu_walk_reorder(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::integers>>(r_index)));
+  END_CPP11
+}
+// walk.cpp
 SEXP dust2_cpu_walk_rng_state(cpp11::sexp ptr);
 extern "C" SEXP _dust2_dust2_cpu_walk_rng_state(SEXP ptr) {
   BEGIN_CPP11
@@ -136,6 +143,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_dust2_dust2_cpu_sir_state",              (DL_FUNC) &_dust2_dust2_cpu_sir_state,              2},
     {"_dust2_dust2_cpu_sir_time",               (DL_FUNC) &_dust2_dust2_cpu_sir_time,               1},
     {"_dust2_dust2_cpu_walk_alloc",             (DL_FUNC) &_dust2_dust2_cpu_walk_alloc,             7},
+    {"_dust2_dust2_cpu_walk_reorder",           (DL_FUNC) &_dust2_dust2_cpu_walk_reorder,           2},
     {"_dust2_dust2_cpu_walk_rng_state",         (DL_FUNC) &_dust2_dust2_cpu_walk_rng_state,         1},
     {"_dust2_dust2_cpu_walk_run_steps",         (DL_FUNC) &_dust2_dust2_cpu_walk_run_steps,         2},
     {"_dust2_dust2_cpu_walk_set_state",         (DL_FUNC) &_dust2_dust2_cpu_walk_set_state,         3},

--- a/src/walk.cpp
+++ b/src/walk.cpp
@@ -47,6 +47,11 @@ SEXP dust2_cpu_walk_set_state(cpp11::sexp ptr, cpp11::sexp r_state,
 }
 
 [[cpp11::register]]
+SEXP dust2_cpu_walk_reorder(cpp11::sexp ptr, cpp11::integers r_index) {
+  return dust2::r::dust2_cpu_reorder<walk>(ptr, r_index);
+}
+
+[[cpp11::register]]
 SEXP dust2_cpu_walk_rng_state(cpp11::sexp ptr) {
   return dust2::r::dust2_cpu_rng_state<walk>(ptr);
 }

--- a/tests/testthat/test-walk.R
+++ b/tests/testthat/test-walk.R
@@ -383,11 +383,11 @@ test_that("can reorder state", {
   obj <- dust2_cpu_walk_alloc(pars, 0, 1, 10, 0, 42, FALSE)
   ptr <- obj[[1]]
   expect_null(dust2_cpu_walk_set_state_initial(ptr))
-  s1 <- dust2_cpu_walk_state(ptr)
+  s1 <- dust2_cpu_walk_state(ptr, FALSE)
   i <- sample(10, replace = TRUE)
   expect_null(dust2_cpu_walk_reorder(ptr, i))
-  s2 <- dust2_cpu_walk_state(ptr)
-  expect_equal(s2, s1[i])
+  s2 <- dust2_cpu_walk_state(ptr, FALSE)
+  expect_equal(s2, s1[, i, drop = FALSE])
 })
 
 
@@ -396,10 +396,11 @@ test_that("can reorder state in a multiparameter model", {
   obj <- dust2_cpu_walk_alloc(pars, 0, 1, 10, 4, 42, FALSE)
   ptr <- obj[[1]]
   expect_null(dust2_cpu_walk_set_state_initial(ptr))
-  s1 <- matrix(dust2_cpu_walk_state(ptr), 10)
+  s1 <- dust2_cpu_walk_state(ptr, TRUE)
   i <- replicate(4, sample(10, replace = TRUE))
   expect_null(dust2_cpu_walk_reorder(ptr, i))
-  s2 <- matrix(dust2_cpu_walk_state(ptr), 10)
-
-  expect_equal(s2, vapply(1:4, function(j) s1[i[, j], j], numeric(10)))
+  s2 <- dust2_cpu_walk_state(ptr, TRUE)
+  expect_equal(
+    s2,
+    vapply(1:4, function(j) s1[, i[, j], j, drop = FALSE], matrix(0, 1, 10)))
 })

--- a/tests/testthat/test-walk.R
+++ b/tests/testthat/test-walk.R
@@ -389,3 +389,17 @@ test_that("can reorder state", {
   s2 <- dust2_cpu_walk_state(ptr)
   expect_equal(s2, s1[i])
 })
+
+
+test_that("can reorder state in a multiparameter model", {
+  pars <- lapply(1:4, function(sd) list(sd = sd, random_initial = TRUE))
+  obj <- dust2_cpu_walk_alloc(pars, 0, 1, 10, 4, 42, FALSE)
+  ptr <- obj[[1]]
+  expect_null(dust2_cpu_walk_set_state_initial(ptr))
+  s1 <- matrix(dust2_cpu_walk_state(ptr), 10)
+  i <- replicate(4, sample(10, replace = TRUE))
+  expect_null(dust2_cpu_walk_reorder(ptr, i))
+  s2 <- matrix(dust2_cpu_walk_state(ptr), 10)
+
+  expect_equal(s2, vapply(1:4, function(j) s1[i[, j], j], numeric(10)))
+})

--- a/tests/testthat/test-walk.R
+++ b/tests/testthat/test-walk.R
@@ -376,3 +376,16 @@ test_that("can set ungrouped state into grouped model", {
   expect_equal(dust2_cpu_walk_state(ptr, TRUE),
                array(s, c(3, 10, 4)))
 })
+
+
+test_that("can reorder state", {
+  pars <- list(sd = 1, random_initial = TRUE)
+  obj <- dust2_cpu_walk_alloc(pars, 0, 1, 10, 0, 42, FALSE)
+  ptr <- obj[[1]]
+  expect_null(dust2_cpu_walk_set_state_initial(ptr))
+  s1 <- dust2_cpu_walk_state(ptr)
+  i <- sample(10, replace = TRUE)
+  expect_null(dust2_cpu_walk_reorder(ptr, i))
+  s2 <- dust2_cpu_walk_state(ptr)
+  expect_equal(s2, s1[i])
+})


### PR DESCRIPTION
This PR allows us to reorder state among particles; this is one of the bits we need to support a particle filter and is rarely useful in its own right.  I've exposed a little helper for it for now at least though as it makes testing much easier.