### PR TITLE
Run to time, rather than number of steps

### DIFF
--- a/R/cpp11.R
+++ b/R/cpp11.R
@@ -8,6 +8,10 @@ dust2_cpu_sir_run_steps <- function(ptr, r_n_steps) {
   .Call(`_dust2_dust2_cpu_sir_run_steps`, ptr, r_n_steps)
 }
 
+dust2_cpu_sir_run_to_time <- function(ptr, r_time) {
+  .Call(`_dust2_dust2_cpu_sir_run_to_time`, ptr, r_time)
+}
+
 dust2_cpu_sir_state <- function(ptr, grouped) {
   .Call(`_dust2_dust2_cpu_sir_state`, ptr, grouped)
 }
@@ -50,6 +54,10 @@ dust2_cpu_walk_alloc <- function(r_pars, r_time, r_dt, r_n_particles, r_n_groups
 
 dust2_cpu_walk_run_steps <- function(ptr, r_n_steps) {
   .Call(`_dust2_dust2_cpu_walk_run_steps`, ptr, r_n_steps)
+}
+
+dust2_cpu_walk_run_to_time <- function(ptr, r_time) {
+  .Call(`_dust2_dust2_cpu_walk_run_to_time`, ptr, r_time)
 }
 
 dust2_cpu_walk_state <- function(ptr, grouped) {

--- a/inst/include/dust2/cpu.hpp
+++ b/inst/include/dust2/cpu.hpp
@@ -43,6 +43,11 @@ public:
     // that shared and internal have the same size).
   }
 
+  auto run_to_time(real_type time) {
+    const size_t n_steps = std::round(std::max(0.0, time - time_) / dt_);
+    return run_steps(n_steps);
+  }
+
   auto run_steps(size_t n_steps) {
     // Ignore errors for now.
     real_type * state_data = state_.data();
@@ -66,11 +71,6 @@ public:
     if (n_steps % 2 == 1) {
       std::swap(state_, state_next_);
     }
-    // Time management here is going to require some effort once we
-    // support interesting dt so that we always land on times with no
-    // non-integer bits, but for now we require that dt is 1 so this
-    // is easy.  We need this to hold within run_particle too, so it's
-    // possible that's where the calculation here will be done.
     time_ = time_ + n_steps * dt_;
   }
 

--- a/inst/include/dust2/r/cpu.hpp
+++ b/inst/include/dust2/r/cpu.hpp
@@ -58,6 +58,19 @@ SEXP dust2_cpu_run_steps(cpp11::sexp ptr, cpp11::sexp r_n_steps) {
 }
 
 template <typename T>
+SEXP dust2_cpu_run_to_time(cpp11::sexp ptr, cpp11::sexp r_time) {
+  auto *obj = cpp11::as_cpp<cpp11::external_pointer<dust_cpu<T>>>(ptr).get();
+  const auto time = check_time(r_time, "time");
+  const auto curr = obj->time();
+  if (time < curr) {
+    cpp11::stop("Can't run to time %f, model already at time %f",
+                time, curr);
+  }
+  obj->run_to_time(time);
+  return R_NilValue;
+}
+
+template <typename T>
 SEXP dust2_cpu_state(cpp11::sexp ptr, bool grouped) {
   auto *obj = cpp11::as_cpp<cpp11::external_pointer<dust_cpu<T>>>(ptr).get();
   cpp11::sexp ret = R_NilValue;

--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -20,6 +20,13 @@ extern "C" SEXP _dust2_dust2_cpu_sir_run_steps(SEXP ptr, SEXP r_n_steps) {
   END_CPP11
 }
 // sir.cpp
+SEXP dust2_cpu_sir_run_to_time(cpp11::sexp ptr, cpp11::sexp r_time);
+extern "C" SEXP _dust2_dust2_cpu_sir_run_to_time(SEXP ptr, SEXP r_time) {
+  BEGIN_CPP11
+    return cpp11::as_sexp(dust2_cpu_sir_run_to_time(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_time)));
+  END_CPP11
+}
+// sir.cpp
 SEXP dust2_cpu_sir_state(cpp11::sexp ptr, bool grouped);
 extern "C" SEXP _dust2_dust2_cpu_sir_state(SEXP ptr, SEXP grouped) {
   BEGIN_CPP11
@@ -97,6 +104,13 @@ extern "C" SEXP _dust2_dust2_cpu_walk_run_steps(SEXP ptr, SEXP r_n_steps) {
   END_CPP11
 }
 // walk.cpp
+SEXP dust2_cpu_walk_run_to_time(cpp11::sexp ptr, cpp11::sexp r_time);
+extern "C" SEXP _dust2_dust2_cpu_walk_run_to_time(SEXP ptr, SEXP r_time) {
+  BEGIN_CPP11
+    return cpp11::as_sexp(dust2_cpu_walk_run_to_time(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_time)));
+  END_CPP11
+}
+// walk.cpp
 SEXP dust2_cpu_walk_state(cpp11::sexp ptr, bool grouped);
 extern "C" SEXP _dust2_dust2_cpu_walk_state(SEXP ptr, SEXP grouped) {
   BEGIN_CPP11
@@ -159,6 +173,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_dust2_dust2_cpu_sir_compare_data",       (DL_FUNC) &_dust2_dust2_cpu_sir_compare_data,       3},
     {"_dust2_dust2_cpu_sir_rng_state",          (DL_FUNC) &_dust2_dust2_cpu_sir_rng_state,          1},
     {"_dust2_dust2_cpu_sir_run_steps",          (DL_FUNC) &_dust2_dust2_cpu_sir_run_steps,          2},
+    {"_dust2_dust2_cpu_sir_run_to_time",        (DL_FUNC) &_dust2_dust2_cpu_sir_run_to_time,        2},
     {"_dust2_dust2_cpu_sir_set_state",          (DL_FUNC) &_dust2_dust2_cpu_sir_set_state,          3},
     {"_dust2_dust2_cpu_sir_set_state_initial",  (DL_FUNC) &_dust2_dust2_cpu_sir_set_state_initial,  1},
     {"_dust2_dust2_cpu_sir_state",              (DL_FUNC) &_dust2_dust2_cpu_sir_state,              2},
@@ -170,6 +185,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_dust2_dust2_cpu_walk_reorder",           (DL_FUNC) &_dust2_dust2_cpu_walk_reorder,           2},
     {"_dust2_dust2_cpu_walk_rng_state",         (DL_FUNC) &_dust2_dust2_cpu_walk_rng_state,         1},
     {"_dust2_dust2_cpu_walk_run_steps",         (DL_FUNC) &_dust2_dust2_cpu_walk_run_steps,         2},
+    {"_dust2_dust2_cpu_walk_run_to_time",       (DL_FUNC) &_dust2_dust2_cpu_walk_run_to_time,       2},
     {"_dust2_dust2_cpu_walk_set_state",         (DL_FUNC) &_dust2_dust2_cpu_walk_set_state,         3},
     {"_dust2_dust2_cpu_walk_set_state_initial", (DL_FUNC) &_dust2_dust2_cpu_walk_set_state_initial, 1},
     {"_dust2_dust2_cpu_walk_set_time",          (DL_FUNC) &_dust2_dust2_cpu_walk_set_time,          2},

--- a/src/sir.cpp
+++ b/src/sir.cpp
@@ -27,6 +27,11 @@ SEXP dust2_cpu_sir_run_steps(cpp11::sexp ptr, cpp11::sexp r_n_steps) {
 }
 
 [[cpp11::register]]
+SEXP dust2_cpu_sir_run_to_time(cpp11::sexp ptr, cpp11::sexp r_time) {
+  return dust2::r::dust2_cpu_run_to_time<sir>(ptr, r_time);
+}
+
+[[cpp11::register]]
 SEXP dust2_cpu_sir_state(cpp11::sexp ptr, bool grouped) {
   return dust2::r::dust2_cpu_state<sir>(ptr, grouped);
 }

--- a/src/walk.cpp
+++ b/src/walk.cpp
@@ -26,6 +26,11 @@ SEXP dust2_cpu_walk_run_steps(cpp11::sexp ptr, cpp11::sexp r_n_steps) {
 }
 
 [[cpp11::register]]
+SEXP dust2_cpu_walk_run_to_time(cpp11::sexp ptr, cpp11::sexp r_time) {
+  return dust2::r::dust2_cpu_run_to_time<walk>(ptr, r_time);
+}
+
+[[cpp11::register]]
 SEXP dust2_cpu_walk_state(cpp11::sexp ptr, bool grouped) {
   return dust2::r::dust2_cpu_state<walk>(ptr, grouped);
 }

--- a/tests/testthat/test-sir.R
+++ b/tests/testthat/test-sir.R
@@ -121,6 +121,25 @@ test_that("can reset cases daily", {
 })
 
 
+test_that("can run sir model to time", {
+  pars <- list(beta = 0.1, gamma = 0.2, N = 1000, I0 = 10, exp_noise = 1e6)
+  obj1 <- dust2_cpu_sir_alloc(pars, 0, 0.25, 10, 0, 42, FALSE)
+  obj2 <- dust2_cpu_sir_alloc(pars, 0, 0.25, 10, 0, 42, FALSE)
+  ptr1 <- obj1[[1]]
+  ptr2 <- obj2[[1]]
+
+  dust2_cpu_sir_set_state_initial(ptr1)
+  expect_null(dust2_cpu_sir_run_steps(ptr1, 40))
+  expect_equal(dust2_cpu_sir_time(ptr1), 10)
+  s1 <- dust2_cpu_sir_state(ptr1, FALSE)
+
+  dust2_cpu_sir_set_state_initial(ptr2)
+  expect_null(dust2_cpu_sir_run_to_time(ptr2, 10))
+  expect_equal(dust2_cpu_sir_time(ptr2), 10)
+  expect_equal(dust2_cpu_sir_state(ptr2, FALSE), s1)
+})
+
+
 test_that("can update parameters", {
   base <- list(beta = 0.1, gamma = 0.2, N = 1000, I0 = 10, exp_noise = 1e6)
   update <- list(beta = 0.3, gamma = 0.2)

--- a/tests/testthat/test-walk.R
+++ b/tests/testthat/test-walk.R
@@ -439,3 +439,15 @@ test_that("can run walk model to time", {
   expect_equal(dust2_cpu_walk_time(ptr2), 10)
   expect_equal(dust2_cpu_walk_state(ptr2, FALSE), s1)
 })
+
+
+test_that("time must not be in the past", {
+  pars <- list(sd = 1)
+  obj <- dust2_cpu_walk_alloc(pars, 0, 0.25, 10, 0, 42, FALSE)
+  ptr <- obj[[1]]
+
+  dust2_cpu_walk_set_state_initial(ptr)
+  expect_error(
+    dust2_cpu_walk_run_to_time(ptr, -5),
+    "Can't run to time -5.*, model already at time 0.*")
+})

--- a/tests/testthat/test-walk.R
+++ b/tests/testthat/test-walk.R
@@ -420,3 +420,22 @@ test_that("validate inputs for reordering", {
     "Expected 'index' values to lie in [1, 10]",
     fixed = TRUE)
 })
+
+
+test_that("can run walk model to time", {
+  pars <- list(sd = 1)
+  obj1 <- dust2_cpu_walk_alloc(pars, 0, 0.25, 10, 0, 42, FALSE)
+  obj2 <- dust2_cpu_walk_alloc(pars, 0, 0.25, 10, 0, 42, FALSE)
+  ptr1 <- obj1[[1]]
+  ptr2 <- obj2[[1]]
+
+  dust2_cpu_walk_set_state_initial(ptr1)
+  expect_null(dust2_cpu_walk_run_steps(ptr1, 40))
+  expect_equal(dust2_cpu_walk_time(ptr1), 10)
+  s1 <- dust2_cpu_walk_state(ptr1, FALSE)
+
+  dust2_cpu_walk_set_state_initial(ptr2)
+  expect_null(dust2_cpu_walk_run_to_time(ptr2, 10))
+  expect_equal(dust2_cpu_walk_time(ptr2), 10)
+  expect_equal(dust2_cpu_walk_state(ptr2, FALSE), s1)
+})


### PR DESCRIPTION
~Merge after #11, contains those commits~

This PR adds a higher-level run function that runs to a specific time, rather than a specific number of steps.  This is likely the interface that we'll use most of time, certainly for the user.  This interface will also improve readability of the particle filter PRs because we don't have to think so much in terms of steps (though this will be inevitable in some cases)