### PR TITLE
Support for collecting then throwing errors

### DIFF
--- a/inst/include/dust2/errors.hpp
+++ b/inst/include/dust2/errors.hpp
@@ -31,8 +31,7 @@ public:
     seen[i] = true;
   }
 
-  void report(bool clear = false, const char *title = "particles",
-              size_t n_max = 4) {
+  void report(const char *title = "particles", size_t n_max = 4) {
     count = std::accumulate(std::begin(seen), std::end(seen), 0);
     if (count == 0) {
       return;
@@ -50,10 +49,6 @@ public:
     }
     if (n_report < count) {
       msg << std::endl << "  - (and " << (count - n_report) << " more)";
-    }
-
-    if (clear) {
-      reset();
     }
 
     throw std::runtime_error(msg.str());

--- a/inst/include/dust2/errors.hpp
+++ b/inst/include/dust2/errors.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
-// #include <algorithm>
-// #include <numeric>
+#include <numeric>
 #include <sstream>
 #include <vector>
 

--- a/inst/include/dust2/errors.hpp
+++ b/inst/include/dust2/errors.hpp
@@ -1,0 +1,70 @@
+#pragma once
+
+// #include <algorithm>
+// #include <numeric>
+#include <sstream>
+#include <vector>
+
+namespace dust2 {
+namespace utils {
+
+class errors {
+public:
+  errors() : errors(0) {
+  }
+  errors(size_t len) :
+    count(0), err(len), seen(len) {
+  }
+
+  void reset() {
+    count = 0;
+    std::fill(seen.begin(), seen.end(), false);
+    std::fill(err.begin(), err.end(), "");
+  }
+
+  bool unresolved() const {
+    return count > 0;
+  }
+
+  template <typename T>
+  void capture(const T& e, size_t i) {
+    err[i] = e.what();
+    seen[i] = true;
+  }
+
+  void report(bool clear = false, const char *title = "particles",
+              size_t n_max = 4) {
+    count = std::accumulate(std::begin(seen), std::end(seen), 0);
+    if (count == 0) {
+      return;
+    }
+
+    std::stringstream msg;
+    msg << count << " " << title << " reported errors.";
+
+    const size_t n_report = std::min(n_max, count);
+    for (size_t i = 0, j = 0; i < seen.size() && j < n_report; ++i) {
+      if (seen[i]) {
+        msg << std::endl << "  - " << i + 1 << ": " << err[i];
+        ++j;
+      }
+    }
+    if (n_report < count) {
+      msg << std::endl << "  - (and " << (count - n_report) << " more)";
+    }
+
+    if (clear) {
+      reset();
+    }
+
+    throw std::runtime_error(msg.str());
+  }
+
+private:
+  size_t count;
+  std::vector<std::string> err;
+  std::vector<bool> seen;
+};
+
+}
+}


### PR DESCRIPTION
This is a necessary condition for openmp, because errors thrown in parallel blocks are efficiently converted into crashes!

The implementation here closely mirrors the one we used in dust1, though some of the details of reporting are slightly different.