### PR TITLE
Fix lint, coverage holes and trivial features

### DIFF
--- a/R/cpp11.R
+++ b/R/cpp11.R
@@ -76,6 +76,10 @@ test_resample_weight <- function(w, u) {
   .Call(`_dust2_test_resample_weight`, w, u)
 }
 
+test_scale_log_weights <- function(w) {
+  .Call(`_dust2_test_scale_log_weights`, w)
+}
+
 test_history <- function(r_time, r_state, r_order, reorder) {
   .Call(`_dust2_test_history`, r_time, r_state, r_order, reorder)
 }

--- a/R/cpp11.R
+++ b/R/cpp11.R
@@ -64,8 +64,8 @@ dust2_cpu_sir_filter_alloc <- function(r_pars, r_time_start, r_time, r_dt, r_dat
   .Call(`_dust2_dust2_cpu_sir_filter_alloc`, r_pars, r_time_start, r_time, r_dt, r_data, r_n_particles, r_n_groups, r_seed)
 }
 
-dust2_cpu_sir_filter_run <- function(ptr, r_pars, grouped) {
-  .Call(`_dust2_dust2_cpu_sir_filter_run`, ptr, r_pars, grouped)
+dust2_cpu_sir_filter_run <- function(ptr, r_pars, r_initial, grouped) {
+  .Call(`_dust2_dust2_cpu_sir_filter_run`, ptr, r_pars, r_initial, grouped)
 }
 
 dust2_cpu_sir_filter_rng_state <- function(ptr) {

--- a/R/interface.R
+++ b/R/interface.R
@@ -348,7 +348,7 @@ dust_model_compare_data <- function(model, data) {
   if (!model$properties$has_compare) {
     ## This moves into something general soon?
     cli::cli_abort(
-      paste("Can't compare against data, the '{model$name}' model does not",
+      paste("Can't compare against data; the '{model$name}' model does not",
             "have 'compare_data' support"),
       arg = "model")
   }
@@ -381,7 +381,7 @@ dust_unfilter_create <- function(generator, pars, time_start, time, data,
   if (!generator$properties$has_compare) {
     ## This moves into something general soon?
     cli::cli_abort(
-      paste("Can't compare against data, the '{generator$name}' model does",
+      paste("Can't create unfilter; the '{generator$name}' model does",
             "not have 'compare_data' support"),
       arg = "generator")
   }
@@ -468,7 +468,7 @@ dust_filter_create <- function(generator, pars, time_start, time, data,
   if (!generator$properties$has_compare) {
     ## This moves into something general soon?
     cli::cli_abort(
-      paste("Can't compare against data, the '{generator$name}' model does",
+      paste("Can't create filter; the '{generator$name}' model does",
             "not have 'compare_data' support"),
       arg = "generator")
   }

--- a/R/interface.R
+++ b/R/interface.R
@@ -407,10 +407,6 @@ dust_unfilter_create <- function(generator, pars, time_start, time, data,
 ##' @param pars Optional parameters to run the filter with.  If not
 ##'   provided, parameters are not updated
 ##'
-##' @param initial Optional initial conditions, as a matrix (state x
-##'   particle) or 3d array (state x particle x group).  If not
-##'   provided, the model initial conditions are used.
-##'
 ##' @return A vector of likelihood values, with as many elements as
 ##'   there are groups.
 ##'
@@ -504,10 +500,7 @@ dust_filter_create <- function(generator, pars, time_start, time, data,
 ##' @export
 dust_filter_run <- function(filter, pars = NULL, initial = NULL) {
   check_is_dust_filter(filter)
-  if (!is.null(initial)) {
-    cli::cli_abort("Setting 'initial' not yet supported")
-  }
-  filter$methods$run(filter$ptr, pars, filter$grouped)
+  filter$methods$run(filter$ptr, pars, initial, filter$grouped)
 }
 
 

--- a/inst/examples/walk.cpp
+++ b/inst/examples/walk.cpp
@@ -89,7 +89,7 @@ public:
   // Then, rather than a constructor we have some converters:
   static shared_state build_shared(cpp11::list pars) {
     const auto len = dust2::r::read_size(pars, "len", 1);
-    const auto sd = dust2::r::read_real(pars, "sd", 1);
+    const auto sd = dust2::r::read_real(pars, "sd");
     const auto random_initial =
       dust2::r::read_bool(pars, "random_initial", false);
     return shared_state{len, sd, random_initial};

--- a/inst/include/dust2/filter.hpp
+++ b/inst/include/dust2/filter.hpp
@@ -105,11 +105,13 @@ public:
     }
   }
 
-  void run() {
+  void run(bool set_initial) {
     const auto n_times = step_.size();
 
     model.set_time(time_start_);
-    model.set_state_initial();
+    if (set_initial) {
+      model.set_state_initial();
+    }
     std::fill(ll_.begin(), ll_.end(), 0);
 
     // Just store this here; later once we have state to save we can

--- a/inst/include/dust2/r/cpu.hpp
+++ b/inst/include/dust2/r/cpu.hpp
@@ -188,9 +188,6 @@ SEXP dust2_cpu_compare_data(cpp11::sexp ptr,
       data.push_back(T::build_data(r_data_list_i));
     }
   } else {
-    if (n_groups > 1) {
-      cpp11::stop("Can't compare with grouped = FALSE with more than one group");
-    }
     data.push_back(T::build_data(r_data_list));
   }
 

--- a/inst/include/dust2/r/filter.hpp
+++ b/inst/include/dust2/r/filter.hpp
@@ -169,13 +169,16 @@ cpp11::sexp dust2_cpu_filter_alloc(cpp11::list r_pars,
 
 template <typename T>
 cpp11::sexp dust2_cpu_filter_run(cpp11::sexp ptr, cpp11::sexp r_pars,
-                                 bool grouped) {
+                                 cpp11::sexp r_initial, bool grouped) {
   auto *obj =
     cpp11::as_cpp<cpp11::external_pointer<filter<T>>>(ptr).get();
   if (r_pars != R_NilValue) {
     update_pars(obj->model, cpp11::as_cpp<cpp11::list>(r_pars), grouped);
   }
-  obj->run();
+  if (r_initial != R_NilValue) {
+    set_state(obj->model, r_initial, grouped);
+  }
+  obj->run(r_initial == R_NilValue);
 
   cpp11::writable::doubles ret(obj->model.n_groups());
   obj->last_log_likelihood(REAL(ret));

--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -118,10 +118,10 @@ extern "C" SEXP _dust2_dust2_cpu_sir_filter_alloc(SEXP r_pars, SEXP r_time_start
   END_CPP11
 }
 // sir.cpp
-SEXP dust2_cpu_sir_filter_run(cpp11::sexp ptr, cpp11::sexp r_pars, bool grouped);
-extern "C" SEXP _dust2_dust2_cpu_sir_filter_run(SEXP ptr, SEXP r_pars, SEXP grouped) {
+SEXP dust2_cpu_sir_filter_run(cpp11::sexp ptr, cpp11::sexp r_pars, cpp11::sexp r_initial, bool grouped);
+extern "C" SEXP _dust2_dust2_cpu_sir_filter_run(SEXP ptr, SEXP r_pars, SEXP r_initial, SEXP grouped) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust2_cpu_sir_filter_run(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_pars), cpp11::as_cpp<cpp11::decay_t<bool>>(grouped)));
+    return cpp11::as_sexp(dust2_cpu_sir_filter_run(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_pars), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_initial), cpp11::as_cpp<cpp11::decay_t<bool>>(grouped)));
   END_CPP11
 }
 // sir.cpp
@@ -236,7 +236,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_dust2_dust2_cpu_sir_compare_data",       (DL_FUNC) &_dust2_dust2_cpu_sir_compare_data,       3},
     {"_dust2_dust2_cpu_sir_filter_alloc",       (DL_FUNC) &_dust2_dust2_cpu_sir_filter_alloc,       8},
     {"_dust2_dust2_cpu_sir_filter_rng_state",   (DL_FUNC) &_dust2_dust2_cpu_sir_filter_rng_state,   1},
-    {"_dust2_dust2_cpu_sir_filter_run",         (DL_FUNC) &_dust2_dust2_cpu_sir_filter_run,         3},
+    {"_dust2_dust2_cpu_sir_filter_run",         (DL_FUNC) &_dust2_dust2_cpu_sir_filter_run,         4},
     {"_dust2_dust2_cpu_sir_reorder",            (DL_FUNC) &_dust2_dust2_cpu_sir_reorder,            2},
     {"_dust2_dust2_cpu_sir_rng_state",          (DL_FUNC) &_dust2_dust2_cpu_sir_rng_state,          1},
     {"_dust2_dust2_cpu_sir_run_steps",          (DL_FUNC) &_dust2_dust2_cpu_sir_run_steps,          2},

--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -139,6 +139,13 @@ extern "C" SEXP _dust2_test_resample_weight(SEXP w, SEXP u) {
   END_CPP11
 }
 // test.cpp
+cpp11::list test_scale_log_weights(std::vector<double> w);
+extern "C" SEXP _dust2_test_scale_log_weights(SEXP w) {
+  BEGIN_CPP11
+    return cpp11::as_sexp(test_scale_log_weights(cpp11::as_cpp<cpp11::decay_t<std::vector<double>>>(w)));
+  END_CPP11
+}
+// test.cpp
 cpp11::sexp test_history(cpp11::doubles r_time, cpp11::list r_state, cpp11::sexp r_order, bool reorder);
 extern "C" SEXP _dust2_test_history(SEXP r_time, SEXP r_state, SEXP r_order, SEXP reorder) {
   BEGIN_CPP11
@@ -264,6 +271,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_dust2_dust2_cpu_walk_update_pars",       (DL_FUNC) &_dust2_dust2_cpu_walk_update_pars,       3},
     {"_dust2_test_history",                     (DL_FUNC) &_dust2_test_history,                     4},
     {"_dust2_test_resample_weight",             (DL_FUNC) &_dust2_test_resample_weight,             2},
+    {"_dust2_test_scale_log_weights",           (DL_FUNC) &_dust2_test_scale_log_weights,           1},
     {NULL, NULL, 0}
 };
 }

--- a/src/sir.cpp
+++ b/src/sir.cpp
@@ -121,8 +121,8 @@ SEXP dust2_cpu_sir_filter_alloc(cpp11::list r_pars,
 
 [[cpp11::register]]
 SEXP dust2_cpu_sir_filter_run(cpp11::sexp ptr, cpp11::sexp r_pars,
-                              bool grouped) {
-  return dust2::r::dust2_cpu_filter_run<sir>(ptr, r_pars, grouped);
+                              cpp11::sexp r_initial, bool grouped) {
+  return dust2::r::dust2_cpu_filter_run<sir>(ptr, r_pars, r_initial, grouped);
 }
 
 [[cpp11::register]]

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -15,6 +15,12 @@ cpp11::integers test_resample_weight(std::vector<double> w, double u) {
   return ret;
 }
 
+[[cpp11::register]]
+cpp11::list test_scale_log_weights(std::vector<double> w) {
+  const auto res = dust2::details::scale_log_weights<double>(w.size(), w.begin());
+  return cpp11::writable::list{cpp11::as_sexp(res), cpp11::as_sexp(w)};
+}
+
 // Simple driver for exercising the history saving outside of any
 // particle filter.
 [[cpp11::register]]

--- a/tests/testthat/helper-dust.R
+++ b/tests/testthat/helper-dust.R
@@ -11,12 +11,16 @@ sir_filter_manual <- function(pars, time_start, time, dt, data, n_particles,
                            time = time_start, dt = dt, seed = seed)
   n_steps <- round((time - c(time_start, time[-length(time)])) / dt)
 
-  function(pars) {
+  function(pars, initial = NULL) {
     if (!is.null(pars)) {
       dust_model_update_pars(obj, pars)
     }
     dust_model_set_time(obj, time_start)
-    dust_model_set_state_initial(obj)
+    if (is.null(initial)) {
+      dust_model_set_state_initial(obj)
+    } else {
+      dust_model_set_state(obj, initial)
+    }
     ll <- 0
     for (i in seq_along(time)) {
       dust_model_run_steps(obj, n_steps[[i]])

--- a/tests/testthat/test-filter-details.R
+++ b/tests/testthat/test-filter-details.R
@@ -13,6 +13,12 @@ test_that("Resampling works as expected", {
   expect_equal(
     test_resample_weight(w, u) + 1L,
     ref_resample_weight(w, u))
+  expect_equal(
+    test_resample_weight(w, 0) + 1L,
+    ref_resample_weight(w, 0))
+  expect_equal(
+    test_resample_weight(w, 1 - 1e-8) + 1L,
+    ref_resample_weight(w, 1 - 1e-8))
 })
 
 
@@ -35,6 +41,18 @@ test_that("can use history", {
                list(time[1:3], s_arr[, , , 1:3]))
   expect_equal(test_history(time, s, vector("list", length(time)), TRUE),
                list(time, s_arr))
+})
+
+
+test_that("can scale log weights", {
+  w <- log(abs(rcauchy(20)))
+  expect_equal(test_scale_log_weights(w[1]), list(w[1], w[1]))
+  expect_equal(test_scale_log_weights(w),
+               list(log(mean(exp(w))), exp(w - max(w))))
+  expect_equal(test_scale_log_weights(c(w, NA)),
+               list(log(mean(c(exp(w), 0))), c(exp(w - max(w)), 0)))
+  expect_equal(test_scale_log_weights(c(-Inf, -Inf)),
+               list(-Inf, c(-Inf, -Inf)))
 })
 
 

--- a/tests/testthat/test-filter.R
+++ b/tests/testthat/test-filter.R
@@ -218,3 +218,25 @@ test_that("can run a nested particle filter and get the same result", {
   expect_equal(res2, res[2, ])
   expect_equal(s2, s[3233:6464])
 })
+
+
+test_that("can run filter and change parameters", {
+  base <- list(beta = 0.1, gamma = 0.2, N = 1000, I0 = 10, exp_noise = 1e6)
+  update <- list(beta = 0.15, gamma = 0.25, I0 = 15)
+  pars <- modifyList(base, update)
+
+  time_start <- 0
+  time <- c(4, 8, 12, 16)
+  data <- lapply(1:4, function(i) list(incidence = i))
+  dt <- 1
+  n_particles <- 100
+  seed <- 42
+
+  obj1 <- dust_filter_create(sir(), base, time_start, time, data,
+                             n_particles = n_particles, seed = seed)
+  obj2 <- dust_filter_create(sir(), pars, time_start, time, data,
+                             n_particles = n_particles, seed = seed)
+
+  expect_equal(dust_filter_run(obj1, update),
+               dust_filter_run(obj2))
+})

--- a/tests/testthat/test-filter.R
+++ b/tests/testthat/test-filter.R
@@ -240,3 +240,24 @@ test_that("can run filter and change parameters", {
   expect_equal(dust_filter_run(obj1, update),
                dust_filter_run(obj2))
 })
+
+
+test_that("can run particle filter with manual initial state", {
+  pars <- list(beta = 0.1, gamma = 0.2, N = 1000, I0 = 10, exp_noise = 1e6)
+  state <- matrix(c(1000 - 17, 17, 0, 0, 0), ncol = 1)
+
+  time_start <- 0
+  time <- c(4, 8, 12, 16)
+  data <- lapply(1:4, function(i) list(incidence = i))
+  dt <- 1
+  n_particles <- 100
+  seed <- 42
+
+  obj <- dust_filter_create(sir(), pars, time_start, time, data,
+                           n_particles = n_particles, seed = seed)
+  res <- replicate(20, dust_filter_run(obj, initial = state))
+
+  cmp_filter <- sir_filter_manual(
+    pars, time_start, time, dt, data, n_particles, seed)
+  expect_equal(res, replicate(20, cmp_filter(NULL, state)))
+})

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -56,3 +56,11 @@ test_that("error if non-dust model given to dust function", {
   expect_error(dust_model_state(NULL),
                "Expected 'model' to be a 'dust_model' object")
 })
+
+
+test_that("error if non-dust model given to dust function", {
+  expect_error(dust_unfilter_run(NULL),
+               "Expected 'unfilter' to be a 'dust_unfilter' object")
+  expect_error(dust_filter_run(NULL),
+               "Expected 'filter' to be a 'dust_filter' object")
+})

--- a/tests/testthat/test-sir.R
+++ b/tests/testthat/test-sir.R
@@ -60,7 +60,7 @@ test_that("can compare against multple parameter groups at once", {
   pars <- lapply(1:4, function(i) {
     list(beta = 0.1 * i, gamma = 0.2, N = 1000, I0 = 10, exp_noise = 10^i)
   })
-  obj <- dust_model_create(sir(), pars, n_particles = 10, n_groups = 4, 
+  obj <- dust_model_create(sir(), pars, n_particles = 10, n_groups = 4,
                            seed = 42)
 
   s <- dust_model_state(obj)

--- a/tests/testthat/test-sir.R
+++ b/tests/testthat/test-sir.R
@@ -196,3 +196,15 @@ test_that("copy names with index", {
 
   expect_equal(unname(res1), res2)
 })
+
+
+test_that("can reorder state", {
+  obj <- dust_model_create(sir(), list(), n_particles = 10, seed = 42)
+  expect_null(dust_model_set_state_initial(obj))
+  dust_model_run_steps(obj, 100)
+  s1 <- dust_model_state(obj)
+  i <- sample(10, replace = TRUE)
+  expect_null(dust_model_reorder(obj, i))
+  s2 <- dust_model_state(obj)
+  expect_equal(s2, s1[, i, drop = FALSE])
+})

--- a/tests/testthat/test-walk.R
+++ b/tests/testthat/test-walk.R
@@ -142,6 +142,10 @@ test_that("validate inputs", {
   expect_error(
     dust_model_create(walk(), pars, n_particles = 10, deterministic = 1),
     "'deterministic' must be scalar logical")
+
+  expect_error(
+    dust_model_create(walk(), list(), n_particles = 10),
+    "A value is expected for 'sd'")
 })
 
 
@@ -471,4 +475,27 @@ test_that("can validate index values", {
   expect_error(
     dust_model_simulate(obj, 0:20, integer()),
     "'index' must have nonzero length")
+})
+
+
+test_that("can't compare walk to data", {
+  pars <- list(sd = 1)
+  obj <- dust_model_create(walk(), pars, n_particles = 10, seed = 42)
+  expect_error(
+    dust_model_compare_data(obj, list()),
+    "Can't compare against data; the 'walk' model does not have 'compare_data'")
+})
+
+
+test_that("can't create filter with walk model", {
+  pars <- list(sd = 1)
+  time_start <- 0
+  time <- 1:4
+  data <- vector("list", length(time))
+  expect_error(
+    dust_unfilter_create(walk(), pars, time_start, time, data),
+    "Can't create unfilter; the 'walk' model does not have 'compare_data'")
+  expect_error(
+    dust_filter_create(walk(), pars, time_start, time, data, 10),
+    "Can't create filter; the 'walk' model does not have 'compare_data'")
 })


### PR DESCRIPTION
* Small lint
* Various bits of missing coverage, one of which (for the filter details) required a new little helper test function
* Pass `initial` through to filter for consistency with the unfilter