### PR TITLE
Allow filtering states on extraction

### DIFF
--- a/R/cpp11.R
+++ b/R/cpp11.R
@@ -12,8 +12,8 @@ dust2_system_logistic_run_to_time <- function(ptr, r_time) {
   .Call(`_dust2_dust2_system_logistic_run_to_time`, ptr, r_time)
 }
 
-dust2_system_logistic_state <- function(ptr, grouped) {
-  .Call(`_dust2_dust2_system_logistic_state`, ptr, grouped)
+dust2_system_logistic_state <- function(ptr, r_index_state, r_index_particle, r_index_group, grouped) {
+  .Call(`_dust2_dust2_system_logistic_state`, ptr, r_index_state, r_index_particle, r_index_group, grouped)
 }
 
 dust2_system_logistic_time <- function(ptr) {
@@ -60,8 +60,8 @@ dust2_system_sir_run_to_time <- function(ptr, r_time) {
   .Call(`_dust2_dust2_system_sir_run_to_time`, ptr, r_time)
 }
 
-dust2_system_sir_state <- function(ptr, grouped) {
-  .Call(`_dust2_dust2_system_sir_state`, ptr, grouped)
+dust2_system_sir_state <- function(ptr, r_index_state, r_index_particle, r_index_group, grouped) {
+  .Call(`_dust2_dust2_system_sir_state`, ptr, r_index_state, r_index_particle, r_index_group, grouped)
 }
 
 dust2_system_sir_time <- function(ptr) {
@@ -160,8 +160,8 @@ dust2_system_sirode_run_to_time <- function(ptr, r_time) {
   .Call(`_dust2_dust2_system_sirode_run_to_time`, ptr, r_time)
 }
 
-dust2_system_sirode_state <- function(ptr, grouped) {
-  .Call(`_dust2_dust2_system_sirode_state`, ptr, grouped)
+dust2_system_sirode_state <- function(ptr, r_index_state, r_index_particle, r_index_group, grouped) {
+  .Call(`_dust2_dust2_system_sirode_state`, ptr, r_index_state, r_index_particle, r_index_group, grouped)
 }
 
 dust2_system_sirode_time <- function(ptr) {
@@ -220,8 +220,8 @@ dust2_system_walk_run_to_time <- function(ptr, r_time) {
   .Call(`_dust2_dust2_system_walk_run_to_time`, ptr, r_time)
 }
 
-dust2_system_walk_state <- function(ptr, grouped) {
-  .Call(`_dust2_dust2_system_walk_state`, ptr, grouped)
+dust2_system_walk_state <- function(ptr, r_index_state, r_index_particle, r_index_group, grouped) {
+  .Call(`_dust2_dust2_system_walk_state`, ptr, r_index_state, r_index_particle, r_index_group, grouped)
 }
 
 dust2_system_walk_time <- function(ptr) {

--- a/R/interface.R
+++ b/R/interface.R
@@ -170,6 +170,15 @@ dust_system_create <- function(generator, pars, n_particles, n_groups = 0,
 ##'
 ##' @param sys A `dust_system` object
 ##'
+##' @param index_state Index of the state to fetch, if you would like
+##'   only a subset
+##'
+##' @param index_particle Index of the particle to fetch, if you would
+##'   like a subset
+##'
+##' @param index_group Index of the group to fetch, if you would like
+##'   a subset
+##'
 ##' @return An array of system state.  If your system is ungrouped, then
 ##'   this has two dimensions (state, particle).  If grouped, this has
 ##'   three dimensions (state, particle, group)
@@ -179,9 +188,11 @@ dust_system_create <- function(generator, pars, n_particles, n_groups = 0,
 ##'   system-specific initial conditions.
 ##'
 ##' @export
-dust_system_state <- function(sys) {
+dust_system_state <- function(sys, index_state = NULL, index_particle = NULL,
+                              index_group = NULL) {
   check_is_dust_system(sys)
-  sys$methods$state(sys$ptr, sys$grouped)
+  sys$methods$state(sys$ptr, index_state, index_particle, index_group,
+                    sys$grouped)
 }
 
 

--- a/inst/include/dust2/r/system.hpp
+++ b/inst/include/dust2/r/system.hpp
@@ -30,17 +30,69 @@ SEXP dust2_system_run_to_time(cpp11::sexp ptr, cpp11::sexp r_time) {
 }
 
 template <typename T>
-SEXP dust2_system_state(cpp11::sexp ptr, bool grouped) {
+SEXP dust2_system_state(cpp11::sexp ptr, cpp11::sexp r_index_state,
+			cpp11::sexp r_index_particle,
+			cpp11::sexp r_index_group, bool grouped) {
   auto *obj = cpp11::as_cpp<cpp11::external_pointer<T>>(ptr).get();
   check_errors(obj, "get state from");
+  const auto n_state = obj->n_state();
+  const auto n_particles = obj->n_particles();
+  const auto n_groups = obj->n_groups();
+
   cpp11::sexp ret = R_NilValue;
-  const auto iter = obj->state().begin();
-  if (grouped) {
-    ret = export_array_n(iter,
-                         {obj->n_state(), obj->n_particles(), obj->n_groups()});
+  const auto iter_src = obj->state().begin();
+  bool everything = r_index_state == R_NilValue &&
+    r_index_particle == R_NilValue &&
+    r_index_group == R_NilValue;
+  if (everything) {
+    if (grouped) {
+      ret = export_array_n(iter_src, {n_state, n_particles, n_groups});
+    } else {
+      ret = export_array_n(iter_src, {n_state, n_particles * n_groups});
+    }
   } else {
-    ret = export_array_n(iter,
-                         {obj->n_state(), obj->n_particles() * obj->n_groups()});
+    if (!grouped && r_index_group != R_NilValue) {
+      cpp11::stop("Can't provide 'index_group' for a non-grouped system");
+    }
+    const auto index_state =
+      check_index(r_index_state, n_state, "index_state");
+    const auto index_particle =
+      check_index(r_index_particle, n_particles, "index_particle");
+    const auto index_group =
+      check_index(r_index_group, n_groups, "index_group");
+
+    // This is surprisingly icky to do, but this will do a subsetting copy
+    const auto n_state_save =
+      index_state.empty() ? n_state : index_state.size();
+    const auto n_particle_save =
+      index_particle.empty() ? n_particles : index_particle.size();
+    const auto n_group_save =
+      index_group.empty() ? n_groups : index_group.size();
+    cpp11::writable::doubles d(n_state_save * n_particle_save * n_group_save);
+    double* it_dst = REAL(d);
+    if (grouped) {
+      set_array_dims(d, {n_state_save, n_particle_save, n_group_save});
+    } else {
+      set_array_dims(d, {n_state_save, n_particle_save * n_group_save});
+    }
+
+    for (size_t i = 0; i < n_group_save; ++i) {
+      const auto ii = index_group.empty() ? i : index_group[i];
+      auto it_i = iter_src + ii * n_state * n_particles;
+      for (size_t j = 0; j < n_particle_save; ++j) {
+	const auto jj = index_particle.empty() ? j : index_particle[j];
+	const auto it_j = it_i + jj * n_state;
+	if (index_state.empty()) {
+	  it_dst = std::copy_n(it_j, n_state, it_dst);
+	} else {
+	  for (size_t k = 0; k < n_state_save; ++k, ++it_dst) {
+	    const auto kk = index_state.empty() ? j : index_state[k];
+	    *it_dst = *(it_j + kk);
+	  }
+	}
+      }
+    }
+    ret = d;
   }
   return ret;
 }

--- a/inst/include/dust2/r/system.hpp
+++ b/inst/include/dust2/r/system.hpp
@@ -86,7 +86,7 @@ SEXP dust2_system_state(cpp11::sexp ptr, cpp11::sexp r_index_state,
 	  it_dst = std::copy_n(it_j, n_state, it_dst);
 	} else {
 	  for (size_t k = 0; k < n_state_save; ++k, ++it_dst) {
-	    const auto kk = index_state.empty() ? j : index_state[k];
+	    const auto kk = index_state[k];
 	    *it_dst = *(it_j + kk);
 	  }
 	}

--- a/inst/template/system.cpp
+++ b/inst/template/system.cpp
@@ -4,8 +4,8 @@ SEXP dust2_system_{{name}}_run_to_time(cpp11::sexp ptr, cpp11::sexp r_time) {
 }
 
 [[cpp11::register]]
-SEXP dust2_system_{{name}}_state(cpp11::sexp ptr, bool grouped) {
-  return dust2::r::dust2_system_state<dust2::dust_{{time_type}}<{{class}}>>(ptr, grouped);
+SEXP dust2_system_{{name}}_state(cpp11::sexp ptr, cpp11::sexp r_index_state, cpp11::sexp r_index_particle, cpp11::sexp r_index_group, bool grouped) {
+  return dust2::r::dust2_system_state<dust2::dust_{{time_type}}<{{class}}>>(ptr, r_index_state, r_index_particle, r_index_group, grouped);
 }
 
 [[cpp11::register]]

--- a/man/dust_system_state.Rd
+++ b/man/dust_system_state.Rd
@@ -4,10 +4,24 @@
 \alias{dust_system_state}
 \title{Extract system state}
 \usage{
-dust_system_state(sys)
+dust_system_state(
+  sys,
+  index_state = NULL,
+  index_particle = NULL,
+  index_group = NULL
+)
 }
 \arguments{
 \item{sys}{A \code{dust_system} object}
+
+\item{index_state}{Index of the state to fetch, if you would like
+only a subset}
+
+\item{index_particle}{Index of the particle to fetch, if you would
+like a subset}
+
+\item{index_group}{Index of the group to fetch, if you would like
+a subset}
 }
 \value{
 An array of system state.  If your system is ungrouped, then

--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -27,10 +27,10 @@ extern "C" SEXP _dust2_dust2_system_logistic_run_to_time(SEXP ptr, SEXP r_time) 
   END_CPP11
 }
 // logistic.cpp
-SEXP dust2_system_logistic_state(cpp11::sexp ptr, bool grouped);
-extern "C" SEXP _dust2_dust2_system_logistic_state(SEXP ptr, SEXP grouped) {
+SEXP dust2_system_logistic_state(cpp11::sexp ptr, cpp11::sexp r_index_state, cpp11::sexp r_index_particle, cpp11::sexp r_index_group, bool grouped);
+extern "C" SEXP _dust2_dust2_system_logistic_state(SEXP ptr, SEXP r_index_state, SEXP r_index_particle, SEXP r_index_group, SEXP grouped) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust2_system_logistic_state(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<bool>>(grouped)));
+    return cpp11::as_sexp(dust2_system_logistic_state(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_state), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_particle), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_group), cpp11::as_cpp<cpp11::decay_t<bool>>(grouped)));
   END_CPP11
 }
 // logistic.cpp
@@ -111,10 +111,10 @@ extern "C" SEXP _dust2_dust2_system_sir_run_to_time(SEXP ptr, SEXP r_time) {
   END_CPP11
 }
 // sir.cpp
-SEXP dust2_system_sir_state(cpp11::sexp ptr, bool grouped);
-extern "C" SEXP _dust2_dust2_system_sir_state(SEXP ptr, SEXP grouped) {
+SEXP dust2_system_sir_state(cpp11::sexp ptr, cpp11::sexp r_index_state, cpp11::sexp r_index_particle, cpp11::sexp r_index_group, bool grouped);
+extern "C" SEXP _dust2_dust2_system_sir_state(SEXP ptr, SEXP r_index_state, SEXP r_index_particle, SEXP r_index_group, SEXP grouped) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust2_system_sir_state(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<bool>>(grouped)));
+    return cpp11::as_sexp(dust2_system_sir_state(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_state), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_particle), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_group), cpp11::as_cpp<cpp11::decay_t<bool>>(grouped)));
   END_CPP11
 }
 // sir.cpp
@@ -286,10 +286,10 @@ extern "C" SEXP _dust2_dust2_system_sirode_run_to_time(SEXP ptr, SEXP r_time) {
   END_CPP11
 }
 // sirode.cpp
-SEXP dust2_system_sirode_state(cpp11::sexp ptr, bool grouped);
-extern "C" SEXP _dust2_dust2_system_sirode_state(SEXP ptr, SEXP grouped) {
+SEXP dust2_system_sirode_state(cpp11::sexp ptr, cpp11::sexp r_index_state, cpp11::sexp r_index_particle, cpp11::sexp r_index_group, bool grouped);
+extern "C" SEXP _dust2_dust2_system_sirode_state(SEXP ptr, SEXP r_index_state, SEXP r_index_particle, SEXP r_index_group, SEXP grouped) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust2_system_sirode_state(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<bool>>(grouped)));
+    return cpp11::as_sexp(dust2_system_sirode_state(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_state), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_particle), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_group), cpp11::as_cpp<cpp11::decay_t<bool>>(grouped)));
   END_CPP11
 }
 // sirode.cpp
@@ -391,10 +391,10 @@ extern "C" SEXP _dust2_dust2_system_walk_run_to_time(SEXP ptr, SEXP r_time) {
   END_CPP11
 }
 // walk.cpp
-SEXP dust2_system_walk_state(cpp11::sexp ptr, bool grouped);
-extern "C" SEXP _dust2_dust2_system_walk_state(SEXP ptr, SEXP grouped) {
+SEXP dust2_system_walk_state(cpp11::sexp ptr, cpp11::sexp r_index_state, cpp11::sexp r_index_particle, cpp11::sexp r_index_group, bool grouped);
+extern "C" SEXP _dust2_dust2_system_walk_state(SEXP ptr, SEXP r_index_state, SEXP r_index_particle, SEXP r_index_group, SEXP grouped) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust2_system_walk_state(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<bool>>(grouped)));
+    return cpp11::as_sexp(dust2_system_walk_state(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_state), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_particle), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_group), cpp11::as_cpp<cpp11::decay_t<bool>>(grouped)));
   END_CPP11
 }
 // walk.cpp
@@ -479,7 +479,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_dust2_dust2_system_logistic_set_state_initial", (DL_FUNC) &_dust2_dust2_system_logistic_set_state_initial,  1},
     {"_dust2_dust2_system_logistic_set_time",          (DL_FUNC) &_dust2_dust2_system_logistic_set_time,           2},
     {"_dust2_dust2_system_logistic_simulate",          (DL_FUNC) &_dust2_dust2_system_logistic_simulate,           4},
-    {"_dust2_dust2_system_logistic_state",             (DL_FUNC) &_dust2_dust2_system_logistic_state,              2},
+    {"_dust2_dust2_system_logistic_state",             (DL_FUNC) &_dust2_dust2_system_logistic_state,              5},
     {"_dust2_dust2_system_logistic_time",              (DL_FUNC) &_dust2_dust2_system_logistic_time,               1},
     {"_dust2_dust2_system_logistic_update_pars",       (DL_FUNC) &_dust2_dust2_system_logistic_update_pars,        3},
     {"_dust2_dust2_system_sir_alloc",                  (DL_FUNC) &_dust2_dust2_system_sir_alloc,                   8},
@@ -492,7 +492,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_dust2_dust2_system_sir_set_state_initial",      (DL_FUNC) &_dust2_dust2_system_sir_set_state_initial,       1},
     {"_dust2_dust2_system_sir_set_time",               (DL_FUNC) &_dust2_dust2_system_sir_set_time,                2},
     {"_dust2_dust2_system_sir_simulate",               (DL_FUNC) &_dust2_dust2_system_sir_simulate,                4},
-    {"_dust2_dust2_system_sir_state",                  (DL_FUNC) &_dust2_dust2_system_sir_state,                   2},
+    {"_dust2_dust2_system_sir_state",                  (DL_FUNC) &_dust2_dust2_system_sir_state,                   5},
     {"_dust2_dust2_system_sir_time",                   (DL_FUNC) &_dust2_dust2_system_sir_time,                    1},
     {"_dust2_dust2_system_sir_update_pars",            (DL_FUNC) &_dust2_dust2_system_sir_update_pars,             3},
     {"_dust2_dust2_system_sirode_alloc",               (DL_FUNC) &_dust2_dust2_system_sirode_alloc,                8},
@@ -505,7 +505,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_dust2_dust2_system_sirode_set_state_initial",   (DL_FUNC) &_dust2_dust2_system_sirode_set_state_initial,    1},
     {"_dust2_dust2_system_sirode_set_time",            (DL_FUNC) &_dust2_dust2_system_sirode_set_time,             2},
     {"_dust2_dust2_system_sirode_simulate",            (DL_FUNC) &_dust2_dust2_system_sirode_simulate,             4},
-    {"_dust2_dust2_system_sirode_state",               (DL_FUNC) &_dust2_dust2_system_sirode_state,                2},
+    {"_dust2_dust2_system_sirode_state",               (DL_FUNC) &_dust2_dust2_system_sirode_state,                5},
     {"_dust2_dust2_system_sirode_time",                (DL_FUNC) &_dust2_dust2_system_sirode_time,                 1},
     {"_dust2_dust2_system_sirode_update_pars",         (DL_FUNC) &_dust2_dust2_system_sirode_update_pars,          3},
     {"_dust2_dust2_system_walk_alloc",                 (DL_FUNC) &_dust2_dust2_system_walk_alloc,                  8},
@@ -517,7 +517,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_dust2_dust2_system_walk_set_state_initial",     (DL_FUNC) &_dust2_dust2_system_walk_set_state_initial,      1},
     {"_dust2_dust2_system_walk_set_time",              (DL_FUNC) &_dust2_dust2_system_walk_set_time,               2},
     {"_dust2_dust2_system_walk_simulate",              (DL_FUNC) &_dust2_dust2_system_walk_simulate,               4},
-    {"_dust2_dust2_system_walk_state",                 (DL_FUNC) &_dust2_dust2_system_walk_state,                  2},
+    {"_dust2_dust2_system_walk_state",                 (DL_FUNC) &_dust2_dust2_system_walk_state,                  5},
     {"_dust2_dust2_system_walk_time",                  (DL_FUNC) &_dust2_dust2_system_walk_time,                   1},
     {"_dust2_dust2_system_walk_update_pars",           (DL_FUNC) &_dust2_dust2_system_walk_update_pars,            3},
     {"_dust2_dust2_unfilter_sir_alloc",                (DL_FUNC) &_dust2_dust2_unfilter_sir_alloc,                 9},

--- a/src/logistic.cpp
+++ b/src/logistic.cpp
@@ -107,8 +107,8 @@ SEXP dust2_system_logistic_run_to_time(cpp11::sexp ptr, cpp11::sexp r_time) {
 }
 
 [[cpp11::register]]
-SEXP dust2_system_logistic_state(cpp11::sexp ptr, bool grouped) {
-  return dust2::r::dust2_system_state<dust2::dust_continuous<logistic>>(ptr, grouped);
+SEXP dust2_system_logistic_state(cpp11::sexp ptr, cpp11::sexp r_index_state, cpp11::sexp r_index_particle, cpp11::sexp r_index_group, bool grouped) {
+  return dust2::r::dust2_system_state<dust2::dust_continuous<logistic>>(ptr, r_index_state, r_index_particle, r_index_group, grouped);
 }
 
 [[cpp11::register]]

--- a/src/sir.cpp
+++ b/src/sir.cpp
@@ -224,8 +224,8 @@ SEXP dust2_system_sir_run_to_time(cpp11::sexp ptr, cpp11::sexp r_time) {
 }
 
 [[cpp11::register]]
-SEXP dust2_system_sir_state(cpp11::sexp ptr, bool grouped) {
-  return dust2::r::dust2_system_state<dust2::dust_discrete<sir>>(ptr, grouped);
+SEXP dust2_system_sir_state(cpp11::sexp ptr, cpp11::sexp r_index_state, cpp11::sexp r_index_particle, cpp11::sexp r_index_group, bool grouped) {
+  return dust2::r::dust2_system_state<dust2::dust_discrete<sir>>(ptr, r_index_state, r_index_particle, r_index_group, grouped);
 }
 
 [[cpp11::register]]

--- a/src/sirode.cpp
+++ b/src/sirode.cpp
@@ -113,8 +113,8 @@ SEXP dust2_system_sirode_run_to_time(cpp11::sexp ptr, cpp11::sexp r_time) {
 }
 
 [[cpp11::register]]
-SEXP dust2_system_sirode_state(cpp11::sexp ptr, bool grouped) {
-  return dust2::r::dust2_system_state<dust2::dust_continuous<sirode>>(ptr, grouped);
+SEXP dust2_system_sirode_state(cpp11::sexp ptr, cpp11::sexp r_index_state, cpp11::sexp r_index_particle, cpp11::sexp r_index_group, bool grouped) {
+  return dust2::r::dust2_system_state<dust2::dust_continuous<sirode>>(ptr, r_index_state, r_index_particle, r_index_group, grouped);
 }
 
 [[cpp11::register]]

--- a/src/walk.cpp
+++ b/src/walk.cpp
@@ -121,8 +121,8 @@ SEXP dust2_system_walk_run_to_time(cpp11::sexp ptr, cpp11::sexp r_time) {
 }
 
 [[cpp11::register]]
-SEXP dust2_system_walk_state(cpp11::sexp ptr, bool grouped) {
-  return dust2::r::dust2_system_state<dust2::dust_discrete<walk>>(ptr, grouped);
+SEXP dust2_system_walk_state(cpp11::sexp ptr, cpp11::sexp r_index_state, cpp11::sexp r_index_particle, cpp11::sexp r_index_group, bool grouped) {
+  return dust2::r::dust2_system_state<dust2::dust_discrete<walk>>(ptr, r_index_state, r_index_particle, r_index_group, grouped);
 }
 
 [[cpp11::register]]

--- a/tests/testthat/test-walk.R
+++ b/tests/testthat/test-walk.R
@@ -545,3 +545,77 @@ test_that("discrete time models have no internals", {
   expect_null(dust_system_run_to_time(obj, 3))
   expect_null(dust_system_internals(obj))
 })
+
+
+test_that("can extract subset of state from an ungrouped system", {
+  set.seed(1)
+  pars <- list(len = 5, sd = 1, random_initial = TRUE)
+  obj <- dust_system_create(walk(), pars, n_particles = 7)
+  dust_system_set_state_initial(obj)
+  m <- dust_system_state(obj)
+  expect_equal(dim(m), c(5, 7))
+
+  expect_equal(
+    dust_system_state(obj, index_particle = c(2, 5, 6)),
+    m[, c(2, 5, 6)])
+  expect_equal(
+    dust_system_state(obj, index_state = c(1, 2, 4)),
+    m[c(1, 2, 4), ])
+  expect_equal(
+    dust_system_state(obj, index_particle = c(4, 7), index_state = c(1, 2, 4)),
+    m[c(1, 2, 4), c(4, 7)])
+
+  expect_error(
+    dust_system_state(obj, index_particle = integer(0)),
+    "'index_particle' must have nonzero length")
+  expect_error(
+    dust_system_state(obj, index_state = integer(0)),
+    "'index_state' must have nonzero length")
+
+  expect_error(
+    dust_system_state(obj, index_group = 1),
+    "Can't provide 'index_group' for a non-grouped system")
+  expect_error(
+    dust_system_state(obj, index_group = 1:2),
+    "Can't provide 'index_group' for a non-grouped system")
+})
+
+
+test_that("can extract subset of state from a grouped system", {
+  set.seed(1)
+  pars <- rep(list(list(len = 5, sd = 1, random_initial = TRUE)), 3)
+  obj <- dust_system_create(walk(), pars, n_particles = 7, n_groups = 3)
+  dust_system_set_state_initial(obj)
+  m <- dust_system_state(obj)
+  expect_equal(dim(m), c(5, 7, 3))
+
+  expect_equal(
+    dust_system_state(obj, index_particle = c(2, 5, 6)),
+    m[, c(2, 5, 6), ])
+  expect_equal(
+    dust_system_state(obj, index_state = c(1, 2, 4)),
+    m[c(1, 2, 4), , ])
+  expect_equal(
+    dust_system_state(obj, index_group = c(2, 3)),
+    m[, , c(2, 3)])
+  expect_equal(
+    dust_system_state(obj, index_particle = c(4, 7), index_state = c(1, 2, 4)),
+    m[c(1, 2, 4), c(4, 7), ])
+  expect_equal(
+    dust_system_state(obj, index_particle = c(4, 7), index_group = c(2, 3)),
+    m[, c(4, 7), c(2, 3)])
+  expect_equal(
+    dust_system_state(obj, index_state = 2, index_particle = c(4, 7),
+                      index_group = c(2, 3)),
+    m[2, c(4, 7), c(2, 3), drop = FALSE])
+
+  expect_error(
+    dust_system_state(obj, index_particle = integer(0)),
+    "'index_particle' must have nonzero length")
+  expect_error(
+    dust_system_state(obj, index_state = integer(0)),
+    "'index_state' must have nonzero length")
+  expect_error(
+    dust_system_state(obj, index_group = integer(0)),
+    "'index_group' must have nonzero length")
+})


### PR DESCRIPTION
This PR allows `dust_system_state` to filter system state by state index, particle index or (in a grouped system) group index.  This will certainly be pulled into some sort of helper function at some point because this sort of filtering will turn up elsewhere (e.g., within the particle filter) and because it's surprisingly awkward.  This will also be the basis for the inteface at the R level of things like "run the filter just for these groups only" I think.