### PR TITLE
Compute likelihood via particle filter

### DIFF
--- a/R/cpp11.R
+++ b/R/cpp11.R
@@ -48,6 +48,18 @@ dust2_cpu_sir_unfilter_run <- function(ptr, r_pars, r_initial, grouped) {
   .Call(`_dust2_dust2_cpu_sir_unfilter_run`, ptr, r_pars, r_initial, grouped)
 }
 
+dust2_cpu_sir_filter_alloc <- function(r_pars, r_time_start, r_time, r_dt, r_data, r_n_particles, r_n_groups, r_seed) {
+  .Call(`_dust2_dust2_cpu_sir_filter_alloc`, r_pars, r_time_start, r_time, r_dt, r_data, r_n_particles, r_n_groups, r_seed)
+}
+
+dust2_cpu_sir_filter_run <- function(ptr, r_pars, grouped) {
+  .Call(`_dust2_dust2_cpu_sir_filter_run`, ptr, r_pars, grouped)
+}
+
+test_resample_weight <- function(w, u) {
+  .Call(`_dust2_test_resample_weight`, w, u)
+}
+
 dust2_cpu_walk_alloc <- function(r_pars, r_time, r_dt, r_n_particles, r_n_groups, r_seed, r_deterministic) {
   .Call(`_dust2_dust2_cpu_walk_alloc`, r_pars, r_time, r_dt, r_n_particles, r_n_groups, r_seed, r_deterministic)
 }

--- a/R/cpp11.R
+++ b/R/cpp11.R
@@ -56,6 +56,10 @@ dust2_cpu_sir_filter_run <- function(ptr, r_pars, grouped) {
   .Call(`_dust2_dust2_cpu_sir_filter_run`, ptr, r_pars, grouped)
 }
 
+dust2_cpu_sir_filter_rng_state <- function(ptr) {
+  .Call(`_dust2_dust2_cpu_sir_filter_rng_state`, ptr)
+}
+
 test_resample_weight <- function(w, u) {
   .Call(`_dust2_test_resample_weight`, w, u)
 }

--- a/inst/include/dust2/filter.hpp
+++ b/inst/include/dust2/filter.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <dust2/cpu.hpp>
+#include <dust2/filter_details.hpp>
+#include <mcstate/random/random.hpp>
 
 namespace dust2 {
 
@@ -65,6 +67,99 @@ private:
   std::vector<data_type> data_;
   size_t n_particles_;
   size_t n_groups_;
+  std::vector<real_type> ll_;
+  std::vector<real_type> ll_step_;
+};
+
+template <typename T>
+class filter {
+public:
+  using real_type = typename T::real_type;
+  using data_type = typename T::data_type;
+  using rng_state_type = typename T::rng_state_type;
+  using rng_int_type = typename rng_state_type::int_type;
+
+  dust_cpu<T> model;
+
+  filter(dust_cpu<T> model_,
+         real_type time_start,
+         std::vector<real_type> time,
+         std::vector<data_type> data,
+         const std::vector<rng_int_type>& seed) :
+    model(model_),
+    time_start_(time_start),
+    time_(time),
+    data_(data),
+    n_particles_(model.n_particles()),
+    n_groups_(model.n_groups()),
+    rng_(n_groups_, seed, false),
+    ll_(n_groups_ * n_particles_, 0),
+    ll_step_(n_groups_ * n_particles_, 0) {
+    // TODO: duplicated with the above, can be done generically though
+    // it's not a lot of code.
+    const auto dt = model_.dt();
+    for (size_t i = 0; i < time_.size(); i++) {
+      const auto t0 = i == 0 ? time_start_ : time_[i - 1];
+      const auto t1 = time_[i];
+      step_.push_back(static_cast<size_t>(std::round((t1 - t0) / dt)));
+    }
+  }
+
+  void run() {
+    const auto n_times = step_.size();
+
+    model.set_time(time_start_);
+    model.set_state_initial();
+    std::fill(ll_.begin(), ll_.end(), 0);
+
+    // Just store this here; later once we have state to save we can
+    // probably use that vector instead.
+    std::vector<size_t> index(n_particles_ * n_groups_);
+
+    auto it_data = data_.begin();
+    for (size_t i = 0; i < n_times; ++i, it_data += n_groups_) {
+      model.run_steps(step_[i]);
+      model.compare_data(it_data, ll_step_.begin());
+
+      for (size_t i = 0; i < n_groups_; ++i) {
+        const auto offset = i * n_particles_;
+        const auto w = ll_step_.begin() + offset;
+        ll_[i] += details::scale_log_weights<real_type>(n_particles_, w);
+      }
+
+      // early exit here, once enabled, setting and checking a
+      // threshhold log likelihood below which we're uninterested;
+      // this requires some fiddling.
+
+      // This can be parallelised across groups
+      for (size_t i = 0; i < n_groups_; ++i) {
+        const auto offset = i * n_particles_;
+        const auto w = ll_step_.begin() + offset;
+        const auto idx = index.begin() + offset;
+        const auto u = mcstate::random::random_real<real_type>(rng_.state(i));
+        details::resample_weight(n_particles_, w, u, idx);
+      }
+
+      model.reorder(index.begin());
+
+      // save trajectories (perhaps)
+      // save snapshots (perhaps)
+    }
+  }
+
+  template <typename It>
+  void last_log_likelihood(It it) {
+    std::copy_n(ll_.begin(), n_groups_, it);
+  }
+
+private:
+  real_type time_start_;
+  std::vector<real_type> time_;
+  std::vector<size_t> step_;
+  std::vector<data_type> data_;
+  size_t n_particles_;
+  size_t n_groups_;
+  mcstate::random::prng<rng_state_type> rng_;
   std::vector<real_type> ll_;
   std::vector<real_type> ll_step_;
 };

--- a/inst/include/dust2/filter.hpp
+++ b/inst/include/dust2/filter.hpp
@@ -152,6 +152,10 @@ public:
     std::copy_n(ll_.begin(), n_groups_, it);
   }
 
+  auto rng_state() { // TODO: should be const, error in mcstate2
+    return rng_.export_state();
+  }
+
 private:
   real_type time_start_;
   std::vector<real_type> time_;

--- a/inst/include/dust2/filter_details.hpp
+++ b/inst/include/dust2/filter_details.hpp
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <cmath>
+#include <limits>
+#include <numeric>
+#include <vector>
+
+namespace dust2 {
+namespace details {
+
+template <typename real_type>
+real_type scale_log_weights(size_t n, typename std::vector<real_type>::iterator w) {
+  if (n == 1) {
+    return *w;
+  }
+  constexpr auto neg_infinity = -std::numeric_limits<real_type>::infinity();
+  real_type max_w = neg_infinity;
+  auto wi = w;
+  for (size_t i = 0; i < n; ++i, ++wi) {
+    if (std::isnan(*wi)) {
+      *wi = neg_infinity;
+    } else {
+      max_w = std::max(max_w, *wi);
+    }
+  }
+
+  if (max_w == neg_infinity) {
+    return max_w;
+  }
+
+  real_type tot = 0.0;
+  wi = w;
+  for (size_t i = 0; i < n; ++i, ++wi) {
+    *wi = std::exp(*wi - max_w);
+    tot += *wi;
+  }
+
+  return std::log(tot / n) + max_w;
+}
+
+
+// This is a nasty bit of bookkeeping for the "systematic" resample,
+// which is one of several options (we may allow configuration of this
+// later, which will present its own challenges of course).
+template <typename real_type>
+void resample_weight(size_t n_particles,
+                     typename std::vector<real_type>::const_iterator w,
+                     const real_type u,
+                     typename std::vector<size_t>::iterator idx) {
+  const auto tot = std::accumulate(w, w + n_particles,
+                                   static_cast<real_type>(0));
+  const auto uu0 = tot * u / n_particles;
+  const auto du = tot / n_particles;
+
+  real_type ww = 0.0;
+  size_t j = 0;
+  for (size_t i = 0; i < n_particles; ++i) {
+    const real_type uu = uu0 + i * du;
+    // The second clause (i.e., j < n_particles) should never be hit but
+    // prevents any invalid read if we have pathalogical 'u' that is
+    // within floating point eps of 1 - solve this instead by passing
+    // w as begin/end pair, something that only happens in single precision:
+    //
+    // https://github.com/reside-ic/reside-ic.github.io/pull/60/files
+    // https://github.com/mrc-ide/dust/pull/238
+    while (ww < uu && j < n_particles) {
+      ww += *w;
+      ++w;
+      ++j;
+    }
+    *idx = j == 0 ? 0 : j - 1;
+    ++idx;
+  }
+}
+
+
+}
+}

--- a/inst/include/dust2/r/cpu.hpp
+++ b/inst/include/dust2/r/cpu.hpp
@@ -21,8 +21,8 @@ SEXP dust2_cpu_alloc(cpp11::list r_pars,
   const auto time = check_time(r_time, "time");
   const auto dt = check_dt(r_dt);
 
-  auto n_particles = to_size(r_n_particles, "n_particles");
-  auto n_groups = to_size(r_n_groups, "n_groups");
+  const auto n_particles = to_size(r_n_particles, "n_particles");
+  const auto n_groups = to_size(r_n_groups, "n_groups");
 
   const auto shared = build_shared<T>(r_pars, n_groups);
   // Later, we need one of these per thread
@@ -144,14 +144,8 @@ SEXP dust2_cpu_reorder(cpp11::sexp ptr, cpp11::integers r_index) {
 
 template <typename T>
 SEXP dust2_cpu_rng_state(cpp11::sexp ptr) {
-  using rng_state_type = typename T::rng_state_type;
   auto *obj = cpp11::as_cpp<cpp11::external_pointer<dust_cpu<T>>>(ptr).get();
-
-  const auto state = obj->rng_state();
-  const auto len = sizeof(typename rng_state_type::int_type) * state.size();
-  cpp11::writable::raws ret(len);
-  std::memcpy(RAW(ret), state.data(), len);
-  return ret;
+  return rng_state_as_raw(obj->rng_state());
 }
 
 template <typename T>

--- a/inst/include/dust2/r/filter.hpp
+++ b/inst/include/dust2/r/filter.hpp
@@ -20,7 +20,7 @@ cpp11::sexp dust2_cpu_unfilter_alloc(cpp11::list r_pars,
 
   auto n_particles = to_size(r_n_particles, "n_particles");
   auto n_groups = to_size(r_n_groups, "n_groups");
-  const bool grouped = n_groups > 0;
+  const auto grouped = n_groups > 0;
   const auto time_start = check_time(r_time_start, "time_start");
   const auto time = check_time_sequence<real_type>(time_start, r_time, "time");
   const auto dt = check_dt(r_dt);
@@ -75,6 +75,81 @@ cpp11::sexp dust2_cpu_unfilter_run(cpp11::sexp ptr, cpp11::sexp r_pars,
   if (grouped && n_particles > 1) {
     set_array_dims(ret, {n_particles, n_groups});
   }
+  return ret;
+}
+
+template <typename T>
+cpp11::sexp dust2_cpu_filter_alloc(cpp11::list r_pars,
+                                   cpp11::sexp r_time_start,
+                                   cpp11::sexp r_time,
+                                   cpp11::sexp r_dt,
+                                   cpp11::list r_data,
+                                   cpp11::sexp r_n_particles,
+                                   cpp11::sexp r_n_groups,
+                                   cpp11::sexp r_seed) {
+  using real_type = typename T::real_type;
+  using rng_state_type = typename T::rng_state_type;
+  using rng_seed_type = std::vector<typename rng_state_type::int_type>;
+
+  auto n_particles = to_size(r_n_particles, "n_particles");
+  auto n_groups = to_size(r_n_groups, "n_groups");
+  const auto grouped = n_groups > 0;
+  const auto time_start = check_time(r_time_start, "time_start");
+  const auto time = check_time_sequence<real_type>(time_start, r_time, "time");
+  const auto dt = check_dt(r_dt);
+  const auto shared = build_shared<T>(r_pars, n_groups);
+  const auto internal = build_internal<T>(shared);
+  const auto data = check_data<T>(r_data, time.size(), n_groups, "data");
+
+  // It's possible that we don't want to always really be
+  // deterministic here?  Though nooone can think of a case where
+  // that's actually the behaviour wanted.  For now let's go fully
+  // deterministic.
+  auto seed = mcstate::random::r::as_rng_seed<rng_state_type>(r_seed);
+  const auto deterministic = false;
+
+  // Create all the required rng states across the filter and the
+  // model, in a reasonable way.  We need to make this slightly easier
+  // to do from mcstate really.  Expand the state to give all the
+  // state required by the filter (n_groups streams worth) and the
+  // model (n_groups * n_particles worth, though the last bit of
+  // expansion could be done by the model itself instead?)
+  const auto n_streams = n_groups * (n_particles + 1);
+  const auto rng_state = mcstate::random::prng<rng_state_type>(n_streams, seed, deterministic).export_state();
+  const auto rng_len = rng_state_type::size();
+  const rng_seed_type seed_filter(rng_state.begin(),
+                                  rng_state.begin() + rng_len * n_groups);
+  const rng_seed_type seed_model(rng_state.begin() + rng_len * n_groups,
+                                 rng_state.end());
+
+  const auto model = dust2::dust_cpu<T>(shared, internal, time_start, dt, n_particles,
+                                        seed_model, deterministic);
+
+  auto obj = new filter<T>(model, time_start, time, data, seed_filter);
+  cpp11::external_pointer<filter<T>> ptr(obj, true, false);
+
+  cpp11::sexp r_n_state = cpp11::as_sexp(obj->model.n_state());
+  cpp11::sexp r_group_names = R_NilValue;
+  if (grouped) {
+    r_group_names = r_pars.attr("names");
+  }
+  cpp11::sexp r_grouped = cpp11::as_sexp(grouped);
+
+  return cpp11::writable::list{ptr, r_n_state, r_grouped, r_group_names};
+}
+
+template <typename T>
+cpp11::sexp dust2_cpu_filter_run(cpp11::sexp ptr, cpp11::sexp r_pars,
+                                 bool grouped) {
+  auto *obj =
+    cpp11::as_cpp<cpp11::external_pointer<filter<T>>>(ptr).get();
+  if (r_pars != R_NilValue) {
+    update_pars(obj->model, cpp11::as_cpp<cpp11::list>(r_pars), grouped);
+  }
+  obj->run();
+
+  cpp11::writable::doubles ret(obj->model.n_groups());
+  obj->last_log_likelihood(REAL(ret));
   return ret;
 }
 

--- a/inst/include/dust2/r/helpers.hpp
+++ b/inst/include/dust2/r/helpers.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstring>
 #include <numeric>
 #include <vector>
 #include <dust2/common.hpp>
@@ -275,6 +276,14 @@ void set_state(dust_cpu<T>& obj, cpp11::sexp r_state, bool grouped) {
                 n_groups);
   }
   obj.set_state(REAL(r_state), recycle_particle, recycle_group);
+}
+
+template <typename T>
+SEXP rng_state_as_raw(const std::vector<T>& state) {
+  const auto len = sizeof(T) * state.size();
+  cpp11::writable::raws ret(len);
+  std::memcpy(RAW(ret), state.data(), len);
+  return ret;
 }
 
 }

--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -103,6 +103,13 @@ extern "C" SEXP _dust2_dust2_cpu_sir_filter_run(SEXP ptr, SEXP r_pars, SEXP grou
     return cpp11::as_sexp(dust2_cpu_sir_filter_run(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_pars), cpp11::as_cpp<cpp11::decay_t<bool>>(grouped)));
   END_CPP11
 }
+// sir.cpp
+SEXP dust2_cpu_sir_filter_rng_state(cpp11::sexp ptr);
+extern "C" SEXP _dust2_dust2_cpu_sir_filter_rng_state(SEXP ptr) {
+  BEGIN_CPP11
+    return cpp11::as_sexp(dust2_cpu_sir_filter_rng_state(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr)));
+  END_CPP11
+}
 // test.cpp
 cpp11::integers test_resample_weight(std::vector<double> w, double u);
 extern "C" SEXP _dust2_test_resample_weight(SEXP w, SEXP u) {
@@ -193,6 +200,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_dust2_dust2_cpu_sir_alloc",              (DL_FUNC) &_dust2_dust2_cpu_sir_alloc,              7},
     {"_dust2_dust2_cpu_sir_compare_data",       (DL_FUNC) &_dust2_dust2_cpu_sir_compare_data,       3},
     {"_dust2_dust2_cpu_sir_filter_alloc",       (DL_FUNC) &_dust2_dust2_cpu_sir_filter_alloc,       8},
+    {"_dust2_dust2_cpu_sir_filter_rng_state",   (DL_FUNC) &_dust2_dust2_cpu_sir_filter_rng_state,   1},
     {"_dust2_dust2_cpu_sir_filter_run",         (DL_FUNC) &_dust2_dust2_cpu_sir_filter_run,         3},
     {"_dust2_dust2_cpu_sir_rng_state",          (DL_FUNC) &_dust2_dust2_cpu_sir_rng_state,          1},
     {"_dust2_dust2_cpu_sir_run_steps",          (DL_FUNC) &_dust2_dust2_cpu_sir_run_steps,          2},

--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -89,6 +89,27 @@ extern "C" SEXP _dust2_dust2_cpu_sir_unfilter_run(SEXP ptr, SEXP r_pars, SEXP r_
     return cpp11::as_sexp(dust2_cpu_sir_unfilter_run(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_pars), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_initial), cpp11::as_cpp<cpp11::decay_t<bool>>(grouped)));
   END_CPP11
 }
+// sir.cpp
+SEXP dust2_cpu_sir_filter_alloc(cpp11::list r_pars, cpp11::sexp r_time_start, cpp11::sexp r_time, cpp11::sexp r_dt, cpp11::list r_data, cpp11::sexp r_n_particles, cpp11::sexp r_n_groups, cpp11::sexp r_seed);
+extern "C" SEXP _dust2_dust2_cpu_sir_filter_alloc(SEXP r_pars, SEXP r_time_start, SEXP r_time, SEXP r_dt, SEXP r_data, SEXP r_n_particles, SEXP r_n_groups, SEXP r_seed) {
+  BEGIN_CPP11
+    return cpp11::as_sexp(dust2_cpu_sir_filter_alloc(cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(r_pars), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_time_start), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_time), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_dt), cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(r_data), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_n_particles), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_n_groups), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_seed)));
+  END_CPP11
+}
+// sir.cpp
+SEXP dust2_cpu_sir_filter_run(cpp11::sexp ptr, cpp11::sexp r_pars, bool grouped);
+extern "C" SEXP _dust2_dust2_cpu_sir_filter_run(SEXP ptr, SEXP r_pars, SEXP grouped) {
+  BEGIN_CPP11
+    return cpp11::as_sexp(dust2_cpu_sir_filter_run(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_pars), cpp11::as_cpp<cpp11::decay_t<bool>>(grouped)));
+  END_CPP11
+}
+// test.cpp
+cpp11::integers test_resample_weight(std::vector<double> w, double u);
+extern "C" SEXP _dust2_test_resample_weight(SEXP w, SEXP u) {
+  BEGIN_CPP11
+    return cpp11::as_sexp(test_resample_weight(cpp11::as_cpp<cpp11::decay_t<std::vector<double>>>(w), cpp11::as_cpp<cpp11::decay_t<double>>(u)));
+  END_CPP11
+}
 // walk.cpp
 SEXP dust2_cpu_walk_alloc(cpp11::list r_pars, cpp11::sexp r_time, cpp11::sexp r_dt, cpp11::sexp r_n_particles, cpp11::sexp r_n_groups, cpp11::sexp r_seed, cpp11::sexp r_deterministic);
 extern "C" SEXP _dust2_dust2_cpu_walk_alloc(SEXP r_pars, SEXP r_time, SEXP r_dt, SEXP r_n_particles, SEXP r_n_groups, SEXP r_seed, SEXP r_deterministic) {
@@ -171,6 +192,8 @@ extern "C" {
 static const R_CallMethodDef CallEntries[] = {
     {"_dust2_dust2_cpu_sir_alloc",              (DL_FUNC) &_dust2_dust2_cpu_sir_alloc,              7},
     {"_dust2_dust2_cpu_sir_compare_data",       (DL_FUNC) &_dust2_dust2_cpu_sir_compare_data,       3},
+    {"_dust2_dust2_cpu_sir_filter_alloc",       (DL_FUNC) &_dust2_dust2_cpu_sir_filter_alloc,       8},
+    {"_dust2_dust2_cpu_sir_filter_run",         (DL_FUNC) &_dust2_dust2_cpu_sir_filter_run,         3},
     {"_dust2_dust2_cpu_sir_rng_state",          (DL_FUNC) &_dust2_dust2_cpu_sir_rng_state,          1},
     {"_dust2_dust2_cpu_sir_run_steps",          (DL_FUNC) &_dust2_dust2_cpu_sir_run_steps,          2},
     {"_dust2_dust2_cpu_sir_run_to_time",        (DL_FUNC) &_dust2_dust2_cpu_sir_run_to_time,        2},
@@ -192,6 +215,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_dust2_dust2_cpu_walk_state",             (DL_FUNC) &_dust2_dust2_cpu_walk_state,             2},
     {"_dust2_dust2_cpu_walk_time",              (DL_FUNC) &_dust2_dust2_cpu_walk_time,              1},
     {"_dust2_dust2_cpu_walk_update_pars",       (DL_FUNC) &_dust2_dust2_cpu_walk_update_pars,       3},
+    {"_dust2_test_resample_weight",             (DL_FUNC) &_dust2_test_resample_weight,             2},
     {NULL, NULL, 0}
 };
 }

--- a/src/sir.cpp
+++ b/src/sir.cpp
@@ -108,3 +108,8 @@ SEXP dust2_cpu_sir_filter_run(cpp11::sexp ptr, cpp11::sexp r_pars,
                               bool grouped) {
   return dust2::r::dust2_cpu_filter_run<sir>(ptr, r_pars, grouped);
 }
+
+[[cpp11::register]]
+SEXP dust2_cpu_sir_filter_rng_state(cpp11::sexp ptr) {
+  return dust2::r::dust2_cpu_filter_rng_state<sir>(ptr);
+}

--- a/src/sir.cpp
+++ b/src/sir.cpp
@@ -87,3 +87,24 @@ SEXP dust2_cpu_sir_unfilter_run(cpp11::sexp ptr, cpp11::sexp r_pars,
                                 cpp11::sexp r_initial, bool grouped) {
   return dust2::r::dust2_cpu_unfilter_run<sir>(ptr, r_pars, r_initial, grouped);
 }
+
+[[cpp11::register]]
+SEXP dust2_cpu_sir_filter_alloc(cpp11::list r_pars,
+                                cpp11::sexp r_time_start,
+                                cpp11::sexp r_time,
+                                cpp11::sexp r_dt,
+                                cpp11::list r_data,
+                                cpp11::sexp r_n_particles,
+                                cpp11::sexp r_n_groups,
+                                cpp11::sexp r_seed) {
+  return dust2::r::dust2_cpu_filter_alloc<sir>(r_pars, r_time_start, r_time,
+                                               r_dt, r_data,
+                                               r_n_particles, r_n_groups,
+                                               r_seed);
+}
+
+[[cpp11::register]]
+SEXP dust2_cpu_sir_filter_run(cpp11::sexp ptr, cpp11::sexp r_pars,
+                              bool grouped) {
+  return dust2::r::dust2_cpu_filter_run<sir>(ptr, r_pars, grouped);
+}

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -1,0 +1,13 @@
+#include <dust2/filter_details.hpp>
+
+#include <cpp11/integers.hpp>
+#include <cpp11/doubles.hpp>
+
+[[cpp11::register]]
+cpp11::integers test_resample_weight(std::vector<double> w, double u) {
+  const size_t n_particles = w.size();
+  std::vector<size_t> idx(n_particles);
+  dust2::details::resample_weight(n_particles, w.begin(), u, idx.begin());
+  cpp11::writable::integers ret(idx.begin(), idx.end());
+  return ret;
+}

--- a/tests/testthat/helper-dust.R
+++ b/tests/testthat/helper-dust.R
@@ -1,0 +1,33 @@
+## This is a basic reimplementation of a particle filter for the SIR
+## model; once we have a generic model interface we can make this more
+## generic.  It just redoes the same logic as in the C++ code but is
+## easier to read (and quite a lot slower due to churn in state).
+sir_filter_manual <- function(pars, time_start, time, dt, data, n_particles,
+                              seed) {
+  r <- mcstate2::mcstate_rng$new(n_streams = 1, seed = seed)
+  seed <- mcstate2::mcstate_rng$new(n_streams = 1, seed = seed)$jump()$state()
+
+  obj <- dust2_cpu_sir_alloc(pars, time_start, dt, n_particles, 0, seed, FALSE)
+  ptr <- obj[[1]]
+  n_steps <- round((time - c(time_start, time[-length(time)])) / dt)
+
+  function(pars) {
+    if (!is.null(pars)) {
+      dust2_cpu_sir_update_pars(ptr, pars, FALSE)
+    }
+    expect_null(dust2_cpu_walk_set_time(ptr, time_start))
+    dust2_cpu_sir_set_state_initial(ptr)
+    ll <- 0
+    for (i in seq_along(time)) {
+      dust2_cpu_sir_run_steps(ptr, n_steps[[i]])
+      tmp <- dust2_cpu_sir_compare_data(ptr, data[[i]], FALSE)
+      w <- exp(tmp - max(tmp))
+      ll <- ll + log(mean(w)) + max(tmp)
+      u <- r$random_real(1)
+      k <- test_resample_weight(w, u) + 1L
+      state <- dust2_cpu_sir_state(ptr, FALSE)
+      dust2_cpu_sir_set_state(ptr, state[, k], FALSE)
+    }
+    ll
+  }
+}

--- a/tests/testthat/test-filter-details.R
+++ b/tests/testthat/test-filter-details.R
@@ -1,0 +1,16 @@
+test_that("Resampling works as expected", {
+  ref_resample_weight <- function(w, u) {
+    n <- length(w)
+    uu <- u / n + seq(0, by = 1 / n, length.out = n)
+    cw <- cumsum(w / sum(w))
+    findInterval(uu, cw) + 1L
+  }
+
+  set.seed(1)
+  w <- abs(rcauchy(20))
+  u <- runif(1)
+
+  expect_equal(
+    test_resample_weight(w, u) + 1L,
+    ref_resample_weight(w, u))
+})


### PR DESCRIPTION
~Merge after #8, contains those commits~

We'll get better statistical tests on this later, but some poking about with it suggests we're correct :-/

For the future tests, we have a model where we derived the likelihood a different way and show it converges.  But for that I need to implement support for compiling models as we go, and that's a few PRs away.

This PR implements the same particle filter algorithm as used in dust1 and mcstate1:

1. advance the model up to the next data point
2. compare particles to the data
3. convert the log likelihoods into a set of weights (this requires moving out of the log basis into a normal basis, which is half of the gross bookkeeping - `scale_log_weights`)
4. resample using the "systematic sampling" scheme (this is the other half of gross bookkeeping, see `resample_weight` - tbh I forget how this works but the R reference implementation in `test-filter-details.R` is actually very simple). This samples, with replacement, particles in proportion to the weight computed in step 3
5. accumulate the log likelihood which is the log of the average likelihood (*not* the average log likelihood) over each step

Some future features are flagged in the code

* early exit for filter invocations that will not be accepted
* save trajectories as the filter proceeds
* save snapshots at some time points in the simulation

The RNG seeding is complex, and different to the way that we do this in dust1:

* every filter gets its own rng, with the aim that a filter that computes multiple parameter sets at once could split apart.  This frees us up to parallelise in different ways (e.g., openmp, mpi or something else). This means for `n` particles and `m` parameter sets we need `(n + 1) * m` streams
* we will pull these from the rng state by jumping so that the first `n + 1` streams go to the first parameter sets, and of that the first stream goes to the filter and the remaining `n` go to the model
* I've written a state extraction routine which checks this, and a test that shows you get the same answer running a filter with multiple parameter sets as a set of filters seeded appropriately