### PR TITLE
Use size_state in place of size

### DIFF
--- a/inst/examples/sir.cpp
+++ b/inst/examples/sir.cpp
@@ -29,7 +29,7 @@ public:
 
   using rng_state_type = mcstate::random::generator<real_type>;
 
-  static size_t size(const shared_state& shared) {
+  static size_t size_state(const shared_state& shared) {
     return 5;
   }
 

--- a/inst/examples/walk.cpp
+++ b/inst/examples/walk.cpp
@@ -38,7 +38,7 @@ public:
   // This one always feels a bit weird, really.
   using rng_state_type = mcstate::random::generator<real_type>;
 
-  static size_t size(const shared_state& shared) {
+  static size_t size_state(const shared_state& shared) {
     return shared.len;
   }
 

--- a/inst/include/dust2/discrete/system.hpp
+++ b/inst/include/dust2/discrete/system.hpp
@@ -24,7 +24,7 @@ public:
                 size_t n_particles, // per group
                 const std::vector<rng_int_type>& seed,
                 bool deterministic) :
-    n_state_(T::size(shared[0])),
+    n_state_(T::size_state(shared[0])),
     n_particles_(n_particles),
     n_groups_(shared.size()),
     n_particles_total_(n_particles_ * n_groups_),

--- a/inst/include/dust2/r/helpers.hpp
+++ b/inst/include/dust2/r/helpers.hpp
@@ -212,7 +212,7 @@ std::vector<typename T::shared_state> build_shared(cpp11::list r_pars,
     size_t size = 0;
     for (size_t i = 0; i < n_groups; ++i) {
       shared.push_back(T::build_shared(r_pars[i]));
-      const auto size_i = T::size(shared[i]);
+      const auto size_i = T::size_state(shared[i]);
       if (i == 0) {
         size = size_i;
       } else if (size_i != size) {

--- a/src/sir.cpp
+++ b/src/sir.cpp
@@ -31,7 +31,7 @@ public:
 
   using rng_state_type = mcstate::random::generator<real_type>;
 
-  static size_t size(const shared_state& shared) {
+  static size_t size_state(const shared_state& shared) {
     return 5;
   }
 

--- a/src/walk.cpp
+++ b/src/walk.cpp
@@ -40,7 +40,7 @@ public:
   // This one always feels a bit weird, really.
   using rng_state_type = mcstate::random::generator<real_type>;
 
-  static size_t size(const shared_state& shared) {
+  static size_t size_state(const shared_state& shared) {
     return shared.len;
   }
 


### PR DESCRIPTION
This is one of several bits that will help with the move to using ODE models as there we also have the size of output (derived quantities from state).  This way is less ambiguous in general