### PR TITLE
Graceful control over single dimension axes

### DIFF
--- a/R/check.R
+++ b/R/check.R
@@ -1,0 +1,17 @@
+## Distinct from the code in util_assert.R which are our generic
+## validation functions, these are bits of validation that group
+## together to validate inputs to dust systems.
+check_pars <- function(pars, n_groups, preserve_group_dimension,
+                       name = deparse(substitute(pars)), call = NULL) {
+  if (preserve_group_dimension) {
+    if (!length(pars) != n_groups) {
+      cli::cli_abort(
+        paste("Expected 'pars' to have length {n_groups} to match 'n_groups',",
+              "but it had length {length(pars)}"),
+        arg = "pars", call = call)
+    }
+  } else {
+    pars <- list(pars)
+  }
+  pars
+}

--- a/R/check.R
+++ b/R/check.R
@@ -4,7 +4,7 @@
 check_pars <- function(pars, n_groups, preserve_group_dimension,
                        name = deparse(substitute(pars)), call = NULL) {
   if (preserve_group_dimension) {
-    if (!length(pars) != n_groups) {
+    if (length(pars) != n_groups) {
       cli::cli_abort(
         paste("Expected 'pars' to have length {n_groups} to match 'n_groups',",
               "but it had length {length(pars)}"),

--- a/R/cpp11.R
+++ b/R/cpp11.R
@@ -100,12 +100,12 @@ dust2_system_sir_simulate <- function(ptr, r_times, r_index, preserve_particle_d
   .Call(`_dust2_dust2_system_sir_simulate`, ptr, r_times, r_index, preserve_particle_dimension, preserve_group_dimension)
 }
 
-dust2_unfilter_sir_alloc <- function(r_pars, r_time_start, r_time, r_dt, r_data, r_n_particles, r_n_groups, r_n_threads, r_index) {
-  .Call(`_dust2_dust2_unfilter_sir_alloc`, r_pars, r_time_start, r_time, r_dt, r_data, r_n_particles, r_n_groups, r_n_threads, r_index)
+dust2_unfilter_sir_alloc <- function(r_pars, r_time_start, r_time, r_dt, r_data, r_n_particles, r_n_groups, r_n_threads, r_index_state) {
+  .Call(`_dust2_dust2_unfilter_sir_alloc`, r_pars, r_time_start, r_time, r_dt, r_data, r_n_particles, r_n_groups, r_n_threads, r_index_state)
 }
 
-dust2_filter_sir_alloc <- function(r_pars, r_time_start, r_time, r_dt, r_data, r_n_particles, r_n_groups, r_n_threads, r_index, r_seed) {
-  .Call(`_dust2_dust2_filter_sir_alloc`, r_pars, r_time_start, r_time, r_dt, r_data, r_n_particles, r_n_groups, r_n_threads, r_index, r_seed)
+dust2_filter_sir_alloc <- function(r_pars, r_time_start, r_time, r_dt, r_data, r_n_particles, r_n_groups, r_n_threads, r_index_state, r_seed) {
+  .Call(`_dust2_dust2_filter_sir_alloc`, r_pars, r_time_start, r_time, r_dt, r_data, r_n_particles, r_n_groups, r_n_threads, r_index_state, r_seed)
 }
 
 dust2_system_sir_compare_data <- function(ptr, r_data, preserve_particle_dimension, preserve_group_dimension) {

--- a/R/cpp11.R
+++ b/R/cpp11.R
@@ -12,8 +12,8 @@ dust2_system_logistic_run_to_time <- function(ptr, r_time) {
   .Call(`_dust2_dust2_system_logistic_run_to_time`, ptr, r_time)
 }
 
-dust2_system_logistic_state <- function(ptr, r_index_state, r_index_particle, r_index_group, grouped) {
-  .Call(`_dust2_dust2_system_logistic_state`, ptr, r_index_state, r_index_particle, r_index_group, grouped)
+dust2_system_logistic_state <- function(ptr, r_index_state, r_index_particle, r_index_group, preserve_group_dimension) {
+  .Call(`_dust2_dust2_system_logistic_state`, ptr, r_index_state, r_index_particle, r_index_group, preserve_group_dimension)
 }
 
 dust2_system_logistic_time <- function(ptr) {
@@ -24,8 +24,8 @@ dust2_system_logistic_set_state_initial <- function(ptr) {
   .Call(`_dust2_dust2_system_logistic_set_state_initial`, ptr)
 }
 
-dust2_system_logistic_set_state <- function(ptr, r_state, grouped) {
-  .Call(`_dust2_dust2_system_logistic_set_state`, ptr, r_state, grouped)
+dust2_system_logistic_set_state <- function(ptr, r_state) {
+  .Call(`_dust2_dust2_system_logistic_set_state`, ptr, r_state)
 }
 
 dust2_system_logistic_reorder <- function(ptr, r_index) {
@@ -44,12 +44,12 @@ dust2_system_logistic_set_time <- function(ptr, r_time) {
   .Call(`_dust2_dust2_system_logistic_set_time`, ptr, r_time)
 }
 
-dust2_system_logistic_update_pars <- function(ptr, pars, grouped) {
-  .Call(`_dust2_dust2_system_logistic_update_pars`, ptr, pars, grouped)
+dust2_system_logistic_update_pars <- function(ptr, pars) {
+  .Call(`_dust2_dust2_system_logistic_update_pars`, ptr, pars)
 }
 
-dust2_system_logistic_simulate <- function(ptr, r_times, r_index, grouped) {
-  .Call(`_dust2_dust2_system_logistic_simulate`, ptr, r_times, r_index, grouped)
+dust2_system_logistic_simulate <- function(ptr, r_times, r_index, preserve_group_dimension) {
+  .Call(`_dust2_dust2_system_logistic_simulate`, ptr, r_times, r_index, preserve_group_dimension)
 }
 
 dust2_system_sir_alloc <- function(r_pars, r_time, r_dt, r_n_particles, r_n_groups, r_seed, r_deterministic, r_n_threads) {
@@ -60,8 +60,8 @@ dust2_system_sir_run_to_time <- function(ptr, r_time) {
   .Call(`_dust2_dust2_system_sir_run_to_time`, ptr, r_time)
 }
 
-dust2_system_sir_state <- function(ptr, r_index_state, r_index_particle, r_index_group, grouped) {
-  .Call(`_dust2_dust2_system_sir_state`, ptr, r_index_state, r_index_particle, r_index_group, grouped)
+dust2_system_sir_state <- function(ptr, r_index_state, r_index_particle, r_index_group, preserve_group_dimension) {
+  .Call(`_dust2_dust2_system_sir_state`, ptr, r_index_state, r_index_particle, r_index_group, preserve_group_dimension)
 }
 
 dust2_system_sir_time <- function(ptr) {
@@ -72,8 +72,8 @@ dust2_system_sir_set_state_initial <- function(ptr) {
   .Call(`_dust2_dust2_system_sir_set_state_initial`, ptr)
 }
 
-dust2_system_sir_set_state <- function(ptr, r_state, grouped) {
-  .Call(`_dust2_dust2_system_sir_set_state`, ptr, r_state, grouped)
+dust2_system_sir_set_state <- function(ptr, r_state) {
+  .Call(`_dust2_dust2_system_sir_set_state`, ptr, r_state)
 }
 
 dust2_system_sir_reorder <- function(ptr, r_index) {
@@ -92,12 +92,12 @@ dust2_system_sir_set_time <- function(ptr, r_time) {
   .Call(`_dust2_dust2_system_sir_set_time`, ptr, r_time)
 }
 
-dust2_system_sir_update_pars <- function(ptr, pars, grouped) {
-  .Call(`_dust2_dust2_system_sir_update_pars`, ptr, pars, grouped)
+dust2_system_sir_update_pars <- function(ptr, pars) {
+  .Call(`_dust2_dust2_system_sir_update_pars`, ptr, pars)
 }
 
-dust2_system_sir_simulate <- function(ptr, r_times, r_index, grouped) {
-  .Call(`_dust2_dust2_system_sir_simulate`, ptr, r_times, r_index, grouped)
+dust2_system_sir_simulate <- function(ptr, r_times, r_index, preserve_group_dimension) {
+  .Call(`_dust2_dust2_system_sir_simulate`, ptr, r_times, r_index, preserve_group_dimension)
 }
 
 dust2_unfilter_sir_alloc <- function(r_pars, r_time_start, r_time, r_dt, r_data, r_n_particles, r_n_groups, r_n_threads, r_index) {
@@ -108,32 +108,32 @@ dust2_filter_sir_alloc <- function(r_pars, r_time_start, r_time, r_dt, r_data, r
   .Call(`_dust2_dust2_filter_sir_alloc`, r_pars, r_time_start, r_time, r_dt, r_data, r_n_particles, r_n_groups, r_n_threads, r_index, r_seed)
 }
 
-dust2_system_sir_compare_data <- function(ptr, r_data, grouped) {
-  .Call(`_dust2_dust2_system_sir_compare_data`, ptr, r_data, grouped)
+dust2_system_sir_compare_data <- function(ptr, r_data, preserve_group_dimension) {
+  .Call(`_dust2_dust2_system_sir_compare_data`, ptr, r_data, preserve_group_dimension)
 }
 
-dust2_unfilter_sir_update_pars <- function(ptr, r_pars, grouped) {
-  .Call(`_dust2_dust2_unfilter_sir_update_pars`, ptr, r_pars, grouped)
+dust2_unfilter_sir_update_pars <- function(ptr, r_pars) {
+  .Call(`_dust2_dust2_unfilter_sir_update_pars`, ptr, r_pars)
 }
 
-dust2_unfilter_sir_run <- function(ptr, r_initial, save_history, adjoint, grouped) {
-  .Call(`_dust2_dust2_unfilter_sir_run`, ptr, r_initial, save_history, adjoint, grouped)
+dust2_unfilter_sir_run <- function(ptr, r_initial, save_history, adjoint, preserve_group_dimension) {
+  .Call(`_dust2_dust2_unfilter_sir_run`, ptr, r_initial, save_history, adjoint, preserve_group_dimension)
 }
 
-dust2_unfilter_sir_last_history <- function(ptr, grouped) {
-  .Call(`_dust2_dust2_unfilter_sir_last_history`, ptr, grouped)
+dust2_unfilter_sir_last_history <- function(ptr, preserve_group_dimension) {
+  .Call(`_dust2_dust2_unfilter_sir_last_history`, ptr, preserve_group_dimension)
 }
 
-dust2_filter_sir_update_pars <- function(ptr, r_pars, grouped) {
-  .Call(`_dust2_dust2_filter_sir_update_pars`, ptr, r_pars, grouped)
+dust2_filter_sir_update_pars <- function(ptr, r_pars) {
+  .Call(`_dust2_dust2_filter_sir_update_pars`, ptr, r_pars)
 }
 
-dust2_filter_sir_run <- function(ptr, r_initial, save_history, grouped) {
-  .Call(`_dust2_dust2_filter_sir_run`, ptr, r_initial, save_history, grouped)
+dust2_filter_sir_run <- function(ptr, r_initial, save_history) {
+  .Call(`_dust2_dust2_filter_sir_run`, ptr, r_initial, save_history)
 }
 
-dust2_filter_sir_last_history <- function(ptr, grouped) {
-  .Call(`_dust2_dust2_filter_sir_last_history`, ptr, grouped)
+dust2_filter_sir_last_history <- function(ptr, preserve_group_dimension) {
+  .Call(`_dust2_dust2_filter_sir_last_history`, ptr, preserve_group_dimension)
 }
 
 dust2_filter_sir_rng_state <- function(ptr) {
@@ -160,8 +160,8 @@ dust2_system_sirode_run_to_time <- function(ptr, r_time) {
   .Call(`_dust2_dust2_system_sirode_run_to_time`, ptr, r_time)
 }
 
-dust2_system_sirode_state <- function(ptr, r_index_state, r_index_particle, r_index_group, grouped) {
-  .Call(`_dust2_dust2_system_sirode_state`, ptr, r_index_state, r_index_particle, r_index_group, grouped)
+dust2_system_sirode_state <- function(ptr, r_index_state, r_index_particle, r_index_group, preserve_group_dimension) {
+  .Call(`_dust2_dust2_system_sirode_state`, ptr, r_index_state, r_index_particle, r_index_group, preserve_group_dimension)
 }
 
 dust2_system_sirode_time <- function(ptr) {
@@ -172,8 +172,8 @@ dust2_system_sirode_set_state_initial <- function(ptr) {
   .Call(`_dust2_dust2_system_sirode_set_state_initial`, ptr)
 }
 
-dust2_system_sirode_set_state <- function(ptr, r_state, grouped) {
-  .Call(`_dust2_dust2_system_sirode_set_state`, ptr, r_state, grouped)
+dust2_system_sirode_set_state <- function(ptr, r_state) {
+  .Call(`_dust2_dust2_system_sirode_set_state`, ptr, r_state)
 }
 
 dust2_system_sirode_reorder <- function(ptr, r_index) {
@@ -192,12 +192,12 @@ dust2_system_sirode_set_time <- function(ptr, r_time) {
   .Call(`_dust2_dust2_system_sirode_set_time`, ptr, r_time)
 }
 
-dust2_system_sirode_update_pars <- function(ptr, pars, grouped) {
-  .Call(`_dust2_dust2_system_sirode_update_pars`, ptr, pars, grouped)
+dust2_system_sirode_update_pars <- function(ptr, pars) {
+  .Call(`_dust2_dust2_system_sirode_update_pars`, ptr, pars)
 }
 
-dust2_system_sirode_simulate <- function(ptr, r_times, r_index, grouped) {
-  .Call(`_dust2_dust2_system_sirode_simulate`, ptr, r_times, r_index, grouped)
+dust2_system_sirode_simulate <- function(ptr, r_times, r_index, preserve_group_dimension) {
+  .Call(`_dust2_dust2_system_sirode_simulate`, ptr, r_times, r_index, preserve_group_dimension)
 }
 
 test_resample_weight <- function(w, u) {
@@ -220,8 +220,8 @@ dust2_system_walk_run_to_time <- function(ptr, r_time) {
   .Call(`_dust2_dust2_system_walk_run_to_time`, ptr, r_time)
 }
 
-dust2_system_walk_state <- function(ptr, r_index_state, r_index_particle, r_index_group, grouped) {
-  .Call(`_dust2_dust2_system_walk_state`, ptr, r_index_state, r_index_particle, r_index_group, grouped)
+dust2_system_walk_state <- function(ptr, r_index_state, r_index_particle, r_index_group, preserve_group_dimension) {
+  .Call(`_dust2_dust2_system_walk_state`, ptr, r_index_state, r_index_particle, r_index_group, preserve_group_dimension)
 }
 
 dust2_system_walk_time <- function(ptr) {
@@ -232,8 +232,8 @@ dust2_system_walk_set_state_initial <- function(ptr) {
   .Call(`_dust2_dust2_system_walk_set_state_initial`, ptr)
 }
 
-dust2_system_walk_set_state <- function(ptr, r_state, grouped) {
-  .Call(`_dust2_dust2_system_walk_set_state`, ptr, r_state, grouped)
+dust2_system_walk_set_state <- function(ptr, r_state) {
+  .Call(`_dust2_dust2_system_walk_set_state`, ptr, r_state)
 }
 
 dust2_system_walk_reorder <- function(ptr, r_index) {
@@ -252,10 +252,10 @@ dust2_system_walk_set_time <- function(ptr, r_time) {
   .Call(`_dust2_dust2_system_walk_set_time`, ptr, r_time)
 }
 
-dust2_system_walk_update_pars <- function(ptr, pars, grouped) {
-  .Call(`_dust2_dust2_system_walk_update_pars`, ptr, pars, grouped)
+dust2_system_walk_update_pars <- function(ptr, pars) {
+  .Call(`_dust2_dust2_system_walk_update_pars`, ptr, pars)
 }
 
-dust2_system_walk_simulate <- function(ptr, r_times, r_index, grouped) {
-  .Call(`_dust2_dust2_system_walk_simulate`, ptr, r_times, r_index, grouped)
+dust2_system_walk_simulate <- function(ptr, r_times, r_index, preserve_group_dimension) {
+  .Call(`_dust2_dust2_system_walk_simulate`, ptr, r_times, r_index, preserve_group_dimension)
 }

--- a/R/cpp11.R
+++ b/R/cpp11.R
@@ -116,8 +116,8 @@ dust2_unfilter_sir_update_pars <- function(ptr, r_pars) {
   .Call(`_dust2_dust2_unfilter_sir_update_pars`, ptr, r_pars)
 }
 
-dust2_unfilter_sir_run <- function(ptr, r_initial, save_history, adjoint, preserve_group_dimension) {
-  .Call(`_dust2_dust2_unfilter_sir_run`, ptr, r_initial, save_history, adjoint, preserve_group_dimension)
+dust2_unfilter_sir_run <- function(ptr, r_initial, save_history, adjoint, preserve_particle_dimension, preserve_group_dimension) {
+  .Call(`_dust2_dust2_unfilter_sir_run`, ptr, r_initial, save_history, adjoint, preserve_particle_dimension, preserve_group_dimension)
 }
 
 dust2_unfilter_sir_last_history <- function(ptr, preserve_particle_dimension, preserve_group_dimension) {

--- a/R/cpp11.R
+++ b/R/cpp11.R
@@ -12,8 +12,8 @@ dust2_system_logistic_run_to_time <- function(ptr, r_time) {
   .Call(`_dust2_dust2_system_logistic_run_to_time`, ptr, r_time)
 }
 
-dust2_system_logistic_state <- function(ptr, r_index_state, r_index_particle, r_index_group, preserve_group_dimension) {
-  .Call(`_dust2_dust2_system_logistic_state`, ptr, r_index_state, r_index_particle, r_index_group, preserve_group_dimension)
+dust2_system_logistic_state <- function(ptr, r_index_state, r_index_particle, r_index_group, preserve_particle_dimension, preserve_group_dimension) {
+  .Call(`_dust2_dust2_system_logistic_state`, ptr, r_index_state, r_index_particle, r_index_group, preserve_particle_dimension, preserve_group_dimension)
 }
 
 dust2_system_logistic_time <- function(ptr) {
@@ -48,8 +48,8 @@ dust2_system_logistic_update_pars <- function(ptr, pars) {
   .Call(`_dust2_dust2_system_logistic_update_pars`, ptr, pars)
 }
 
-dust2_system_logistic_simulate <- function(ptr, r_times, r_index, preserve_group_dimension) {
-  .Call(`_dust2_dust2_system_logistic_simulate`, ptr, r_times, r_index, preserve_group_dimension)
+dust2_system_logistic_simulate <- function(ptr, r_times, r_index, preserve_particle_dimension, preserve_group_dimension) {
+  .Call(`_dust2_dust2_system_logistic_simulate`, ptr, r_times, r_index, preserve_particle_dimension, preserve_group_dimension)
 }
 
 dust2_system_sir_alloc <- function(r_pars, r_time, r_dt, r_n_particles, r_n_groups, r_seed, r_deterministic, r_n_threads) {
@@ -60,8 +60,8 @@ dust2_system_sir_run_to_time <- function(ptr, r_time) {
   .Call(`_dust2_dust2_system_sir_run_to_time`, ptr, r_time)
 }
 
-dust2_system_sir_state <- function(ptr, r_index_state, r_index_particle, r_index_group, preserve_group_dimension) {
-  .Call(`_dust2_dust2_system_sir_state`, ptr, r_index_state, r_index_particle, r_index_group, preserve_group_dimension)
+dust2_system_sir_state <- function(ptr, r_index_state, r_index_particle, r_index_group, preserve_particle_dimension, preserve_group_dimension) {
+  .Call(`_dust2_dust2_system_sir_state`, ptr, r_index_state, r_index_particle, r_index_group, preserve_particle_dimension, preserve_group_dimension)
 }
 
 dust2_system_sir_time <- function(ptr) {
@@ -96,8 +96,8 @@ dust2_system_sir_update_pars <- function(ptr, pars) {
   .Call(`_dust2_dust2_system_sir_update_pars`, ptr, pars)
 }
 
-dust2_system_sir_simulate <- function(ptr, r_times, r_index, preserve_group_dimension) {
-  .Call(`_dust2_dust2_system_sir_simulate`, ptr, r_times, r_index, preserve_group_dimension)
+dust2_system_sir_simulate <- function(ptr, r_times, r_index, preserve_particle_dimension, preserve_group_dimension) {
+  .Call(`_dust2_dust2_system_sir_simulate`, ptr, r_times, r_index, preserve_particle_dimension, preserve_group_dimension)
 }
 
 dust2_unfilter_sir_alloc <- function(r_pars, r_time_start, r_time, r_dt, r_data, r_n_particles, r_n_groups, r_n_threads, r_index) {
@@ -108,8 +108,8 @@ dust2_filter_sir_alloc <- function(r_pars, r_time_start, r_time, r_dt, r_data, r
   .Call(`_dust2_dust2_filter_sir_alloc`, r_pars, r_time_start, r_time, r_dt, r_data, r_n_particles, r_n_groups, r_n_threads, r_index, r_seed)
 }
 
-dust2_system_sir_compare_data <- function(ptr, r_data, preserve_group_dimension) {
-  .Call(`_dust2_dust2_system_sir_compare_data`, ptr, r_data, preserve_group_dimension)
+dust2_system_sir_compare_data <- function(ptr, r_data, preserve_particle_dimension, preserve_group_dimension) {
+  .Call(`_dust2_dust2_system_sir_compare_data`, ptr, r_data, preserve_particle_dimension, preserve_group_dimension)
 }
 
 dust2_unfilter_sir_update_pars <- function(ptr, r_pars) {
@@ -160,8 +160,8 @@ dust2_system_sirode_run_to_time <- function(ptr, r_time) {
   .Call(`_dust2_dust2_system_sirode_run_to_time`, ptr, r_time)
 }
 
-dust2_system_sirode_state <- function(ptr, r_index_state, r_index_particle, r_index_group, preserve_group_dimension) {
-  .Call(`_dust2_dust2_system_sirode_state`, ptr, r_index_state, r_index_particle, r_index_group, preserve_group_dimension)
+dust2_system_sirode_state <- function(ptr, r_index_state, r_index_particle, r_index_group, preserve_particle_dimension, preserve_group_dimension) {
+  .Call(`_dust2_dust2_system_sirode_state`, ptr, r_index_state, r_index_particle, r_index_group, preserve_particle_dimension, preserve_group_dimension)
 }
 
 dust2_system_sirode_time <- function(ptr) {
@@ -196,8 +196,8 @@ dust2_system_sirode_update_pars <- function(ptr, pars) {
   .Call(`_dust2_dust2_system_sirode_update_pars`, ptr, pars)
 }
 
-dust2_system_sirode_simulate <- function(ptr, r_times, r_index, preserve_group_dimension) {
-  .Call(`_dust2_dust2_system_sirode_simulate`, ptr, r_times, r_index, preserve_group_dimension)
+dust2_system_sirode_simulate <- function(ptr, r_times, r_index, preserve_particle_dimension, preserve_group_dimension) {
+  .Call(`_dust2_dust2_system_sirode_simulate`, ptr, r_times, r_index, preserve_particle_dimension, preserve_group_dimension)
 }
 
 test_resample_weight <- function(w, u) {
@@ -220,8 +220,8 @@ dust2_system_walk_run_to_time <- function(ptr, r_time) {
   .Call(`_dust2_dust2_system_walk_run_to_time`, ptr, r_time)
 }
 
-dust2_system_walk_state <- function(ptr, r_index_state, r_index_particle, r_index_group, preserve_group_dimension) {
-  .Call(`_dust2_dust2_system_walk_state`, ptr, r_index_state, r_index_particle, r_index_group, preserve_group_dimension)
+dust2_system_walk_state <- function(ptr, r_index_state, r_index_particle, r_index_group, preserve_particle_dimension, preserve_group_dimension) {
+  .Call(`_dust2_dust2_system_walk_state`, ptr, r_index_state, r_index_particle, r_index_group, preserve_particle_dimension, preserve_group_dimension)
 }
 
 dust2_system_walk_time <- function(ptr) {
@@ -256,6 +256,6 @@ dust2_system_walk_update_pars <- function(ptr, pars) {
   .Call(`_dust2_dust2_system_walk_update_pars`, ptr, pars)
 }
 
-dust2_system_walk_simulate <- function(ptr, r_times, r_index, preserve_group_dimension) {
-  .Call(`_dust2_dust2_system_walk_simulate`, ptr, r_times, r_index, preserve_group_dimension)
+dust2_system_walk_simulate <- function(ptr, r_times, r_index, preserve_particle_dimension, preserve_group_dimension) {
+  .Call(`_dust2_dust2_system_walk_simulate`, ptr, r_times, r_index, preserve_particle_dimension, preserve_group_dimension)
 }

--- a/R/cpp11.R
+++ b/R/cpp11.R
@@ -120,8 +120,8 @@ dust2_unfilter_sir_run <- function(ptr, r_initial, save_history, adjoint, preser
   .Call(`_dust2_dust2_unfilter_sir_run`, ptr, r_initial, save_history, adjoint, preserve_group_dimension)
 }
 
-dust2_unfilter_sir_last_history <- function(ptr, preserve_group_dimension) {
-  .Call(`_dust2_dust2_unfilter_sir_last_history`, ptr, preserve_group_dimension)
+dust2_unfilter_sir_last_history <- function(ptr, preserve_particle_dimension, preserve_group_dimension) {
+  .Call(`_dust2_dust2_unfilter_sir_last_history`, ptr, preserve_particle_dimension, preserve_group_dimension)
 }
 
 dust2_filter_sir_update_pars <- function(ptr, r_pars) {

--- a/R/cpp11.R
+++ b/R/cpp11.R
@@ -24,8 +24,8 @@ dust2_system_logistic_set_state_initial <- function(ptr) {
   .Call(`_dust2_dust2_system_logistic_set_state_initial`, ptr)
 }
 
-dust2_system_logistic_set_state <- function(ptr, r_state) {
-  .Call(`_dust2_dust2_system_logistic_set_state`, ptr, r_state)
+dust2_system_logistic_set_state <- function(ptr, r_state, preserve_group_dimension) {
+  .Call(`_dust2_dust2_system_logistic_set_state`, ptr, r_state, preserve_group_dimension)
 }
 
 dust2_system_logistic_reorder <- function(ptr, r_index) {
@@ -72,8 +72,8 @@ dust2_system_sir_set_state_initial <- function(ptr) {
   .Call(`_dust2_dust2_system_sir_set_state_initial`, ptr)
 }
 
-dust2_system_sir_set_state <- function(ptr, r_state) {
-  .Call(`_dust2_dust2_system_sir_set_state`, ptr, r_state)
+dust2_system_sir_set_state <- function(ptr, r_state, preserve_group_dimension) {
+  .Call(`_dust2_dust2_system_sir_set_state`, ptr, r_state, preserve_group_dimension)
 }
 
 dust2_system_sir_reorder <- function(ptr, r_index) {
@@ -128,8 +128,8 @@ dust2_filter_sir_update_pars <- function(ptr, r_pars) {
   .Call(`_dust2_dust2_filter_sir_update_pars`, ptr, r_pars)
 }
 
-dust2_filter_sir_run <- function(ptr, r_initial, save_history) {
-  .Call(`_dust2_dust2_filter_sir_run`, ptr, r_initial, save_history)
+dust2_filter_sir_run <- function(ptr, r_initial, save_history, preserve_group_dimension) {
+  .Call(`_dust2_dust2_filter_sir_run`, ptr, r_initial, save_history, preserve_group_dimension)
 }
 
 dust2_filter_sir_last_history <- function(ptr, preserve_group_dimension) {
@@ -172,8 +172,8 @@ dust2_system_sirode_set_state_initial <- function(ptr) {
   .Call(`_dust2_dust2_system_sirode_set_state_initial`, ptr)
 }
 
-dust2_system_sirode_set_state <- function(ptr, r_state) {
-  .Call(`_dust2_dust2_system_sirode_set_state`, ptr, r_state)
+dust2_system_sirode_set_state <- function(ptr, r_state, preserve_group_dimension) {
+  .Call(`_dust2_dust2_system_sirode_set_state`, ptr, r_state, preserve_group_dimension)
 }
 
 dust2_system_sirode_reorder <- function(ptr, r_index) {
@@ -232,8 +232,8 @@ dust2_system_walk_set_state_initial <- function(ptr) {
   .Call(`_dust2_dust2_system_walk_set_state_initial`, ptr)
 }
 
-dust2_system_walk_set_state <- function(ptr, r_state) {
-  .Call(`_dust2_dust2_system_walk_set_state`, ptr, r_state)
+dust2_system_walk_set_state <- function(ptr, r_state, preserve_group_dimension) {
+  .Call(`_dust2_dust2_system_walk_set_state`, ptr, r_state, preserve_group_dimension)
 }
 
 dust2_system_walk_reorder <- function(ptr, r_index) {

--- a/R/cpp11.R
+++ b/R/cpp11.R
@@ -144,8 +144,8 @@ dust2_filter_sir_set_rng_state <- function(ptr, r_rng_state) {
   .Call(`_dust2_dust2_filter_sir_set_rng_state`, ptr, r_rng_state)
 }
 
-dust2_unfilter_sir_last_gradient <- function(ptr, grouped) {
-  .Call(`_dust2_dust2_unfilter_sir_last_gradient`, ptr, grouped)
+dust2_unfilter_sir_last_gradient <- function(ptr, preserve_particle_dimension, preserve_group_dimension) {
+  .Call(`_dust2_dust2_unfilter_sir_last_gradient`, ptr, preserve_particle_dimension, preserve_group_dimension)
 }
 
 dust2_system_sirode_alloc <- function(r_pars, r_time, r_ode_control, r_n_particles, r_n_groups, r_seed, r_deterministic, r_n_threads) {

--- a/R/filter-support.R
+++ b/R/filter-support.R
@@ -49,11 +49,11 @@ check_time_sequence <- function(time_start, time, call = NULL) {
 }
 
 
-check_data <- function(data, n_time, n_groups, call = NULL) {
+check_data <- function(data, n_time, n_groups, preserve_group_dimension,
+                       call = NULL) {
   assert_list(data, call = call)
   assert_length(data, n_time, call = call)
-  grouped <- n_groups > 0
-  if (grouped) {
+  if (preserve_group_dimension) {
     len <- lengths(data)
     err <- len != n_groups
     if (any(err)) {
@@ -64,10 +64,15 @@ check_data <- function(data, n_time, n_groups, call = NULL) {
           detail[1:4],
           sprintf("...and %d other elements", sum(err) - 4))
       }
+      if (n_groups > 1) {
+        justification <- "'n_groups' is greater than one"
+      } else {
+        justification <- "preserve_group_dimension was TRUE"
+      }
       cli::cli_abort(
         c("Expected all elements of 'data' to have length {n_groups}",
           i = paste(
-            "You have a grouped system ('n_groups' is greater than zero)",
+            "You have a grouped system ({justification})",
             "so each element in data must be a list with data for each group",
             "in turn"),
           set_names(detail, "x")),

--- a/R/filter-support.R
+++ b/R/filter-support.R
@@ -9,6 +9,7 @@ check_generator_for_filter <- function(generator, what, call = NULL) {
   generator
 }
 
+
 check_dt <- function(dt, call = NULL) {
   assert_scalar_numeric(dt, call = call)
   if (dt <= 0) {
@@ -48,7 +49,7 @@ check_time_sequence <- function(time_start, time, call = NULL) {
         set_names(detail, "x")),
       arg = "time", call = call)
   }
-  stop("Fix return")
+  as.numeric(time)
 }
 
 
@@ -82,7 +83,7 @@ check_data <- function(data, n_time, n_groups, preserve_group_dimension,
         arg = "data", call = call)
     }
   } else {
-    data <- list(data)
+    data <- lapply(data, function(el) list(el))
   }
   data
 }

--- a/R/filter-support.R
+++ b/R/filter-support.R
@@ -71,7 +71,7 @@ check_data <- function(data, n_time, n_groups, preserve_group_dimension,
       if (n_groups > 1) {
         justification <- "'n_groups' is greater than one"
       } else {
-        justification <- "preserve_group_dimension was TRUE"
+        justification <- "'preserve_group_dimension' was TRUE"
       }
       cli::cli_abort(
         c("Expected all elements of 'data' to have length {n_groups}",

--- a/R/filter-support.R
+++ b/R/filter-support.R
@@ -6,6 +6,7 @@ check_generator_for_filter <- function(generator, what, call = NULL) {
             "not have 'compare_data' support"),
       arg = "generator")
   }
+  generator
 }
 
 check_dt <- function(dt, call = NULL) {
@@ -20,6 +21,7 @@ check_dt <- function(dt, call = NULL) {
     cli::cli_abort("Expected 'dt' to be the inverse of an integer",
                    arg = "dt", call = call)
   }
+  dt
 }
 
 
@@ -46,6 +48,7 @@ check_time_sequence <- function(time_start, time, call = NULL) {
         set_names(detail, "x")),
       arg = "time", call = call)
   }
+  stop("Fix return")
 }
 
 
@@ -78,7 +81,10 @@ check_data <- function(data, n_time, n_groups, preserve_group_dimension,
           set_names(detail, "x")),
         arg = "data", call = call)
     }
+  } else {
+    data <- list(data)
   }
+  data
 }
 
 
@@ -90,4 +96,5 @@ check_index <- function(index, call = NULL) {
                      arg = "index", call = call)
     }
   }
+  index
 }

--- a/R/interface-filter.R
+++ b/R/interface-filter.R
@@ -37,7 +37,7 @@
 ##' @export
 dust_filter_create <- function(generator, time_start, time, data,
                                n_particles, n_groups = 1, dt = 1,
-                               index = NULL, n_threads = 1,
+                               index_state = NULL, n_threads = 1,
                                preserve_group_dimension = FALSE,
                                seed = NULL) {
   call <- environment()
@@ -54,7 +54,7 @@ dust_filter_create <- function(generator, time_start, time, data,
   dt <- check_dt(dt, call = call)
   data <- check_data(data, length(time), n_groups, preserve_group_dimension,
                      call = call)
-  index <- check_index(index, call = call)
+  index_state <- check_index(index_state, call = call)
   n_threads <- check_n_threads(n_threads, n_particles, n_groups)
 
   inputs <- list(time_start = time_start,
@@ -64,7 +64,7 @@ dust_filter_create <- function(generator, time_start, time, data,
                  n_particles = n_particles,
                  n_groups = n_groups,
                  n_threads = n_threads,
-                 index = index,
+                 index_state = index_state,
                  preserve_group_dimension = preserve_group_dimension)
 
   res <- list2env(
@@ -74,7 +74,7 @@ dust_filter_create <- function(generator, time_start, time, data,
          n_groups = as.integer(max(n_groups), 1),
          deterministic = FALSE,
          methods = generator$methods$filter,
-         index = index,
+         index_state = index_state,
          preserve_group_dimension = preserve_group_dimension),
     parent = emptyenv())
   class(res) <- "dust_filter"
@@ -98,7 +98,7 @@ dust_filter_create <- function(generator, time_start, time, data,
 dust_filter_copy <- function(filter, seed = NULL) {
   dst <- new.env(parent = emptyenv())
   nms <- c("inputs", "n_particles", "n_groups", "deterministic", "methods",
-           "index", "preserve_group_dimension")
+           "index_state", "preserve_group_dimension")
   for (nm in nms) {
     dst[[nm]] <- filter[[nm]]
   }
@@ -120,7 +120,7 @@ filter_create <- function(filter, pars) {
                          inputs$n_particles,
                          inputs$n_groups,
                          inputs$n_threads,
-                         inputs$index,
+                         inputs$index_state,
                          filter$initial_rng_state),
     filter)
   filter$initial_rng_state <- NULL
@@ -145,7 +145,7 @@ filter_create <- function(filter, pars) {
 ##'   should be saved while the simulation runs; this has a small
 ##'   overhead in runtime and in memory.  History (particle
 ##'   trajectories) will be saved at each time in the filter.  If the
-##'   filter was constructed using a non-`NULL` `index` parameter,
+##'   filter was constructed using a non-`NULL` `index_state` parameter,
 ##'   the history is restricted to these states.
 ##'
 ##' @return A vector of likelihood values, with as many elements as

--- a/R/interface-filter.R
+++ b/R/interface-filter.R
@@ -40,6 +40,11 @@ dust_filter_create <- function(generator, time_start, time, data,
                                index = NULL, n_threads = 1,
                                preserve_group_dimension = FALSE,
                                seed = NULL) {
+  call <- environment()
+  check_generator_for_filter(generator, "filter", call = call)
+  assert_scalar_size(n_particles, allow_zero = FALSE, call = call)
+  assert_scalar_size(n_groups, allow_zero = FALSE, call = call)
+  n_threads <- check_n_threads(n_threads, n_particles, n_groups)
   check_time_sequence(time_start, time, call = call)
   check_dt(dt, call = call)
   check_data(data, length(time), n_groups, preserve_group_dimension,

--- a/R/interface-unfilter.R
+++ b/R/interface-unfilter.R
@@ -167,6 +167,7 @@ dust_unfilter_last_gradient <- function(unfilter) {
       i = "Unfilter has not yet been run"))
   }
   unfilter$methods$last_gradient(unfilter$ptr,
+                                 unfilter$preserve_particle_dimension,
                                  unfilter$preserve_group_dimension)
 }
 

--- a/R/interface-unfilter.R
+++ b/R/interface-unfilter.R
@@ -25,14 +25,17 @@ dust_unfilter_create <- function(generator, time_start, time, data,
   check_generator_for_filter(generator, "unfilter", call = call)
   assert_scalar_size(n_particles, allow_zero = FALSE, call = call)
   assert_scalar_size(n_groups, allow_zero = FALSE, call = call)
-  n_threads <- check_n_threads(n_threads, n_particles, n_groups)
-  check_time_sequence(time_start, time, call = call)
-  check_dt(dt, call = call)
   assert_scalar_logical(preserve_particle_dimension, call = call)
   assert_scalar_logical(preserve_group_dimension, call = call)
+  preserve_particle_dimension <- preserve_particle_dimension || n_particles > 1
+  preserve_group_dimension <- preserve_group_dimension || n_groups > 1
+
+  time <- check_time_sequence(time_start, time, call = call)
+  dt <- check_dt(dt, call = call)
   data <- check_data(data, length(time), n_groups, preserve_group_dimension,
                      call = call)
-  check_index(index, call = call)
+  index <- check_index(index, call = call)
+  n_threads <- check_n_threads(n_threads, n_particles, n_groups)
 
   inputs <- list(time_start = time_start,
                  time = time,
@@ -99,7 +102,7 @@ unfilter_create <- function(unfilter, pars) {
 dust_unfilter_run <- function(unfilter, pars, initial = NULL,
                               save_history = FALSE, adjoint = FALSE) {
   check_is_dust_unfilter(unfilter)
-  if (!iis.null(pars)) {
+  if (!is.null(pars)) {
     pars <- check_pars(pars, unfilter$n_groups,
                        unfilter$preserve_group_dimension)
   }
@@ -110,8 +113,7 @@ dust_unfilter_run <- function(unfilter, pars, initial = NULL,
     }
     unfilter_create(unfilter, pars)
   } else if (!is.null(pars)) {
-    unfilter$methods$update_pars(unfilter$ptr, pars,
-                                 unfilter$preserve_group_dimension)
+    unfilter$methods$update_pars(unfilter$ptr, pars)
   }
   unfilter$methods$run(unfilter$ptr, initial, save_history, adjoint,
                        unfilter$preserve_group_dimension)

--- a/R/interface-unfilter.R
+++ b/R/interface-unfilter.R
@@ -5,6 +5,7 @@
 ##'
 ##' @title Create an unfilter
 ##'
+##' @inheritParams dust_system_create
 ##' @inheritParams dust_filter_create
 ##'
 ##' @param n_particles The number of particles to run.  Typically this
@@ -18,7 +19,7 @@
 ##' @export
 dust_unfilter_create <- function(generator, time_start, time, data,
                                  n_particles = 1, n_groups = 1,
-                                 dt = 1, n_threads = 1, index = NULL,
+                                 dt = 1, n_threads = 1, index_state = NULL,
                                  preserve_particle_dimension = FALSE,
                                  preserve_group_dimension = FALSE) {
   call <- environment()
@@ -34,7 +35,7 @@ dust_unfilter_create <- function(generator, time_start, time, data,
   dt <- check_dt(dt, call = call)
   data <- check_data(data, length(time), n_groups, preserve_group_dimension,
                      call = call)
-  index <- check_index(index, call = call)
+  index_state <- check_index(index_state, call = call)
   n_threads <- check_n_threads(n_threads, n_particles, n_groups)
 
   inputs <- list(time_start = time_start,
@@ -44,7 +45,7 @@ dust_unfilter_create <- function(generator, time_start, time, data,
                  n_particles = n_particles,
                  n_groups = n_groups,
                  n_threads = n_threads,
-                 index = index,
+                 index_state = index_state,
                  preserve_particle_dimension = preserve_particle_dimension,
                  preserve_group_dimension = preserve_group_dimension)
 
@@ -54,7 +55,7 @@ dust_unfilter_create <- function(generator, time_start, time, data,
          n_groups = as.integer(n_groups),
          deterministic = TRUE,
          methods = generator$methods$unfilter,
-         index = index,
+         index_state = index_state,
          preserve_particle_dimension = preserve_particle_dimension,
          preserve_group_dimension = preserve_group_dimension),
     parent = emptyenv())
@@ -74,7 +75,7 @@ unfilter_create <- function(unfilter, pars) {
                            inputs$n_particles,
                            inputs$n_groups,
                            inputs$n_threads,
-                           inputs$index),
+                           inputs$index_state),
     unfilter)
 }
 

--- a/R/interface-unfilter.R
+++ b/R/interface-unfilter.R
@@ -116,6 +116,7 @@ dust_unfilter_run <- function(unfilter, pars, initial = NULL,
     unfilter$methods$update_pars(unfilter$ptr, pars)
   }
   unfilter$methods$run(unfilter$ptr, initial, save_history, adjoint,
+                       unfilter$preserve_particle_dimension,
                        unfilter$preserve_group_dimension)
 }
 

--- a/R/interface-unfilter.R
+++ b/R/interface-unfilter.R
@@ -23,8 +23,8 @@ dust_unfilter_create <- function(generator, time_start, time, data,
                                  preserve_group_dimension = FALSE) {
   call <- environment()
   check_generator_for_filter(generator, "unfilter", call = call)
-  assert_scalar_size(n_particles, call = call)
-  assert_scalar_size(n_groups, call = call)
+  assert_scalar_size(n_particles, allow_zero = FALSE, call = call)
+  assert_scalar_size(n_groups, allow_zero = FALSE, call = call)
   n_threads <- check_n_threads(n_threads, n_particles, n_groups)
   check_time_sequence(time_start, time, call = call)
   check_dt(dt, call = call)

--- a/R/interface-unfilter.R
+++ b/R/interface-unfilter.R
@@ -28,10 +28,10 @@ dust_unfilter_create <- function(generator, time_start, time, data,
   n_threads <- check_n_threads(n_threads, n_particles, n_groups)
   check_time_sequence(time_start, time, call = call)
   check_dt(dt, call = call)
-  assert_scalar_character(preserve_particle_dimension, call = call)
-  assert_scalar_character(preserve_group_dimension, call = call)
-  check_data(data, length(time), n_groups, preserve_group_dimension,
-             call = call)
+  assert_scalar_logical(preserve_particle_dimension, call = call)
+  assert_scalar_logical(preserve_group_dimension, call = call)
+  data <- check_data(data, length(time), n_groups, preserve_group_dimension,
+                     call = call)
   check_index(index, call = call)
 
   inputs <- list(time_start = time_start,
@@ -99,6 +99,10 @@ unfilter_create <- function(unfilter, pars) {
 dust_unfilter_run <- function(unfilter, pars, initial = NULL,
                               save_history = FALSE, adjoint = FALSE) {
   check_is_dust_unfilter(unfilter)
+  if (!iis.null(pars)) {
+    pars <- check_pars(pars, unfilter$n_groups,
+                       unfilter$preserve_group_dimension)
+  }
   if (is.null(unfilter$ptr)) {
     if (is.null(pars)) {
       cli::cli_abort("'pars' cannot be NULL, as unfilter is not initialised",

--- a/R/interface-unfilter.R
+++ b/R/interface-unfilter.R
@@ -139,6 +139,7 @@ dust_unfilter_last_history <- function(unfilter) {
       i = "Unfilter has not yet been run"))
   }
   unfilter$methods$last_history(unfilter$ptr,
+                                unfilter$preserve_particle_dimension,
                                 unfilter$preserve_group_dimension)
 }
 

--- a/R/interface.R
+++ b/R/interface.R
@@ -222,7 +222,6 @@ dust_system_create <- function(generator, pars, n_particles, n_groups = 1,
 dust_system_state <- function(sys, index_state = NULL, index_particle = NULL,
                               index_group = NULL) {
   check_is_dust_system(sys)
-  ## TODO: preserve_particle_dimension
   sys$methods$state(sys$ptr, index_state, index_particle, index_group,
                     sys$preserve_particle_dimension,
                     sys$preserve_group_dimension)
@@ -474,7 +473,6 @@ dust_system_internals <- function(sys, include_coefficients = FALSE) {
     ## No internals for now, perhaps never?
     return(NULL)
   }
-  ## TODO: cope with dimension preservation
   dat <- sys$methods$internals(sys$ptr, include_coefficients)
   ret <- data_frame(
     particle = seq_along(dat),

--- a/R/interface.R
+++ b/R/interface.R
@@ -147,9 +147,9 @@ dust_system_create <- function(generator, pars, n_particles, n_groups = 1,
   call <- environment()
   check_is_dust_system_generator(generator, substitute(generator))
   ## check_time(time, call = call)
-  assert_scalar_size(n_particles, call = call)
-  assert_scalar_size(n_groups, call = call)
-  assert_scalar_size(n_threads, call = call)
+  assert_scalar_size(n_particles, allow_zero = FALSE, call = call)
+  assert_scalar_size(n_groups, allow_zero = FALSE, call = call)
+  assert_scalar_size(n_threads, allow_zero = FALSE, call = call)
   assert_scalar_logical(preserve_particle_dimension, call = call)
   assert_scalar_logical(preserve_group_dimension, call = call)
 

--- a/R/interface.R
+++ b/R/interface.R
@@ -163,7 +163,8 @@ dust_system_create <- function(generator, pars, n_particles, n_groups = 1,
     }
     dt <- check_dt(dt %||% 1, call = call)
     res <- generator$methods$alloc(pars, time, dt, n_particles,
-                                   n_groups, seed, deterministic)
+                                   n_groups, seed, deterministic,
+                                   n_threads)
   } else {
     if (!is.null(dt)) {
       cli::cli_abort("Can't use 'dt' with continuous-time systems")

--- a/inst/include/dust2/r/continuous/system.hpp
+++ b/inst/include/dust2/r/continuous/system.hpp
@@ -45,20 +45,10 @@ SEXP dust2_continuous_alloc(cpp11::list r_pars,
   // Later, we'll export a bit more back from the system (in particular
   // systems need to provide information about how they organise
   // variables.
-  const auto grouped = n_groups > 0;
-  cpp11::sexp r_group_names = R_NilValue;
-  if (grouped) {
-    r_group_names = r_pars.attr("names");
-  }
   cpp11::sexp r_n_state = cpp11::as_sexp(obj->n_state());
-  cpp11::sexp r_grouped = cpp11::as_sexp(grouped);
 
   using namespace cpp11::literals;
-  return cpp11::writable::list{"ptr"_nm = ptr,
-      "n_state"_nm = r_n_state,
-      "grouped"_nm = r_grouped,
-      "group_names"_nm = r_group_names
-      };
+  return cpp11::writable::list{"ptr"_nm = ptr, "n_state"_nm = r_n_state};
 }
 
 template <typename real_type>

--- a/inst/include/dust2/r/discrete/filter.hpp
+++ b/inst/include/dust2/r/discrete/filter.hpp
@@ -62,13 +62,12 @@ cpp11::sexp dust2_discrete_filter_alloc(cpp11::list r_pars,
   // means that we can change the number of groups without affecting
   // the results, though we can't change the number of particles as
   // easily.
-  const auto n_groups_effective = grouped ? n_groups : 1;
-  const auto n_streams = n_groups_effective * (n_particles + 1);
+  const auto n_streams = n_groups * (n_particles + 1);
   const auto rng_state = mcstate::random::prng<rng_state_type>(n_streams, seed, deterministic).export_state();
   const auto rng_len = rng_state_type::size();
   rng_seed_type seed_filter;
   rng_seed_type seed_system;
-  for (size_t i = 0; i < n_groups_effective; ++i) {
+  for (size_t i = 0; i < n_groups; ++i) {
     const auto it = rng_state.begin() + i * rng_len * (n_particles + 1);
     seed_filter.insert(seed_filter.end(),
                        it, it + rng_len);
@@ -85,18 +84,9 @@ cpp11::sexp dust2_discrete_filter_alloc(cpp11::list r_pars,
   cpp11::external_pointer<filter<dust_discrete<T>>> ptr(obj, true, false);
 
   cpp11::sexp r_n_state = cpp11::as_sexp(obj->sys.n_state());
-  cpp11::sexp r_group_names = R_NilValue;
-  if (grouped) {
-    r_group_names = r_pars.attr("names");
-  }
-  cpp11::sexp r_grouped = cpp11::as_sexp(grouped);
 
   using namespace cpp11::literals;
-  return cpp11::writable::list{"ptr"_nm = ptr,
-      "n_state"_nm = r_n_state,
-      "grouped"_nm = r_grouped,
-      "group_names"_nm = r_group_names
-      };
+  return cpp11::writable::list{"ptr"_nm = ptr, "n_state"_nm = r_n_state};
 }
 
 }

--- a/inst/include/dust2/r/discrete/filter.hpp
+++ b/inst/include/dust2/r/discrete/filter.hpp
@@ -26,7 +26,6 @@ cpp11::sexp dust2_discrete_filter_alloc(cpp11::list r_pars,
   const auto n_particles = to_size(r_n_particles, "n_particles");
   const auto n_groups = to_size(r_n_groups, "n_groups");
   const auto n_threads = to_size(r_n_threads, "n_threads");
-  const auto grouped = n_groups > 0;
   const auto time_start = check_time(r_time_start, "time_start");
   const auto time = check_time_sequence(time_start, r_time, true, "time");
   const auto dt = check_dt(r_dt);

--- a/inst/include/dust2/r/discrete/filter.hpp
+++ b/inst/include/dust2/r/discrete/filter.hpp
@@ -18,7 +18,7 @@ cpp11::sexp dust2_discrete_filter_alloc(cpp11::list r_pars,
                                         cpp11::sexp r_n_particles,
                                         cpp11::sexp r_n_groups,
 					cpp11::sexp r_n_threads,
-                                        cpp11::sexp r_index,
+                                        cpp11::sexp r_index_state,
                                         cpp11::sexp r_seed) {
   using rng_state_type = typename T::rng_state_type;
   using rng_seed_type = std::vector<typename rng_state_type::int_type>;
@@ -78,9 +78,10 @@ cpp11::sexp dust2_discrete_filter_alloc(cpp11::list r_pars,
   const auto system = dust2::dust_discrete<T>(shared, internal, time_start, dt, n_particles,
                                               seed_system, deterministic, n_threads);
 
-  const auto index = check_index(r_index, system.n_state(), "index");
+  const auto index_state = check_index(r_index_state, system.n_state(),
+                                       "index_state");
 
-  auto obj = new filter<dust_discrete<T>>(system, time_start, time, data, index, seed_filter);
+  auto obj = new filter<dust_discrete<T>>(system, time_start, time, data, index_state, seed_filter);
   cpp11::external_pointer<filter<dust_discrete<T>>> ptr(obj, true, false);
 
   cpp11::sexp r_n_state = cpp11::as_sexp(obj->sys.n_state());

--- a/inst/include/dust2/r/discrete/system.hpp
+++ b/inst/include/dust2/r/discrete/system.hpp
@@ -20,16 +20,24 @@ SEXP dust2_discrete_alloc(cpp11::list r_pars,
 			  cpp11::sexp r_n_threads) {
   using rng_state_type = typename T::rng_state_type;
 
+  // These duplicate checks that happen on the R side and can be
+  // relaxed over time.  However, they're fast and pretty harmless -
+  // most will just arrange for the conversion from SEXP type to the
+  // expected underlying C type (with no cost) and then we cast out
+  // into the C++ type that we need here (e.g., SEXP -> int -> size_t)
+  //
+  // The only one of these that might throw is the the build_shared
+  // call, which might fail because of validation checks that the user
+  // has getting parameters from the SEXP, or because it creates a
+  // system with an unexpected size.  These will result in a fairly
+  // ugly error compared with most.
   const auto time = check_time(r_time, "time");
   const auto dt = check_dt(r_dt);
-
   const auto n_particles = to_size(r_n_particles, "n_particles");
   const auto n_groups = to_size(r_n_groups, "n_groups");
-
   const auto shared = build_shared<T>(r_pars, n_groups);
   // Later, we need one of these per thread
   const auto internal = build_internal<T>(shared);
-
   auto seed = mcstate::random::r::as_rng_seed<rng_state_type>(r_seed);
   auto deterministic = to_bool(r_deterministic, "deterministic");
 
@@ -39,9 +47,8 @@ SEXP dust2_discrete_alloc(cpp11::list r_pars,
                                   seed, deterministic, n_threads);
   cpp11::external_pointer<dust_discrete<T>> ptr(obj, true, false);
 
-  // Later, we'll export a bit more back from the system (in particular
-  // systems need to provide information about how they organise
-  // variables, ode systems report computed control, etc.
+  // Later, we'll export information about how systems structure
+  // variables (mrc-5422, with support needed from mcstate2)
   cpp11::sexp r_n_state = cpp11::as_sexp(obj->n_state());
 
   using namespace cpp11::literals;

--- a/inst/include/dust2/r/discrete/system.hpp
+++ b/inst/include/dust2/r/discrete/system.hpp
@@ -42,20 +42,10 @@ SEXP dust2_discrete_alloc(cpp11::list r_pars,
   // Later, we'll export a bit more back from the system (in particular
   // systems need to provide information about how they organise
   // variables, ode systems report computed control, etc.
-  const auto grouped = n_groups > 0;
-  cpp11::sexp r_group_names = R_NilValue;
-  if (grouped) {
-    r_group_names = r_pars.attr("names");
-  }
   cpp11::sexp r_n_state = cpp11::as_sexp(obj->n_state());
-  cpp11::sexp r_grouped = cpp11::as_sexp(grouped);
 
   using namespace cpp11::literals;
-  return cpp11::writable::list{"ptr"_nm = ptr,
-      "n_state"_nm = r_n_state,
-      "grouped"_nm = r_grouped,
-      "group_names"_nm = r_group_names
-      };
+  return cpp11::writable::list{"ptr"_nm = ptr, "n_state"_nm = r_n_state};
 }
 
 }

--- a/inst/include/dust2/r/discrete/unfilter.hpp
+++ b/inst/include/dust2/r/discrete/unfilter.hpp
@@ -52,18 +52,9 @@ cpp11::sexp dust2_discrete_unfilter_alloc(cpp11::list r_pars,
   cpp11::external_pointer<unfilter<dust_discrete<T>>> ptr(obj, true, false);
 
   cpp11::sexp r_n_state = cpp11::as_sexp(obj->sys.n_state());
-  cpp11::sexp r_group_names = R_NilValue;
-  if (grouped) {
-    r_group_names = r_pars.attr("names");
-  }
-  cpp11::sexp r_grouped = cpp11::as_sexp(grouped);
 
   using namespace cpp11::literals;
-  return cpp11::writable::list{"ptr"_nm = ptr,
-      "n_state"_nm = r_n_state,
-      "grouped"_nm = r_grouped,
-      "group_names"_nm = r_group_names
-      };
+  return cpp11::writable::list{"ptr"_nm = ptr, "n_state"_nm = r_n_state};
 }
 
 }

--- a/inst/include/dust2/r/discrete/unfilter.hpp
+++ b/inst/include/dust2/r/discrete/unfilter.hpp
@@ -25,7 +25,6 @@ cpp11::sexp dust2_discrete_unfilter_alloc(cpp11::list r_pars,
   const auto n_particles = to_size(r_n_particles, "n_particles");
   const auto n_groups = to_size(r_n_groups, "n_groups");
   const auto n_threads = to_size(r_n_threads, "n_threads");
-  const auto grouped = n_groups > 0;
   const auto time_start = check_time(r_time_start, "time_start");
   const auto time = check_time_sequence(time_start, r_time, true, "time");
   const auto dt = check_dt(r_dt);

--- a/inst/include/dust2/r/discrete/unfilter.hpp
+++ b/inst/include/dust2/r/discrete/unfilter.hpp
@@ -19,7 +19,7 @@ cpp11::sexp dust2_discrete_unfilter_alloc(cpp11::list r_pars,
                                           cpp11::sexp r_n_particles,
                                           cpp11::sexp r_n_groups,
 					  cpp11::sexp r_n_threads,
-                                          cpp11::sexp r_index) {
+                                          cpp11::sexp r_index_state) {
   using rng_state_type = typename T::rng_state_type;
 
   const auto n_particles = to_size(r_n_particles, "n_particles");
@@ -46,9 +46,11 @@ cpp11::sexp dust2_discrete_unfilter_alloc(cpp11::list r_pars,
   // going to feel weirder overall.
   const auto system = dust2::dust_discrete<T>(shared, internal, time_start, dt, n_particles,
                                               seed, deterministic, n_threads);
-  const auto index = check_index(r_index, system.n_state(), "index");
+  const auto index_state = check_index(r_index_state, system.n_state(),
+                                       "index_state");
 
-  auto obj = new unfilter<dust_discrete<T>>(system, time_start, time, data, index);
+  auto obj = new unfilter<dust_discrete<T>>(system, time_start, time, data,
+                                            index_state);
   cpp11::external_pointer<unfilter<dust_discrete<T>>> ptr(obj, true, false);
 
   cpp11::sexp r_n_state = cpp11::as_sexp(obj->sys.n_state());

--- a/inst/include/dust2/r/filter.hpp
+++ b/inst/include/dust2/r/filter.hpp
@@ -18,11 +18,12 @@ cpp11::sexp dust2_filter_update_pars(cpp11::sexp ptr,
 
 template <typename T>
 cpp11::sexp dust2_filter_run(cpp11::sexp ptr, cpp11::sexp r_initial,
-                             bool save_history) {
+                             bool save_history,
+                             bool preserve_group_dimension) {
   auto *obj =
     cpp11::as_cpp<cpp11::external_pointer<filter<T>>>(ptr).get();
   if (r_initial != R_NilValue) {
-    set_state(obj->sys, r_initial);
+    set_state(obj->sys, r_initial, preserve_group_dimension);
   }
   obj->run(r_initial == R_NilValue, save_history);
 

--- a/inst/include/dust2/r/filter.hpp
+++ b/inst/include/dust2/r/filter.hpp
@@ -9,21 +9,20 @@ namespace r {
 
 template <typename T>
 cpp11::sexp dust2_filter_update_pars(cpp11::sexp ptr,
-                                     cpp11::list r_pars,
-                                     bool grouped) {
+                                     cpp11::list r_pars) {
   auto *obj =
     cpp11::as_cpp<cpp11::external_pointer<filter<T>>>(ptr).get();
-  update_pars(obj->sys, cpp11::as_cpp<cpp11::list>(r_pars), grouped);
+  update_pars(obj->sys, r_pars);
   return R_NilValue;
 }
 
 template <typename T>
 cpp11::sexp dust2_filter_run(cpp11::sexp ptr, cpp11::sexp r_initial,
-                             bool save_history, bool grouped) {
+                             bool save_history) {
   auto *obj =
     cpp11::as_cpp<cpp11::external_pointer<filter<T>>>(ptr).get();
   if (r_initial != R_NilValue) {
-    set_state(obj->sys, r_initial, grouped);
+    set_state(obj->sys, r_initial);
   }
   obj->run(r_initial == R_NilValue, save_history);
 
@@ -34,7 +33,8 @@ cpp11::sexp dust2_filter_run(cpp11::sexp ptr, cpp11::sexp r_initial,
 
 // Can collapse with above
 template <typename T>
-cpp11::sexp dust2_filter_last_history(cpp11::sexp ptr, bool grouped) {
+cpp11::sexp dust2_filter_last_history(cpp11::sexp ptr,
+				      bool preserve_group_dimension) {
   auto *obj =
     cpp11::as_cpp<cpp11::external_pointer<filter<T>>>(ptr).get();
   if (!obj->last_history_is_current()) {
@@ -54,7 +54,7 @@ cpp11::sexp dust2_filter_last_history(cpp11::sexp ptr, bool grouped) {
   const auto len = n_state * n_particles * n_groups * n_times;
   cpp11::sexp ret = cpp11::writable::doubles(len);
   history.export_state(REAL(ret), reorder);
-  if (grouped) {
+  if (preserve_group_dimension) {
     set_array_dims(ret, {n_state, n_particles, n_groups, n_times});
   } else {
     set_array_dims(ret, {n_state, n_particles * n_groups, n_times});

--- a/inst/include/dust2/r/filter.hpp
+++ b/inst/include/dust2/r/filter.hpp
@@ -18,8 +18,7 @@ cpp11::sexp dust2_filter_update_pars(cpp11::sexp ptr,
 
 template <typename T>
 cpp11::sexp dust2_filter_run(cpp11::sexp ptr, cpp11::sexp r_initial,
-                             bool save_history,
-                             bool preserve_group_dimension) {
+                             bool save_history, bool preserve_group_dimension) {
   auto *obj =
     cpp11::as_cpp<cpp11::external_pointer<filter<T>>>(ptr).get();
   if (r_initial != R_NilValue) {

--- a/inst/include/dust2/r/helpers.hpp
+++ b/inst/include/dust2/r/helpers.hpp
@@ -179,6 +179,9 @@ inline std::vector<size_t> check_index(cpp11::sexp r_index, size_t max,
 // The initializer_list is a type-safe variadic-like approach.
 inline void set_array_dims(cpp11::sexp data,
                            std::initializer_list<size_t> dims) {
+  if (dims.size() < 2) {
+    return;
+  }
   cpp11::writable::integers r_dim(dims.size());
   auto dim_i = dims.begin();
   for (size_t i = 0; i < dims.size(); ++i, ++dim_i) {

--- a/inst/include/dust2/r/system.hpp
+++ b/inst/include/dust2/r/system.hpp
@@ -32,7 +32,8 @@ SEXP dust2_system_run_to_time(cpp11::sexp ptr, cpp11::sexp r_time) {
 template <typename T>
 SEXP dust2_system_state(cpp11::sexp ptr, cpp11::sexp r_index_state,
 			cpp11::sexp r_index_particle,
-			cpp11::sexp r_index_group, bool grouped) {
+			cpp11::sexp r_index_group,
+			bool preserve_group_dimension) {
   auto *obj = cpp11::as_cpp<cpp11::external_pointer<T>>(ptr).get();
   check_errors(obj, "get state from");
   const auto n_state = obj->n_state();
@@ -45,13 +46,13 @@ SEXP dust2_system_state(cpp11::sexp ptr, cpp11::sexp r_index_state,
     r_index_particle == R_NilValue &&
     r_index_group == R_NilValue;
   if (everything) {
-    if (grouped) {
+    if (preserve_group_dimension) {
       ret = export_array_n(iter_src, {n_state, n_particles, n_groups});
     } else {
       ret = export_array_n(iter_src, {n_state, n_particles * n_groups});
     }
   } else {
-    if (!grouped && r_index_group != R_NilValue) {
+    if (!preserve_group_dimension && r_index_group != R_NilValue) {
       cpp11::stop("Can't provide 'index_group' for a non-grouped system");
     }
     const auto index_state =
@@ -70,7 +71,7 @@ SEXP dust2_system_state(cpp11::sexp ptr, cpp11::sexp r_index_state,
       index_group.empty() ? n_groups : index_group.size();
     cpp11::writable::doubles d(n_state_save * n_particle_save * n_group_save);
     double* it_dst = REAL(d);
-    if (grouped) {
+    if (preserve_group_dimension) {
       set_array_dims(d, {n_state_save, n_particle_save, n_group_save});
     } else {
       set_array_dims(d, {n_state_save, n_particle_save * n_group_save});
@@ -124,9 +125,9 @@ SEXP dust2_system_set_state_initial(cpp11::sexp ptr) {
 }
 
 template <typename T>
-SEXP dust2_system_set_state(cpp11::sexp ptr, cpp11::sexp r_state, bool grouped) {
+SEXP dust2_system_set_state(cpp11::sexp ptr, cpp11::sexp r_state) {
   auto *obj = cpp11::as_cpp<cpp11::external_pointer<T>>(ptr).get();
-  set_state(*obj, r_state, grouped);
+  set_state(*obj, r_state);
   return R_NilValue;
 }
 
@@ -183,10 +184,9 @@ SEXP dust2_system_set_time(cpp11::sexp ptr, cpp11::sexp r_time) {
 }
 
 template <typename T>
-SEXP dust2_system_update_pars(cpp11::sexp ptr, cpp11::list r_pars,
-                              bool grouped) {
+SEXP dust2_system_update_pars(cpp11::sexp ptr, cpp11::list r_pars) {
   auto *obj = cpp11::as_cpp<cpp11::external_pointer<T>>(ptr).get();
-  update_pars(*obj, r_pars, grouped);
+  update_pars(*obj, r_pars);
   return R_NilValue;
 }
 
@@ -195,7 +195,7 @@ SEXP dust2_system_update_pars(cpp11::sexp ptr, cpp11::list r_pars,
 template <typename T>
 SEXP dust2_system_compare_data(cpp11::sexp ptr,
                                cpp11::sexp r_data,
-                               bool grouped) {
+                               bool preserve_group_dimension) {
   using system_type = typename T::system_type;
   using data_type = typename T::data_type;
 
@@ -204,7 +204,8 @@ SEXP dust2_system_compare_data(cpp11::sexp ptr,
   const auto n_groups = obj->n_groups();
   std::vector<data_type> data;
   auto r_data_list = cpp11::as_cpp<cpp11::list>(r_data);
-  if (grouped) {
+  // TODO: shift into R
+  if (preserve_group_dimension) {
     check_length(r_data_list, n_groups, "data");
     for (size_t i = 0; i < n_groups; ++i) {
       auto r_data_list_i = cpp11::as_cpp<cpp11::list>(r_data_list[i]);
@@ -216,7 +217,7 @@ SEXP dust2_system_compare_data(cpp11::sexp ptr,
 
   cpp11::writable::doubles ret(obj->n_particles() * obj->n_groups());
   obj->compare_data(data.begin(), REAL(ret));
-  if (grouped) {
+  if (preserve_group_dimension) {
     set_array_dims(ret, {obj->n_particles(), obj->n_groups()});
   }
   return ret;
@@ -226,7 +227,7 @@ template <typename T>
 SEXP dust2_system_simulate(cpp11::sexp ptr,
                            cpp11::sexp r_times,
                            cpp11::sexp r_index,
-                           bool grouped) {
+                           bool preserve_group_dimension) {
   using real_type = typename T::real_type;
   auto *obj = cpp11::as_cpp<cpp11::external_pointer<T>>(ptr).get();
   check_errors(obj, "simulate");
@@ -255,7 +256,7 @@ SEXP dust2_system_simulate(cpp11::sexp ptr,
   const auto len = n_state_save * n_particles * n_groups * n_times;
   cpp11::sexp ret = cpp11::writable::doubles(len);
   h.export_state(REAL(ret), false);
-  if (grouped) {
+  if (preserve_group_dimension) {
     set_array_dims(ret, {n_state_save, n_particles, n_groups, n_times});
   } else {
     set_array_dims(ret, {n_state_save, n_particles * n_groups, n_times});

--- a/inst/include/dust2/r/system.hpp
+++ b/inst/include/dust2/r/system.hpp
@@ -125,9 +125,10 @@ SEXP dust2_system_set_state_initial(cpp11::sexp ptr) {
 }
 
 template <typename T>
-SEXP dust2_system_set_state(cpp11::sexp ptr, cpp11::sexp r_state) {
+SEXP dust2_system_set_state(cpp11::sexp ptr, cpp11::sexp r_state,
+                            bool preserve_group_dimension) {
   auto *obj = cpp11::as_cpp<cpp11::external_pointer<T>>(ptr).get();
-  set_state(*obj, r_state);
+  set_state(*obj, r_state, preserve_group_dimension);
   return R_NilValue;
 }
 

--- a/inst/include/dust2/r/unfilter.hpp
+++ b/inst/include/dust2/r/unfilter.hpp
@@ -23,7 +23,7 @@ cpp11::sexp dust2_unfilter_run(cpp11::sexp ptr, cpp11::sexp r_initial,
   auto *obj =
     cpp11::as_cpp<cpp11::external_pointer<unfilter<T>>>(ptr).get();
   if (r_initial != R_NilValue) {
-    set_state(obj->sys, r_initial);
+    set_state(obj->sys, r_initial, preserve_group_dimension);
   }
   const auto set_initial = r_initial == R_NilValue;
   if (adjoint) {

--- a/inst/include/dust2/r/unfilter.hpp
+++ b/inst/include/dust2/r/unfilter.hpp
@@ -19,6 +19,7 @@ cpp11::sexp dust2_unfilter_update_pars(cpp11::sexp ptr,
 template <typename T>
 cpp11::sexp dust2_unfilter_run(cpp11::sexp ptr, cpp11::sexp r_initial,
                                bool save_history, bool adjoint,
+                               bool preserve_particle_dimension,
 			       bool preserve_group_dimension) {
   auto *obj =
     cpp11::as_cpp<cpp11::external_pointer<unfilter<T>>>(ptr).get();
@@ -36,7 +37,7 @@ cpp11::sexp dust2_unfilter_run(cpp11::sexp ptr, cpp11::sexp r_initial,
   const auto n_particles = obj->sys.n_particles();
   cpp11::writable::doubles ret(n_groups * n_particles);
   obj->last_log_likelihood(REAL(ret));
-  if (preserve_group_dimension && n_particles > 1) { // TODO: particle too
+  if (preserve_group_dimension && preserve_particle_dimension) {
     set_array_dims(ret, {n_particles, n_groups});
   }
   return ret;

--- a/inst/include/dust2/r/unfilter.hpp
+++ b/inst/include/dust2/r/unfilter.hpp
@@ -44,6 +44,7 @@ cpp11::sexp dust2_unfilter_run(cpp11::sexp ptr, cpp11::sexp r_initial,
 
 template <typename T>
 cpp11::sexp dust2_unfilter_last_history(cpp11::sexp ptr,
+                                        bool preserve_particle_dimension,
 					bool preserve_group_dimension) {
   auto *obj =
     cpp11::as_cpp<cpp11::external_pointer<unfilter<T>>>(ptr).get();
@@ -63,10 +64,12 @@ cpp11::sexp dust2_unfilter_last_history(cpp11::sexp ptr,
   const auto len = n_state * n_particles * n_groups * n_times;
   cpp11::sexp ret = cpp11::writable::doubles(len);
   history.export_state(REAL(ret), reorder);
-  if (preserve_group_dimension) {
+  if (preserve_group_dimension && preserve_particle_dimension) {
     set_array_dims(ret, {n_state, n_particles, n_groups, n_times});
-  } else {
+  } else if (preserve_group_dimension || preserve_particle_dimension) {
     set_array_dims(ret, {n_state, n_particles * n_groups, n_times});
+  } else {
+    set_array_dims(ret, {n_state * n_particles * n_groups, n_times});
   }
   return ret;
 }

--- a/inst/include/dust2/r/unfilter.hpp
+++ b/inst/include/dust2/r/unfilter.hpp
@@ -76,7 +76,9 @@ cpp11::sexp dust2_unfilter_last_history(cpp11::sexp ptr,
 }
 
 template <typename T>
-cpp11::sexp dust2_discrete_unfilter_last_gradient(cpp11::sexp ptr, bool grouped) {
+cpp11::sexp dust2_discrete_unfilter_last_gradient(cpp11::sexp ptr,
+                                                  bool preserve_particle_dimension,
+                                                  bool preserve_group_dimension) {
   auto *obj =
     cpp11::as_cpp<cpp11::external_pointer<unfilter<T>>>(ptr).get();
   if (!obj->adjoint_is_current()) {
@@ -95,8 +97,10 @@ cpp11::sexp dust2_discrete_unfilter_last_gradient(cpp11::sexp ptr, bool grouped)
   }
   cpp11::sexp ret = cpp11::writable::doubles(len);
   obj->last_gradient(REAL(ret));
-  if (grouped) {
-    set_array_dims(ret, {n_gradient, n_groups});
+  if (preserve_group_dimension && preserve_particle_dimension) {
+    set_array_dims(ret, {n_gradient, n_particles, n_groups});
+  } else if (preserve_group_dimension || preserve_particle_dimension) {
+    set_array_dims(ret, {n_gradient, n_particles * n_groups});
   }
   return ret;
 }

--- a/inst/include/dust2/r/unfilter.hpp
+++ b/inst/include/dust2/r/unfilter.hpp
@@ -9,21 +9,21 @@ namespace r {
 
 template <typename T>
 cpp11::sexp dust2_unfilter_update_pars(cpp11::sexp ptr,
-                                       cpp11::list r_pars,
-                                       bool grouped) {
+                                       cpp11::list r_pars) {
   auto *obj =
     cpp11::as_cpp<cpp11::external_pointer<unfilter<T>>>(ptr).get();
-  update_pars(obj->sys, cpp11::as_cpp<cpp11::list>(r_pars), grouped);
+  update_pars(obj->sys, r_pars);
   return R_NilValue;
 }
 
 template <typename T>
 cpp11::sexp dust2_unfilter_run(cpp11::sexp ptr, cpp11::sexp r_initial,
-                               bool save_history, bool adjoint, bool grouped) {
+                               bool save_history, bool adjoint,
+			       bool preserve_group_dimension) {
   auto *obj =
     cpp11::as_cpp<cpp11::external_pointer<unfilter<T>>>(ptr).get();
   if (r_initial != R_NilValue) {
-    set_state(obj->sys, r_initial, grouped);
+    set_state(obj->sys, r_initial);
   }
   const auto set_initial = r_initial == R_NilValue;
   if (adjoint) {
@@ -36,14 +36,15 @@ cpp11::sexp dust2_unfilter_run(cpp11::sexp ptr, cpp11::sexp r_initial,
   const auto n_particles = obj->sys.n_particles();
   cpp11::writable::doubles ret(n_groups * n_particles);
   obj->last_log_likelihood(REAL(ret));
-  if (grouped && n_particles > 1) {
+  if (preserve_group_dimension && n_particles > 1) { // TODO: particle too
     set_array_dims(ret, {n_particles, n_groups});
   }
   return ret;
 }
 
 template <typename T>
-cpp11::sexp dust2_unfilter_last_history(cpp11::sexp ptr, bool grouped) {
+cpp11::sexp dust2_unfilter_last_history(cpp11::sexp ptr,
+					bool preserve_group_dimension) {
   auto *obj =
     cpp11::as_cpp<cpp11::external_pointer<unfilter<T>>>(ptr).get();
   if (!obj->last_history_is_current()) {
@@ -62,7 +63,7 @@ cpp11::sexp dust2_unfilter_last_history(cpp11::sexp ptr, bool grouped) {
   const auto len = n_state * n_particles * n_groups * n_times;
   cpp11::sexp ret = cpp11::writable::doubles(len);
   history.export_state(REAL(ret), reorder);
-  if (grouped) {
+  if (preserve_group_dimension) {
     set_array_dims(ret, {n_state, n_particles, n_groups, n_times});
   } else {
     set_array_dims(ret, {n_state, n_particles * n_groups, n_times});

--- a/inst/template/adjoint.cpp
+++ b/inst/template/adjoint.cpp
@@ -1,4 +1,4 @@
 [[cpp11::register]]
-SEXP dust2_unfilter_{{name}}_last_gradient(cpp11::sexp ptr, bool grouped) {
-  return dust2::r::dust2_discrete_unfilter_last_gradient<dust2::dust_{{time_type}}<{{class}}>>(ptr, grouped);
+SEXP dust2_unfilter_{{name}}_last_gradient(cpp11::sexp ptr, bool preserve_particle_dimension, bool preserve_group_dimension) {
+  return dust2::r::dust2_discrete_unfilter_last_gradient<dust2::dust_{{time_type}}<{{class}}>>(ptr, preserve_particle_dimension, preserve_group_dimension);
 }

--- a/inst/template/compare.cpp
+++ b/inst/template/compare.cpp
@@ -24,8 +24,8 @@ SEXP dust2_filter_{{name}}_update_pars(cpp11::sexp ptr, cpp11::list r_pars) {
 }
 
 [[cpp11::register]]
-SEXP dust2_filter_{{name}}_run(cpp11::sexp ptr, cpp11::sexp r_initial, bool save_history) {
-  return dust2::r::dust2_filter_run<dust2::dust_{{time_type}}<{{class}}>>(ptr, r_initial, save_history);
+SEXP dust2_filter_{{name}}_run(cpp11::sexp ptr, cpp11::sexp r_initial, bool save_history, bool preserve_group_dimension) {
+  return dust2::r::dust2_filter_run<dust2::dust_{{time_type}}<{{class}}>>(ptr, r_initial, save_history, preserve_group_dimension);
 }
 
 [[cpp11::register]]

--- a/inst/template/compare.cpp
+++ b/inst/template/compare.cpp
@@ -9,8 +9,8 @@ SEXP dust2_unfilter_{{name}}_update_pars(cpp11::sexp ptr, cpp11::list r_pars) {
 }
 
 [[cpp11::register]]
-SEXP dust2_unfilter_{{name}}_run(cpp11::sexp ptr, cpp11::sexp r_initial, bool save_history, bool adjoint, bool preserve_group_dimension) {
-  return dust2::r::dust2_unfilter_run<dust2::dust_{{time_type}}<{{class}}>>(ptr, r_initial, save_history, adjoint, preserve_group_dimension);
+SEXP dust2_unfilter_{{name}}_run(cpp11::sexp ptr, cpp11::sexp r_initial, bool save_history, bool adjoint, bool preserve_particle_dimension, bool preserve_group_dimension) {
+  return dust2::r::dust2_unfilter_run<dust2::dust_{{time_type}}<{{class}}>>(ptr, r_initial, save_history, adjoint, preserve_particle_dimension, preserve_group_dimension);
 }
 
 [[cpp11::register]]

--- a/inst/template/compare.cpp
+++ b/inst/template/compare.cpp
@@ -14,8 +14,8 @@ SEXP dust2_unfilter_{{name}}_run(cpp11::sexp ptr, cpp11::sexp r_initial, bool sa
 }
 
 [[cpp11::register]]
-SEXP dust2_unfilter_{{name}}_last_history(cpp11::sexp ptr, bool preserve_group_dimension) {
-  return dust2::r::dust2_unfilter_last_history<dust2::dust_{{time_type}}<{{class}}>>(ptr, preserve_group_dimension);
+SEXP dust2_unfilter_{{name}}_last_history(cpp11::sexp ptr, bool preserve_particle_dimension, bool preserve_group_dimension) {
+  return dust2::r::dust2_unfilter_last_history<dust2::dust_{{time_type}}<{{class}}>>(ptr, preserve_particle_dimension, preserve_group_dimension);
 }
 
 [[cpp11::register]]

--- a/inst/template/compare.cpp
+++ b/inst/template/compare.cpp
@@ -1,36 +1,36 @@
 [[cpp11::register]]
-SEXP dust2_system_{{name}}_compare_data(cpp11::sexp ptr, cpp11::sexp r_data, bool grouped) {
-  return dust2::r::dust2_system_compare_data<dust2::dust_{{time_type}}<{{class}}>>(ptr, r_data, grouped);
+SEXP dust2_system_{{name}}_compare_data(cpp11::sexp ptr, cpp11::sexp r_data, bool preserve_group_dimension) {
+  return dust2::r::dust2_system_compare_data<dust2::dust_{{time_type}}<{{class}}>>(ptr, r_data, preserve_group_dimension);
 }
 
 [[cpp11::register]]
-SEXP dust2_unfilter_{{name}}_update_pars(cpp11::sexp ptr, cpp11::list r_pars, bool grouped) {
-  return dust2::r::dust2_unfilter_update_pars<dust2::dust_{{time_type}}<{{class}}>>(ptr, r_pars, grouped);
+SEXP dust2_unfilter_{{name}}_update_pars(cpp11::sexp ptr, cpp11::list r_pars) {
+  return dust2::r::dust2_unfilter_update_pars<dust2::dust_{{time_type}}<{{class}}>>(ptr, r_pars);
 }
 
 [[cpp11::register]]
-SEXP dust2_unfilter_{{name}}_run(cpp11::sexp ptr, cpp11::sexp r_initial, bool save_history, bool adjoint, bool grouped) {
-  return dust2::r::dust2_unfilter_run<dust2::dust_{{time_type}}<{{class}}>>(ptr, r_initial, save_history, adjoint, grouped);
+SEXP dust2_unfilter_{{name}}_run(cpp11::sexp ptr, cpp11::sexp r_initial, bool save_history, bool adjoint, bool preserve_group_dimension) {
+  return dust2::r::dust2_unfilter_run<dust2::dust_{{time_type}}<{{class}}>>(ptr, r_initial, save_history, adjoint, preserve_group_dimension);
 }
 
 [[cpp11::register]]
-SEXP dust2_unfilter_{{name}}_last_history(cpp11::sexp ptr, bool grouped) {
-  return dust2::r::dust2_unfilter_last_history<dust2::dust_{{time_type}}<{{class}}>>(ptr, grouped);
+SEXP dust2_unfilter_{{name}}_last_history(cpp11::sexp ptr, bool preserve_group_dimension) {
+  return dust2::r::dust2_unfilter_last_history<dust2::dust_{{time_type}}<{{class}}>>(ptr, preserve_group_dimension);
 }
 
 [[cpp11::register]]
-SEXP dust2_filter_{{name}}_update_pars(cpp11::sexp ptr, cpp11::list r_pars, bool grouped) {
-  return dust2::r::dust2_filter_update_pars<dust2::dust_{{time_type}}<{{class}}>>(ptr, r_pars, grouped);
+SEXP dust2_filter_{{name}}_update_pars(cpp11::sexp ptr, cpp11::list r_pars) {
+  return dust2::r::dust2_filter_update_pars<dust2::dust_{{time_type}}<{{class}}>>(ptr, r_pars);
 }
 
 [[cpp11::register]]
-SEXP dust2_filter_{{name}}_run(cpp11::sexp ptr, cpp11::sexp r_initial, bool save_history, bool grouped) {
-  return dust2::r::dust2_filter_run<dust2::dust_{{time_type}}<{{class}}>>(ptr, r_initial, save_history, grouped);
+SEXP dust2_filter_{{name}}_run(cpp11::sexp ptr, cpp11::sexp r_initial, bool save_history) {
+  return dust2::r::dust2_filter_run<dust2::dust_{{time_type}}<{{class}}>>(ptr, r_initial, save_history);
 }
 
 [[cpp11::register]]
-SEXP dust2_filter_{{name}}_last_history(cpp11::sexp ptr, bool grouped) {
-  return dust2::r::dust2_filter_last_history<dust2::dust_{{time_type}}<{{class}}>>(ptr, grouped);
+SEXP dust2_filter_{{name}}_last_history(cpp11::sexp ptr, bool preserve_group_dimension) {
+  return dust2::r::dust2_filter_last_history<dust2::dust_{{time_type}}<{{class}}>>(ptr, preserve_group_dimension);
 }
 
 [[cpp11::register]]

--- a/inst/template/compare.cpp
+++ b/inst/template/compare.cpp
@@ -1,6 +1,6 @@
 [[cpp11::register]]
-SEXP dust2_system_{{name}}_compare_data(cpp11::sexp ptr, cpp11::sexp r_data, bool preserve_group_dimension) {
-  return dust2::r::dust2_system_compare_data<dust2::dust_{{time_type}}<{{class}}>>(ptr, r_data, preserve_group_dimension);
+SEXP dust2_system_{{name}}_compare_data(cpp11::sexp ptr, cpp11::list r_data, bool preserve_particle_dimension, bool preserve_group_dimension) {
+  return dust2::r::dust2_system_compare_data<dust2::dust_{{time_type}}<{{class}}>>(ptr, r_data, preserve_particle_dimension, preserve_group_dimension);
 }
 
 [[cpp11::register]]

--- a/inst/template/discrete/compare.cpp
+++ b/inst/template/discrete/compare.cpp
@@ -1,9 +1,9 @@
 [[cpp11::register]]
-SEXP dust2_unfilter_{{name}}_alloc(cpp11::list r_pars, cpp11::sexp r_time_start, cpp11::sexp r_time, cpp11::sexp r_dt, cpp11::list r_data, cpp11::sexp r_n_particles, cpp11::sexp r_n_groups, cpp11::sexp r_n_threads, cpp11::sexp r_index) {
-  return dust2::r::dust2_discrete_unfilter_alloc<{{class}}>(r_pars, r_time_start, r_time, r_dt, r_data, r_n_particles, r_n_groups, r_n_threads, r_index);
+SEXP dust2_unfilter_{{name}}_alloc(cpp11::list r_pars, cpp11::sexp r_time_start, cpp11::sexp r_time, cpp11::sexp r_dt, cpp11::list r_data, cpp11::sexp r_n_particles, cpp11::sexp r_n_groups, cpp11::sexp r_n_threads, cpp11::sexp r_index_state) {
+  return dust2::r::dust2_discrete_unfilter_alloc<{{class}}>(r_pars, r_time_start, r_time, r_dt, r_data, r_n_particles, r_n_groups, r_n_threads, r_index_state);
 }
 
 [[cpp11::register]]
-SEXP dust2_filter_{{name}}_alloc(cpp11::list r_pars, cpp11::sexp r_time_start, cpp11::sexp r_time, cpp11::sexp r_dt, cpp11::list r_data, cpp11::sexp r_n_particles, cpp11::sexp r_n_groups, cpp11::sexp r_n_threads, cpp11::sexp r_index, cpp11::sexp r_seed) {
-  return dust2::r::dust2_discrete_filter_alloc<{{class}}>(r_pars, r_time_start, r_time, r_dt, r_data, r_n_particles, r_n_groups, r_n_threads, r_index, r_seed);
+SEXP dust2_filter_{{name}}_alloc(cpp11::list r_pars, cpp11::sexp r_time_start, cpp11::sexp r_time, cpp11::sexp r_dt, cpp11::list r_data, cpp11::sexp r_n_particles, cpp11::sexp r_n_groups, cpp11::sexp r_n_threads, cpp11::sexp r_index_state, cpp11::sexp r_seed) {
+  return dust2::r::dust2_discrete_filter_alloc<{{class}}>(r_pars, r_time_start, r_time, r_dt, r_data, r_n_particles, r_n_groups, r_n_threads, r_index_state, r_seed);
 }

--- a/inst/template/system.cpp
+++ b/inst/template/system.cpp
@@ -19,8 +19,8 @@ SEXP dust2_system_{{name}}_set_state_initial(cpp11::sexp ptr) {
 }
 
 [[cpp11::register]]
-SEXP dust2_system_{{name}}_set_state(cpp11::sexp ptr, cpp11::sexp r_state) {
-  return dust2::r::dust2_system_set_state<dust2::dust_{{time_type}}<{{class}}>>(ptr, r_state);
+SEXP dust2_system_{{name}}_set_state(cpp11::sexp ptr, cpp11::sexp r_state, bool preserve_group_dimension) {
+  return dust2::r::dust2_system_set_state<dust2::dust_{{time_type}}<{{class}}>>(ptr, r_state, preserve_group_dimension);
 }
 
 [[cpp11::register]]

--- a/inst/template/system.cpp
+++ b/inst/template/system.cpp
@@ -4,8 +4,8 @@ SEXP dust2_system_{{name}}_run_to_time(cpp11::sexp ptr, cpp11::sexp r_time) {
 }
 
 [[cpp11::register]]
-SEXP dust2_system_{{name}}_state(cpp11::sexp ptr, cpp11::sexp r_index_state, cpp11::sexp r_index_particle, cpp11::sexp r_index_group, bool grouped) {
-  return dust2::r::dust2_system_state<dust2::dust_{{time_type}}<{{class}}>>(ptr, r_index_state, r_index_particle, r_index_group, grouped);
+SEXP dust2_system_{{name}}_state(cpp11::sexp ptr, cpp11::sexp r_index_state, cpp11::sexp r_index_particle, cpp11::sexp r_index_group, bool preserve_group_dimension) {
+  return dust2::r::dust2_system_state<dust2::dust_{{time_type}}<{{class}}>>(ptr, r_index_state, r_index_particle, r_index_group, preserve_group_dimension);
 }
 
 [[cpp11::register]]
@@ -19,8 +19,8 @@ SEXP dust2_system_{{name}}_set_state_initial(cpp11::sexp ptr) {
 }
 
 [[cpp11::register]]
-SEXP dust2_system_{{name}}_set_state(cpp11::sexp ptr, cpp11::sexp r_state, bool grouped) {
-  return dust2::r::dust2_system_set_state<dust2::dust_{{time_type}}<{{class}}>>(ptr, r_state, grouped);
+SEXP dust2_system_{{name}}_set_state(cpp11::sexp ptr, cpp11::sexp r_state) {
+  return dust2::r::dust2_system_set_state<dust2::dust_{{time_type}}<{{class}}>>(ptr, r_state);
 }
 
 [[cpp11::register]]
@@ -44,11 +44,11 @@ SEXP dust2_system_{{name}}_set_time(cpp11::sexp ptr, cpp11::sexp r_time) {
 }
 
 [[cpp11::register]]
-SEXP dust2_system_{{name}}_update_pars(cpp11::sexp ptr, cpp11::list pars, bool grouped) {
-  return dust2::r::dust2_system_update_pars<dust2::dust_{{time_type}}<{{class}}>>(ptr, pars, grouped);
+SEXP dust2_system_{{name}}_update_pars(cpp11::sexp ptr, cpp11::list pars) {
+  return dust2::r::dust2_system_update_pars<dust2::dust_{{time_type}}<{{class}}>>(ptr, pars);
 }
 
 [[cpp11::register]]
-SEXP dust2_system_{{name}}_simulate(cpp11::sexp ptr, cpp11::sexp r_times, cpp11::sexp r_index, bool grouped) {
-  return dust2::r::dust2_system_simulate<dust2::dust_{{time_type}}<{{class}}>>(ptr, r_times, r_index, grouped);
+SEXP dust2_system_{{name}}_simulate(cpp11::sexp ptr, cpp11::sexp r_times, cpp11::sexp r_index, bool preserve_group_dimension) {
+  return dust2::r::dust2_system_simulate<dust2::dust_{{time_type}}<{{class}}>>(ptr, r_times, r_index, preserve_group_dimension);
 }

--- a/inst/template/system.cpp
+++ b/inst/template/system.cpp
@@ -4,8 +4,8 @@ SEXP dust2_system_{{name}}_run_to_time(cpp11::sexp ptr, cpp11::sexp r_time) {
 }
 
 [[cpp11::register]]
-SEXP dust2_system_{{name}}_state(cpp11::sexp ptr, cpp11::sexp r_index_state, cpp11::sexp r_index_particle, cpp11::sexp r_index_group, bool preserve_group_dimension) {
-  return dust2::r::dust2_system_state<dust2::dust_{{time_type}}<{{class}}>>(ptr, r_index_state, r_index_particle, r_index_group, preserve_group_dimension);
+SEXP dust2_system_{{name}}_state(cpp11::sexp ptr, cpp11::sexp r_index_state, cpp11::sexp r_index_particle, cpp11::sexp r_index_group, bool preserve_particle_dimension, bool preserve_group_dimension) {
+  return dust2::r::dust2_system_state<dust2::dust_{{time_type}}<{{class}}>>(ptr, r_index_state, r_index_particle, r_index_group, preserve_particle_dimension, preserve_group_dimension);
 }
 
 [[cpp11::register]]
@@ -49,6 +49,6 @@ SEXP dust2_system_{{name}}_update_pars(cpp11::sexp ptr, cpp11::list pars) {
 }
 
 [[cpp11::register]]
-SEXP dust2_system_{{name}}_simulate(cpp11::sexp ptr, cpp11::sexp r_times, cpp11::sexp r_index, bool preserve_group_dimension) {
-  return dust2::r::dust2_system_simulate<dust2::dust_{{time_type}}<{{class}}>>(ptr, r_times, r_index, preserve_group_dimension);
+SEXP dust2_system_{{name}}_simulate(cpp11::sexp ptr, cpp11::sexp r_times, cpp11::sexp r_index, bool preserve_particle_dimension, bool preserve_group_dimension) {
+  return dust2::r::dust2_system_simulate<dust2::dust_{{time_type}}<{{class}}>>(ptr, r_times, r_index, preserve_particle_dimension, preserve_group_dimension);
 }

--- a/man/dust_filter_create.Rd
+++ b/man/dust_filter_create.Rd
@@ -12,7 +12,7 @@ dust_filter_create(
   n_particles,
   n_groups = 1,
   dt = 1,
-  index = NULL,
+  index_state = NULL,
   n_threads = 1,
   preserve_group_dimension = FALSE,
   seed = NULL
@@ -50,6 +50,12 @@ slowly.}
 \item{dt}{The time step for discrete time systems, defaults to 1
 if not given.  It is an error to provide a non-NULL argument
 with continuous-time systems.}
+
+\item{index_state}{An optional index of states to extract.  If
+given, then we subset the system state on return.  You can use
+this to return fewer system states than the system ran with, to
+reorder states, or to name them on exit (names present on the
+index will be copied into the rownames of the returned array).}
 
 \item{n_threads}{Integer, the number of threads to use in
 parallelisable calculations.  See Details.}

--- a/man/dust_filter_create.Rd
+++ b/man/dust_filter_create.Rd
@@ -10,10 +10,11 @@ dust_filter_create(
   time,
   data,
   n_particles,
-  n_groups = 0,
-  n_threads = 1,
+  n_groups = 1,
   dt = 1,
   index = NULL,
+  n_threads = 1,
+  preserve_group_dimension = FALSE,
   seed = NULL
 )
 }
@@ -46,18 +47,18 @@ slowly.}
 
 \item{n_groups}{Optionally, the number of parameter groups}
 
-\item{n_threads}{Integer, the number of threads to use in
-parallelisable calculations.  See Details.}
-
 \item{dt}{The time step for discrete time systems, defaults to 1
 if not given.  It is an error to provide a non-NULL argument
 with continuous-time systems.}
 
-\item{index}{An optional index of states to extract.  If given,
-then we subset the system state on return.  You can use this to
-return fewer system states than the system ran with, to reorder
-states, or to name them on exit (names present on the index will
-be copied into the rownames of the returned array).}
+\item{n_threads}{Integer, the number of threads to use in
+parallelisable calculations.  See Details.}
+
+\item{preserve_group_dimension}{Logical, indicating if state and
+output from the system should preserve the group dimension in
+the case where a single group is run.  In the case where more
+than one group is run, this argument has no effect as the
+dimension is always preserved.}
 
 \item{seed}{Optionally, a seed.  Otherwise we respond to R's RNG seed on
 initialisation.}

--- a/man/dust_filter_run.Rd
+++ b/man/dust_filter_run.Rd
@@ -21,7 +21,7 @@ provided, the system initial conditions are used.}
 should be saved while the simulation runs; this has a small
 overhead in runtime and in memory.  History (particle
 trajectories) will be saved at each time in the filter.  If the
-filter was constructed using a non-\code{NULL} \code{index} parameter,
+filter was constructed using a non-\code{NULL} \code{index_state} parameter,
 the history is restricted to these states.}
 }
 \value{

--- a/man/dust_system_create.Rd
+++ b/man/dust_system_create.Rd
@@ -8,13 +8,15 @@ dust_system_create(
   generator,
   pars,
   n_particles,
-  n_groups = 0,
+  n_groups = 1,
   time = 0,
   dt = NULL,
   ode_control = NULL,
   seed = NULL,
   deterministic = FALSE,
-  n_threads = 1
+  n_threads = 1,
+  preserve_particle_dimension = FALSE,
+  preserve_group_dimension = FALSE
 )
 }
 \arguments{
@@ -47,6 +49,18 @@ allocated in deterministic mode.}
 
 \item{n_threads}{Integer, the number of threads to use in
 parallelisable calculations.  See Details.}
+
+\item{preserve_particle_dimension}{Logical, indicating if output
+from the system should preserve the particle dimension in the
+case where a single particle is run.  In the case where more
+than one particle is run, this argument has no effect as the
+dimension is always preserved.}
+
+\item{preserve_group_dimension}{Logical, indicating if state and
+output from the system should preserve the group dimension in
+the case where a single group is run.  In the case where more
+than one group is run, this argument has no effect as the
+dimension is always preserved.}
 }
 \value{
 A \code{dust_system} object, with opaque format.

--- a/man/dust_system_simulate.Rd
+++ b/man/dust_system_simulate.Rd
@@ -4,7 +4,7 @@
 \alias{dust_system_simulate}
 \title{Simulate system}
 \usage{
-dust_system_simulate(sys, times, index = NULL)
+dust_system_simulate(sys, times, index_state = NULL)
 }
 \arguments{
 \item{sys}{A \code{dust_system} object}
@@ -13,11 +13,11 @@ dust_system_simulate(sys, times, index = NULL)
 first time must be no less than the current system time
 (as reported by \link{dust_system_time})}
 
-\item{index}{An optional index of states to extract.  If given,
-then we subset the system state on return.  You can use this to
-return fewer system states than the system ran with, to reorder
-states, or to name them on exit (names present on the index will
-be copied into the rownames of the returned array).}
+\item{index_state}{An optional index of states to extract.  If
+given, then we subset the system state on return.  You can use
+this to return fewer system states than the system ran with, to
+reorder states, or to name them on exit (names present on the
+index will be copied into the rownames of the returned array).}
 }
 \value{
 An array with 3 dimensions (state x particle x time) or 4

--- a/man/dust_system_state.Rd
+++ b/man/dust_system_state.Rd
@@ -24,9 +24,10 @@ like a subset}
 a subset}
 }
 \value{
-An array of system state.  If your system is ungrouped, then
-this has two dimensions (state, particle).  If grouped, this has
-three dimensions (state, particle, group)
+An array of system state.  If your system is ungrouped
+(i.e., \code{n_groups = 1} and \code{preserve_group_dimension = FALSE}),
+then this has two dimensions (state, particle).  If grouped,
+this has three dimensions (state, particle, group)
 }
 \description{
 Extract system state

--- a/man/dust_unfilter_create.Rd
+++ b/man/dust_unfilter_create.Rd
@@ -10,10 +10,12 @@ dust_unfilter_create(
   time,
   data,
   n_particles = 1,
-  n_groups = 0,
-  n_threads = 1,
+  n_groups = 1,
   dt = 1,
-  index = NULL
+  n_threads = 1,
+  index = NULL,
+  preserve_particle_dimension = FALSE,
+  preserve_group_dimension = FALSE
 )
 }
 \arguments{
@@ -46,18 +48,18 @@ initial conditions then you would see different likelihoods.}
 
 \item{n_groups}{Optionally, the number of parameter groups}
 
-\item{n_threads}{Integer, the number of threads to use in
-parallelisable calculations.  See Details.}
-
 \item{dt}{The time step for discrete time systems, defaults to 1
 if not given.  It is an error to provide a non-NULL argument
 with continuous-time systems.}
 
-\item{index}{An optional index of states to extract.  If given,
-then we subset the system state on return.  You can use this to
-return fewer system states than the system ran with, to reorder
-states, or to name them on exit (names present on the index will
-be copied into the rownames of the returned array).}
+\item{n_threads}{Integer, the number of threads to use in
+parallelisable calculations.  See Details.}
+
+\item{preserve_group_dimension}{Logical, indicating if state and
+output from the system should preserve the group dimension in
+the case where a single group is run.  In the case where more
+than one group is run, this argument has no effect as the
+dimension is always preserved.}
 }
 \value{
 A \code{dust_unfilter} object, which can be used with

--- a/man/dust_unfilter_create.Rd
+++ b/man/dust_unfilter_create.Rd
@@ -13,23 +13,20 @@ dust_unfilter_create(
   n_groups = 1,
   dt = 1,
   n_threads = 1,
-  index = NULL,
+  index_state = NULL,
   preserve_particle_dimension = FALSE,
   preserve_group_dimension = FALSE
 )
 }
 \arguments{
 \item{generator}{A system generator object, with class
-\code{dust_system_generator}.  The system must support \code{compare_data}
-to be used with this function.}
+\code{dust_system_generator}}
 
 \item{time_start}{The start time for the simulation - this is
 typically before the first data point.  Must be an integer-like
 value.}
 
-\item{time}{A vector of times, each of which has a corresponding
-entry in \code{data}.  The system will stop at each of these times to
-compute the likelihood using the compare function.}
+\item{time}{The initial time, defaults to 0}
 
 \item{data}{The data to compare against.  This must be a list with
 the same length as \code{time}, each element of which corresponds to
@@ -54,6 +51,18 @@ with continuous-time systems.}
 
 \item{n_threads}{Integer, the number of threads to use in
 parallelisable calculations.  See Details.}
+
+\item{index_state}{An optional index of states to extract.  If
+given, then we subset the system state on return.  You can use
+this to return fewer system states than the system ran with, to
+reorder states, or to name them on exit (names present on the
+index will be copied into the rownames of the returned array).}
+
+\item{preserve_particle_dimension}{Logical, indicating if output
+from the system should preserve the particle dimension in the
+case where a single particle is run.  In the case where more
+than one particle is run, this argument has no effect as the
+dimension is always preserved.}
 
 \item{preserve_group_dimension}{Logical, indicating if state and
 output from the system should preserve the group dimension in

--- a/man/dust_unfilter_run.Rd
+++ b/man/dust_unfilter_run.Rd
@@ -27,7 +27,7 @@ provided, the system initial conditions are used.}
 should be saved while the simulation runs; this has a small
 overhead in runtime and in memory.  History (particle
 trajectories) will be saved at each time in the filter.  If the
-filter was constructed using a non-\code{NULL} \code{index} parameter,
+filter was constructed using a non-\code{NULL} \code{index_state} parameter,
 the history is restricted to these states.}
 
 \item{adjoint}{Logical, indicating if we should enable adjoint

--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -48,10 +48,10 @@ extern "C" SEXP _dust2_dust2_system_logistic_set_state_initial(SEXP ptr) {
   END_CPP11
 }
 // logistic.cpp
-SEXP dust2_system_logistic_set_state(cpp11::sexp ptr, cpp11::sexp r_state);
-extern "C" SEXP _dust2_dust2_system_logistic_set_state(SEXP ptr, SEXP r_state) {
+SEXP dust2_system_logistic_set_state(cpp11::sexp ptr, cpp11::sexp r_state, bool preserve_group_dimension);
+extern "C" SEXP _dust2_dust2_system_logistic_set_state(SEXP ptr, SEXP r_state, SEXP preserve_group_dimension) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust2_system_logistic_set_state(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_state)));
+    return cpp11::as_sexp(dust2_system_logistic_set_state(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_state), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_group_dimension)));
   END_CPP11
 }
 // logistic.cpp
@@ -132,10 +132,10 @@ extern "C" SEXP _dust2_dust2_system_sir_set_state_initial(SEXP ptr) {
   END_CPP11
 }
 // sir.cpp
-SEXP dust2_system_sir_set_state(cpp11::sexp ptr, cpp11::sexp r_state);
-extern "C" SEXP _dust2_dust2_system_sir_set_state(SEXP ptr, SEXP r_state) {
+SEXP dust2_system_sir_set_state(cpp11::sexp ptr, cpp11::sexp r_state, bool preserve_group_dimension);
+extern "C" SEXP _dust2_dust2_system_sir_set_state(SEXP ptr, SEXP r_state, SEXP preserve_group_dimension) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust2_system_sir_set_state(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_state)));
+    return cpp11::as_sexp(dust2_system_sir_set_state(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_state), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_group_dimension)));
   END_CPP11
 }
 // sir.cpp
@@ -230,10 +230,10 @@ extern "C" SEXP _dust2_dust2_filter_sir_update_pars(SEXP ptr, SEXP r_pars) {
   END_CPP11
 }
 // sir.cpp
-SEXP dust2_filter_sir_run(cpp11::sexp ptr, cpp11::sexp r_initial, bool save_history);
-extern "C" SEXP _dust2_dust2_filter_sir_run(SEXP ptr, SEXP r_initial, SEXP save_history) {
+SEXP dust2_filter_sir_run(cpp11::sexp ptr, cpp11::sexp r_initial, bool save_history, bool preserve_group_dimension);
+extern "C" SEXP _dust2_dust2_filter_sir_run(SEXP ptr, SEXP r_initial, SEXP save_history, SEXP preserve_group_dimension) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust2_filter_sir_run(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_initial), cpp11::as_cpp<cpp11::decay_t<bool>>(save_history)));
+    return cpp11::as_sexp(dust2_filter_sir_run(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_initial), cpp11::as_cpp<cpp11::decay_t<bool>>(save_history), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_group_dimension)));
   END_CPP11
 }
 // sir.cpp
@@ -307,10 +307,10 @@ extern "C" SEXP _dust2_dust2_system_sirode_set_state_initial(SEXP ptr) {
   END_CPP11
 }
 // sirode.cpp
-SEXP dust2_system_sirode_set_state(cpp11::sexp ptr, cpp11::sexp r_state);
-extern "C" SEXP _dust2_dust2_system_sirode_set_state(SEXP ptr, SEXP r_state) {
+SEXP dust2_system_sirode_set_state(cpp11::sexp ptr, cpp11::sexp r_state, bool preserve_group_dimension);
+extern "C" SEXP _dust2_dust2_system_sirode_set_state(SEXP ptr, SEXP r_state, SEXP preserve_group_dimension) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust2_system_sirode_set_state(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_state)));
+    return cpp11::as_sexp(dust2_system_sirode_set_state(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_state), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_group_dimension)));
   END_CPP11
 }
 // sirode.cpp
@@ -412,10 +412,10 @@ extern "C" SEXP _dust2_dust2_system_walk_set_state_initial(SEXP ptr) {
   END_CPP11
 }
 // walk.cpp
-SEXP dust2_system_walk_set_state(cpp11::sexp ptr, cpp11::sexp r_state);
-extern "C" SEXP _dust2_dust2_system_walk_set_state(SEXP ptr, SEXP r_state) {
+SEXP dust2_system_walk_set_state(cpp11::sexp ptr, cpp11::sexp r_state, bool preserve_group_dimension);
+extern "C" SEXP _dust2_dust2_system_walk_set_state(SEXP ptr, SEXP r_state, SEXP preserve_group_dimension) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust2_system_walk_set_state(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_state)));
+    return cpp11::as_sexp(dust2_system_walk_set_state(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_state), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_group_dimension)));
   END_CPP11
 }
 // walk.cpp
@@ -466,7 +466,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_dust2_dust2_filter_sir_alloc",                  (DL_FUNC) &_dust2_dust2_filter_sir_alloc,                  10},
     {"_dust2_dust2_filter_sir_last_history",           (DL_FUNC) &_dust2_dust2_filter_sir_last_history,            2},
     {"_dust2_dust2_filter_sir_rng_state",              (DL_FUNC) &_dust2_dust2_filter_sir_rng_state,               1},
-    {"_dust2_dust2_filter_sir_run",                    (DL_FUNC) &_dust2_dust2_filter_sir_run,                     3},
+    {"_dust2_dust2_filter_sir_run",                    (DL_FUNC) &_dust2_dust2_filter_sir_run,                     4},
     {"_dust2_dust2_filter_sir_set_rng_state",          (DL_FUNC) &_dust2_dust2_filter_sir_set_rng_state,           2},
     {"_dust2_dust2_filter_sir_update_pars",            (DL_FUNC) &_dust2_dust2_filter_sir_update_pars,             2},
     {"_dust2_dust2_system_logistic_alloc",             (DL_FUNC) &_dust2_dust2_system_logistic_alloc,              8},
@@ -475,7 +475,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_dust2_dust2_system_logistic_rng_state",         (DL_FUNC) &_dust2_dust2_system_logistic_rng_state,          1},
     {"_dust2_dust2_system_logistic_run_to_time",       (DL_FUNC) &_dust2_dust2_system_logistic_run_to_time,        2},
     {"_dust2_dust2_system_logistic_set_rng_state",     (DL_FUNC) &_dust2_dust2_system_logistic_set_rng_state,      2},
-    {"_dust2_dust2_system_logistic_set_state",         (DL_FUNC) &_dust2_dust2_system_logistic_set_state,          2},
+    {"_dust2_dust2_system_logistic_set_state",         (DL_FUNC) &_dust2_dust2_system_logistic_set_state,          3},
     {"_dust2_dust2_system_logistic_set_state_initial", (DL_FUNC) &_dust2_dust2_system_logistic_set_state_initial,  1},
     {"_dust2_dust2_system_logistic_set_time",          (DL_FUNC) &_dust2_dust2_system_logistic_set_time,           2},
     {"_dust2_dust2_system_logistic_simulate",          (DL_FUNC) &_dust2_dust2_system_logistic_simulate,           4},
@@ -488,7 +488,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_dust2_dust2_system_sir_rng_state",              (DL_FUNC) &_dust2_dust2_system_sir_rng_state,               1},
     {"_dust2_dust2_system_sir_run_to_time",            (DL_FUNC) &_dust2_dust2_system_sir_run_to_time,             2},
     {"_dust2_dust2_system_sir_set_rng_state",          (DL_FUNC) &_dust2_dust2_system_sir_set_rng_state,           2},
-    {"_dust2_dust2_system_sir_set_state",              (DL_FUNC) &_dust2_dust2_system_sir_set_state,               2},
+    {"_dust2_dust2_system_sir_set_state",              (DL_FUNC) &_dust2_dust2_system_sir_set_state,               3},
     {"_dust2_dust2_system_sir_set_state_initial",      (DL_FUNC) &_dust2_dust2_system_sir_set_state_initial,       1},
     {"_dust2_dust2_system_sir_set_time",               (DL_FUNC) &_dust2_dust2_system_sir_set_time,                2},
     {"_dust2_dust2_system_sir_simulate",               (DL_FUNC) &_dust2_dust2_system_sir_simulate,                4},
@@ -501,7 +501,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_dust2_dust2_system_sirode_rng_state",           (DL_FUNC) &_dust2_dust2_system_sirode_rng_state,            1},
     {"_dust2_dust2_system_sirode_run_to_time",         (DL_FUNC) &_dust2_dust2_system_sirode_run_to_time,          2},
     {"_dust2_dust2_system_sirode_set_rng_state",       (DL_FUNC) &_dust2_dust2_system_sirode_set_rng_state,        2},
-    {"_dust2_dust2_system_sirode_set_state",           (DL_FUNC) &_dust2_dust2_system_sirode_set_state,            2},
+    {"_dust2_dust2_system_sirode_set_state",           (DL_FUNC) &_dust2_dust2_system_sirode_set_state,            3},
     {"_dust2_dust2_system_sirode_set_state_initial",   (DL_FUNC) &_dust2_dust2_system_sirode_set_state_initial,    1},
     {"_dust2_dust2_system_sirode_set_time",            (DL_FUNC) &_dust2_dust2_system_sirode_set_time,             2},
     {"_dust2_dust2_system_sirode_simulate",            (DL_FUNC) &_dust2_dust2_system_sirode_simulate,             4},
@@ -513,7 +513,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_dust2_dust2_system_walk_rng_state",             (DL_FUNC) &_dust2_dust2_system_walk_rng_state,              1},
     {"_dust2_dust2_system_walk_run_to_time",           (DL_FUNC) &_dust2_dust2_system_walk_run_to_time,            2},
     {"_dust2_dust2_system_walk_set_rng_state",         (DL_FUNC) &_dust2_dust2_system_walk_set_rng_state,          2},
-    {"_dust2_dust2_system_walk_set_state",             (DL_FUNC) &_dust2_dust2_system_walk_set_state,              2},
+    {"_dust2_dust2_system_walk_set_state",             (DL_FUNC) &_dust2_dust2_system_walk_set_state,              3},
     {"_dust2_dust2_system_walk_set_state_initial",     (DL_FUNC) &_dust2_dust2_system_walk_set_state_initial,      1},
     {"_dust2_dust2_system_walk_set_time",              (DL_FUNC) &_dust2_dust2_system_walk_set_time,               2},
     {"_dust2_dust2_system_walk_simulate",              (DL_FUNC) &_dust2_dust2_system_walk_simulate,               4},

--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -258,10 +258,10 @@ extern "C" SEXP _dust2_dust2_filter_sir_set_rng_state(SEXP ptr, SEXP r_rng_state
   END_CPP11
 }
 // sir.cpp
-SEXP dust2_unfilter_sir_last_gradient(cpp11::sexp ptr, bool grouped);
-extern "C" SEXP _dust2_dust2_unfilter_sir_last_gradient(SEXP ptr, SEXP grouped) {
+SEXP dust2_unfilter_sir_last_gradient(cpp11::sexp ptr, bool preserve_particle_dimension, bool preserve_group_dimension);
+extern "C" SEXP _dust2_dust2_unfilter_sir_last_gradient(SEXP ptr, SEXP preserve_particle_dimension, SEXP preserve_group_dimension) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust2_unfilter_sir_last_gradient(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<bool>>(grouped)));
+    return cpp11::as_sexp(dust2_unfilter_sir_last_gradient(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_particle_dimension), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_group_dimension)));
   END_CPP11
 }
 // sirode.cpp
@@ -521,7 +521,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_dust2_dust2_system_walk_time",                  (DL_FUNC) &_dust2_dust2_system_walk_time,                   1},
     {"_dust2_dust2_system_walk_update_pars",           (DL_FUNC) &_dust2_dust2_system_walk_update_pars,            2},
     {"_dust2_dust2_unfilter_sir_alloc",                (DL_FUNC) &_dust2_dust2_unfilter_sir_alloc,                 9},
-    {"_dust2_dust2_unfilter_sir_last_gradient",        (DL_FUNC) &_dust2_dust2_unfilter_sir_last_gradient,         2},
+    {"_dust2_dust2_unfilter_sir_last_gradient",        (DL_FUNC) &_dust2_dust2_unfilter_sir_last_gradient,         3},
     {"_dust2_dust2_unfilter_sir_last_history",         (DL_FUNC) &_dust2_dust2_unfilter_sir_last_history,          3},
     {"_dust2_dust2_unfilter_sir_run",                  (DL_FUNC) &_dust2_dust2_unfilter_sir_run,                   6},
     {"_dust2_dust2_unfilter_sir_update_pars",          (DL_FUNC) &_dust2_dust2_unfilter_sir_update_pars,           2},

--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -209,10 +209,10 @@ extern "C" SEXP _dust2_dust2_unfilter_sir_update_pars(SEXP ptr, SEXP r_pars) {
   END_CPP11
 }
 // sir.cpp
-SEXP dust2_unfilter_sir_run(cpp11::sexp ptr, cpp11::sexp r_initial, bool save_history, bool adjoint, bool preserve_group_dimension);
-extern "C" SEXP _dust2_dust2_unfilter_sir_run(SEXP ptr, SEXP r_initial, SEXP save_history, SEXP adjoint, SEXP preserve_group_dimension) {
+SEXP dust2_unfilter_sir_run(cpp11::sexp ptr, cpp11::sexp r_initial, bool save_history, bool adjoint, bool preserve_particle_dimension, bool preserve_group_dimension);
+extern "C" SEXP _dust2_dust2_unfilter_sir_run(SEXP ptr, SEXP r_initial, SEXP save_history, SEXP adjoint, SEXP preserve_particle_dimension, SEXP preserve_group_dimension) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust2_unfilter_sir_run(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_initial), cpp11::as_cpp<cpp11::decay_t<bool>>(save_history), cpp11::as_cpp<cpp11::decay_t<bool>>(adjoint), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_group_dimension)));
+    return cpp11::as_sexp(dust2_unfilter_sir_run(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_initial), cpp11::as_cpp<cpp11::decay_t<bool>>(save_history), cpp11::as_cpp<cpp11::decay_t<bool>>(adjoint), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_particle_dimension), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_group_dimension)));
   END_CPP11
 }
 // sir.cpp
@@ -523,7 +523,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_dust2_dust2_unfilter_sir_alloc",                (DL_FUNC) &_dust2_dust2_unfilter_sir_alloc,                 9},
     {"_dust2_dust2_unfilter_sir_last_gradient",        (DL_FUNC) &_dust2_dust2_unfilter_sir_last_gradient,         2},
     {"_dust2_dust2_unfilter_sir_last_history",         (DL_FUNC) &_dust2_dust2_unfilter_sir_last_history,          3},
-    {"_dust2_dust2_unfilter_sir_run",                  (DL_FUNC) &_dust2_dust2_unfilter_sir_run,                   5},
+    {"_dust2_dust2_unfilter_sir_run",                  (DL_FUNC) &_dust2_dust2_unfilter_sir_run,                   6},
     {"_dust2_dust2_unfilter_sir_update_pars",          (DL_FUNC) &_dust2_dust2_unfilter_sir_update_pars,           2},
     {"_dust2_test_history",                            (DL_FUNC) &_dust2_test_history,                             4},
     {"_dust2_test_resample_weight",                    (DL_FUNC) &_dust2_test_resample_weight,                     2},

--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -27,10 +27,10 @@ extern "C" SEXP _dust2_dust2_system_logistic_run_to_time(SEXP ptr, SEXP r_time) 
   END_CPP11
 }
 // logistic.cpp
-SEXP dust2_system_logistic_state(cpp11::sexp ptr, cpp11::sexp r_index_state, cpp11::sexp r_index_particle, cpp11::sexp r_index_group, bool preserve_group_dimension);
-extern "C" SEXP _dust2_dust2_system_logistic_state(SEXP ptr, SEXP r_index_state, SEXP r_index_particle, SEXP r_index_group, SEXP preserve_group_dimension) {
+SEXP dust2_system_logistic_state(cpp11::sexp ptr, cpp11::sexp r_index_state, cpp11::sexp r_index_particle, cpp11::sexp r_index_group, bool preserve_particle_dimension, bool preserve_group_dimension);
+extern "C" SEXP _dust2_dust2_system_logistic_state(SEXP ptr, SEXP r_index_state, SEXP r_index_particle, SEXP r_index_group, SEXP preserve_particle_dimension, SEXP preserve_group_dimension) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust2_system_logistic_state(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_state), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_particle), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_group), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_group_dimension)));
+    return cpp11::as_sexp(dust2_system_logistic_state(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_state), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_particle), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_group), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_particle_dimension), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_group_dimension)));
   END_CPP11
 }
 // logistic.cpp
@@ -90,10 +90,10 @@ extern "C" SEXP _dust2_dust2_system_logistic_update_pars(SEXP ptr, SEXP pars) {
   END_CPP11
 }
 // logistic.cpp
-SEXP dust2_system_logistic_simulate(cpp11::sexp ptr, cpp11::sexp r_times, cpp11::sexp r_index, bool preserve_group_dimension);
-extern "C" SEXP _dust2_dust2_system_logistic_simulate(SEXP ptr, SEXP r_times, SEXP r_index, SEXP preserve_group_dimension) {
+SEXP dust2_system_logistic_simulate(cpp11::sexp ptr, cpp11::sexp r_times, cpp11::sexp r_index, bool preserve_particle_dimension, bool preserve_group_dimension);
+extern "C" SEXP _dust2_dust2_system_logistic_simulate(SEXP ptr, SEXP r_times, SEXP r_index, SEXP preserve_particle_dimension, SEXP preserve_group_dimension) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust2_system_logistic_simulate(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_times), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_group_dimension)));
+    return cpp11::as_sexp(dust2_system_logistic_simulate(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_times), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_particle_dimension), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_group_dimension)));
   END_CPP11
 }
 // sir.cpp
@@ -111,10 +111,10 @@ extern "C" SEXP _dust2_dust2_system_sir_run_to_time(SEXP ptr, SEXP r_time) {
   END_CPP11
 }
 // sir.cpp
-SEXP dust2_system_sir_state(cpp11::sexp ptr, cpp11::sexp r_index_state, cpp11::sexp r_index_particle, cpp11::sexp r_index_group, bool preserve_group_dimension);
-extern "C" SEXP _dust2_dust2_system_sir_state(SEXP ptr, SEXP r_index_state, SEXP r_index_particle, SEXP r_index_group, SEXP preserve_group_dimension) {
+SEXP dust2_system_sir_state(cpp11::sexp ptr, cpp11::sexp r_index_state, cpp11::sexp r_index_particle, cpp11::sexp r_index_group, bool preserve_particle_dimension, bool preserve_group_dimension);
+extern "C" SEXP _dust2_dust2_system_sir_state(SEXP ptr, SEXP r_index_state, SEXP r_index_particle, SEXP r_index_group, SEXP preserve_particle_dimension, SEXP preserve_group_dimension) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust2_system_sir_state(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_state), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_particle), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_group), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_group_dimension)));
+    return cpp11::as_sexp(dust2_system_sir_state(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_state), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_particle), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_group), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_particle_dimension), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_group_dimension)));
   END_CPP11
 }
 // sir.cpp
@@ -174,10 +174,10 @@ extern "C" SEXP _dust2_dust2_system_sir_update_pars(SEXP ptr, SEXP pars) {
   END_CPP11
 }
 // sir.cpp
-SEXP dust2_system_sir_simulate(cpp11::sexp ptr, cpp11::sexp r_times, cpp11::sexp r_index, bool preserve_group_dimension);
-extern "C" SEXP _dust2_dust2_system_sir_simulate(SEXP ptr, SEXP r_times, SEXP r_index, SEXP preserve_group_dimension) {
+SEXP dust2_system_sir_simulate(cpp11::sexp ptr, cpp11::sexp r_times, cpp11::sexp r_index, bool preserve_particle_dimension, bool preserve_group_dimension);
+extern "C" SEXP _dust2_dust2_system_sir_simulate(SEXP ptr, SEXP r_times, SEXP r_index, SEXP preserve_particle_dimension, SEXP preserve_group_dimension) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust2_system_sir_simulate(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_times), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_group_dimension)));
+    return cpp11::as_sexp(dust2_system_sir_simulate(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_times), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_particle_dimension), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_group_dimension)));
   END_CPP11
 }
 // sir.cpp
@@ -195,10 +195,10 @@ extern "C" SEXP _dust2_dust2_filter_sir_alloc(SEXP r_pars, SEXP r_time_start, SE
   END_CPP11
 }
 // sir.cpp
-SEXP dust2_system_sir_compare_data(cpp11::sexp ptr, cpp11::sexp r_data, bool preserve_group_dimension);
-extern "C" SEXP _dust2_dust2_system_sir_compare_data(SEXP ptr, SEXP r_data, SEXP preserve_group_dimension) {
+SEXP dust2_system_sir_compare_data(cpp11::sexp ptr, cpp11::list r_data, bool preserve_particle_dimension, bool preserve_group_dimension);
+extern "C" SEXP _dust2_dust2_system_sir_compare_data(SEXP ptr, SEXP r_data, SEXP preserve_particle_dimension, SEXP preserve_group_dimension) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust2_system_sir_compare_data(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_data), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_group_dimension)));
+    return cpp11::as_sexp(dust2_system_sir_compare_data(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(r_data), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_particle_dimension), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_group_dimension)));
   END_CPP11
 }
 // sir.cpp
@@ -286,10 +286,10 @@ extern "C" SEXP _dust2_dust2_system_sirode_run_to_time(SEXP ptr, SEXP r_time) {
   END_CPP11
 }
 // sirode.cpp
-SEXP dust2_system_sirode_state(cpp11::sexp ptr, cpp11::sexp r_index_state, cpp11::sexp r_index_particle, cpp11::sexp r_index_group, bool preserve_group_dimension);
-extern "C" SEXP _dust2_dust2_system_sirode_state(SEXP ptr, SEXP r_index_state, SEXP r_index_particle, SEXP r_index_group, SEXP preserve_group_dimension) {
+SEXP dust2_system_sirode_state(cpp11::sexp ptr, cpp11::sexp r_index_state, cpp11::sexp r_index_particle, cpp11::sexp r_index_group, bool preserve_particle_dimension, bool preserve_group_dimension);
+extern "C" SEXP _dust2_dust2_system_sirode_state(SEXP ptr, SEXP r_index_state, SEXP r_index_particle, SEXP r_index_group, SEXP preserve_particle_dimension, SEXP preserve_group_dimension) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust2_system_sirode_state(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_state), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_particle), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_group), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_group_dimension)));
+    return cpp11::as_sexp(dust2_system_sirode_state(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_state), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_particle), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_group), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_particle_dimension), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_group_dimension)));
   END_CPP11
 }
 // sirode.cpp
@@ -349,10 +349,10 @@ extern "C" SEXP _dust2_dust2_system_sirode_update_pars(SEXP ptr, SEXP pars) {
   END_CPP11
 }
 // sirode.cpp
-SEXP dust2_system_sirode_simulate(cpp11::sexp ptr, cpp11::sexp r_times, cpp11::sexp r_index, bool preserve_group_dimension);
-extern "C" SEXP _dust2_dust2_system_sirode_simulate(SEXP ptr, SEXP r_times, SEXP r_index, SEXP preserve_group_dimension) {
+SEXP dust2_system_sirode_simulate(cpp11::sexp ptr, cpp11::sexp r_times, cpp11::sexp r_index, bool preserve_particle_dimension, bool preserve_group_dimension);
+extern "C" SEXP _dust2_dust2_system_sirode_simulate(SEXP ptr, SEXP r_times, SEXP r_index, SEXP preserve_particle_dimension, SEXP preserve_group_dimension) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust2_system_sirode_simulate(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_times), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_group_dimension)));
+    return cpp11::as_sexp(dust2_system_sirode_simulate(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_times), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_particle_dimension), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_group_dimension)));
   END_CPP11
 }
 // test.cpp
@@ -391,10 +391,10 @@ extern "C" SEXP _dust2_dust2_system_walk_run_to_time(SEXP ptr, SEXP r_time) {
   END_CPP11
 }
 // walk.cpp
-SEXP dust2_system_walk_state(cpp11::sexp ptr, cpp11::sexp r_index_state, cpp11::sexp r_index_particle, cpp11::sexp r_index_group, bool preserve_group_dimension);
-extern "C" SEXP _dust2_dust2_system_walk_state(SEXP ptr, SEXP r_index_state, SEXP r_index_particle, SEXP r_index_group, SEXP preserve_group_dimension) {
+SEXP dust2_system_walk_state(cpp11::sexp ptr, cpp11::sexp r_index_state, cpp11::sexp r_index_particle, cpp11::sexp r_index_group, bool preserve_particle_dimension, bool preserve_group_dimension);
+extern "C" SEXP _dust2_dust2_system_walk_state(SEXP ptr, SEXP r_index_state, SEXP r_index_particle, SEXP r_index_group, SEXP preserve_particle_dimension, SEXP preserve_group_dimension) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust2_system_walk_state(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_state), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_particle), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_group), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_group_dimension)));
+    return cpp11::as_sexp(dust2_system_walk_state(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_state), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_particle), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_group), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_particle_dimension), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_group_dimension)));
   END_CPP11
 }
 // walk.cpp
@@ -454,10 +454,10 @@ extern "C" SEXP _dust2_dust2_system_walk_update_pars(SEXP ptr, SEXP pars) {
   END_CPP11
 }
 // walk.cpp
-SEXP dust2_system_walk_simulate(cpp11::sexp ptr, cpp11::sexp r_times, cpp11::sexp r_index, bool preserve_group_dimension);
-extern "C" SEXP _dust2_dust2_system_walk_simulate(SEXP ptr, SEXP r_times, SEXP r_index, SEXP preserve_group_dimension) {
+SEXP dust2_system_walk_simulate(cpp11::sexp ptr, cpp11::sexp r_times, cpp11::sexp r_index, bool preserve_particle_dimension, bool preserve_group_dimension);
+extern "C" SEXP _dust2_dust2_system_walk_simulate(SEXP ptr, SEXP r_times, SEXP r_index, SEXP preserve_particle_dimension, SEXP preserve_group_dimension) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust2_system_walk_simulate(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_times), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_group_dimension)));
+    return cpp11::as_sexp(dust2_system_walk_simulate(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_times), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_particle_dimension), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_group_dimension)));
   END_CPP11
 }
 
@@ -478,12 +478,12 @@ static const R_CallMethodDef CallEntries[] = {
     {"_dust2_dust2_system_logistic_set_state",         (DL_FUNC) &_dust2_dust2_system_logistic_set_state,          3},
     {"_dust2_dust2_system_logistic_set_state_initial", (DL_FUNC) &_dust2_dust2_system_logistic_set_state_initial,  1},
     {"_dust2_dust2_system_logistic_set_time",          (DL_FUNC) &_dust2_dust2_system_logistic_set_time,           2},
-    {"_dust2_dust2_system_logistic_simulate",          (DL_FUNC) &_dust2_dust2_system_logistic_simulate,           4},
-    {"_dust2_dust2_system_logistic_state",             (DL_FUNC) &_dust2_dust2_system_logistic_state,              5},
+    {"_dust2_dust2_system_logistic_simulate",          (DL_FUNC) &_dust2_dust2_system_logistic_simulate,           5},
+    {"_dust2_dust2_system_logistic_state",             (DL_FUNC) &_dust2_dust2_system_logistic_state,              6},
     {"_dust2_dust2_system_logistic_time",              (DL_FUNC) &_dust2_dust2_system_logistic_time,               1},
     {"_dust2_dust2_system_logistic_update_pars",       (DL_FUNC) &_dust2_dust2_system_logistic_update_pars,        2},
     {"_dust2_dust2_system_sir_alloc",                  (DL_FUNC) &_dust2_dust2_system_sir_alloc,                   8},
-    {"_dust2_dust2_system_sir_compare_data",           (DL_FUNC) &_dust2_dust2_system_sir_compare_data,            3},
+    {"_dust2_dust2_system_sir_compare_data",           (DL_FUNC) &_dust2_dust2_system_sir_compare_data,            4},
     {"_dust2_dust2_system_sir_reorder",                (DL_FUNC) &_dust2_dust2_system_sir_reorder,                 2},
     {"_dust2_dust2_system_sir_rng_state",              (DL_FUNC) &_dust2_dust2_system_sir_rng_state,               1},
     {"_dust2_dust2_system_sir_run_to_time",            (DL_FUNC) &_dust2_dust2_system_sir_run_to_time,             2},
@@ -491,8 +491,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_dust2_dust2_system_sir_set_state",              (DL_FUNC) &_dust2_dust2_system_sir_set_state,               3},
     {"_dust2_dust2_system_sir_set_state_initial",      (DL_FUNC) &_dust2_dust2_system_sir_set_state_initial,       1},
     {"_dust2_dust2_system_sir_set_time",               (DL_FUNC) &_dust2_dust2_system_sir_set_time,                2},
-    {"_dust2_dust2_system_sir_simulate",               (DL_FUNC) &_dust2_dust2_system_sir_simulate,                4},
-    {"_dust2_dust2_system_sir_state",                  (DL_FUNC) &_dust2_dust2_system_sir_state,                   5},
+    {"_dust2_dust2_system_sir_simulate",               (DL_FUNC) &_dust2_dust2_system_sir_simulate,                5},
+    {"_dust2_dust2_system_sir_state",                  (DL_FUNC) &_dust2_dust2_system_sir_state,                   6},
     {"_dust2_dust2_system_sir_time",                   (DL_FUNC) &_dust2_dust2_system_sir_time,                    1},
     {"_dust2_dust2_system_sir_update_pars",            (DL_FUNC) &_dust2_dust2_system_sir_update_pars,             2},
     {"_dust2_dust2_system_sirode_alloc",               (DL_FUNC) &_dust2_dust2_system_sirode_alloc,                8},
@@ -504,8 +504,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_dust2_dust2_system_sirode_set_state",           (DL_FUNC) &_dust2_dust2_system_sirode_set_state,            3},
     {"_dust2_dust2_system_sirode_set_state_initial",   (DL_FUNC) &_dust2_dust2_system_sirode_set_state_initial,    1},
     {"_dust2_dust2_system_sirode_set_time",            (DL_FUNC) &_dust2_dust2_system_sirode_set_time,             2},
-    {"_dust2_dust2_system_sirode_simulate",            (DL_FUNC) &_dust2_dust2_system_sirode_simulate,             4},
-    {"_dust2_dust2_system_sirode_state",               (DL_FUNC) &_dust2_dust2_system_sirode_state,                5},
+    {"_dust2_dust2_system_sirode_simulate",            (DL_FUNC) &_dust2_dust2_system_sirode_simulate,             5},
+    {"_dust2_dust2_system_sirode_state",               (DL_FUNC) &_dust2_dust2_system_sirode_state,                6},
     {"_dust2_dust2_system_sirode_time",                (DL_FUNC) &_dust2_dust2_system_sirode_time,                 1},
     {"_dust2_dust2_system_sirode_update_pars",         (DL_FUNC) &_dust2_dust2_system_sirode_update_pars,          2},
     {"_dust2_dust2_system_walk_alloc",                 (DL_FUNC) &_dust2_dust2_system_walk_alloc,                  8},
@@ -516,8 +516,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_dust2_dust2_system_walk_set_state",             (DL_FUNC) &_dust2_dust2_system_walk_set_state,              3},
     {"_dust2_dust2_system_walk_set_state_initial",     (DL_FUNC) &_dust2_dust2_system_walk_set_state_initial,      1},
     {"_dust2_dust2_system_walk_set_time",              (DL_FUNC) &_dust2_dust2_system_walk_set_time,               2},
-    {"_dust2_dust2_system_walk_simulate",              (DL_FUNC) &_dust2_dust2_system_walk_simulate,               4},
-    {"_dust2_dust2_system_walk_state",                 (DL_FUNC) &_dust2_dust2_system_walk_state,                  5},
+    {"_dust2_dust2_system_walk_simulate",              (DL_FUNC) &_dust2_dust2_system_walk_simulate,               5},
+    {"_dust2_dust2_system_walk_state",                 (DL_FUNC) &_dust2_dust2_system_walk_state,                  6},
     {"_dust2_dust2_system_walk_time",                  (DL_FUNC) &_dust2_dust2_system_walk_time,                   1},
     {"_dust2_dust2_system_walk_update_pars",           (DL_FUNC) &_dust2_dust2_system_walk_update_pars,            2},
     {"_dust2_dust2_unfilter_sir_alloc",                (DL_FUNC) &_dust2_dust2_unfilter_sir_alloc,                 9},

--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -216,10 +216,10 @@ extern "C" SEXP _dust2_dust2_unfilter_sir_run(SEXP ptr, SEXP r_initial, SEXP sav
   END_CPP11
 }
 // sir.cpp
-SEXP dust2_unfilter_sir_last_history(cpp11::sexp ptr, bool preserve_group_dimension);
-extern "C" SEXP _dust2_dust2_unfilter_sir_last_history(SEXP ptr, SEXP preserve_group_dimension) {
+SEXP dust2_unfilter_sir_last_history(cpp11::sexp ptr, bool preserve_particle_dimension, bool preserve_group_dimension);
+extern "C" SEXP _dust2_dust2_unfilter_sir_last_history(SEXP ptr, SEXP preserve_particle_dimension, SEXP preserve_group_dimension) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust2_unfilter_sir_last_history(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_group_dimension)));
+    return cpp11::as_sexp(dust2_unfilter_sir_last_history(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_particle_dimension), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_group_dimension)));
   END_CPP11
 }
 // sir.cpp
@@ -522,7 +522,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_dust2_dust2_system_walk_update_pars",           (DL_FUNC) &_dust2_dust2_system_walk_update_pars,            2},
     {"_dust2_dust2_unfilter_sir_alloc",                (DL_FUNC) &_dust2_dust2_unfilter_sir_alloc,                 9},
     {"_dust2_dust2_unfilter_sir_last_gradient",        (DL_FUNC) &_dust2_dust2_unfilter_sir_last_gradient,         2},
-    {"_dust2_dust2_unfilter_sir_last_history",         (DL_FUNC) &_dust2_dust2_unfilter_sir_last_history,          2},
+    {"_dust2_dust2_unfilter_sir_last_history",         (DL_FUNC) &_dust2_dust2_unfilter_sir_last_history,          3},
     {"_dust2_dust2_unfilter_sir_run",                  (DL_FUNC) &_dust2_dust2_unfilter_sir_run,                   5},
     {"_dust2_dust2_unfilter_sir_update_pars",          (DL_FUNC) &_dust2_dust2_unfilter_sir_update_pars,           2},
     {"_dust2_test_history",                            (DL_FUNC) &_dust2_test_history,                             4},

--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -181,17 +181,17 @@ extern "C" SEXP _dust2_dust2_system_sir_simulate(SEXP ptr, SEXP r_times, SEXP r_
   END_CPP11
 }
 // sir.cpp
-SEXP dust2_unfilter_sir_alloc(cpp11::list r_pars, cpp11::sexp r_time_start, cpp11::sexp r_time, cpp11::sexp r_dt, cpp11::list r_data, cpp11::sexp r_n_particles, cpp11::sexp r_n_groups, cpp11::sexp r_n_threads, cpp11::sexp r_index);
-extern "C" SEXP _dust2_dust2_unfilter_sir_alloc(SEXP r_pars, SEXP r_time_start, SEXP r_time, SEXP r_dt, SEXP r_data, SEXP r_n_particles, SEXP r_n_groups, SEXP r_n_threads, SEXP r_index) {
+SEXP dust2_unfilter_sir_alloc(cpp11::list r_pars, cpp11::sexp r_time_start, cpp11::sexp r_time, cpp11::sexp r_dt, cpp11::list r_data, cpp11::sexp r_n_particles, cpp11::sexp r_n_groups, cpp11::sexp r_n_threads, cpp11::sexp r_index_state);
+extern "C" SEXP _dust2_dust2_unfilter_sir_alloc(SEXP r_pars, SEXP r_time_start, SEXP r_time, SEXP r_dt, SEXP r_data, SEXP r_n_particles, SEXP r_n_groups, SEXP r_n_threads, SEXP r_index_state) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust2_unfilter_sir_alloc(cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(r_pars), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_time_start), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_time), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_dt), cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(r_data), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_n_particles), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_n_groups), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_n_threads), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index)));
+    return cpp11::as_sexp(dust2_unfilter_sir_alloc(cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(r_pars), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_time_start), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_time), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_dt), cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(r_data), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_n_particles), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_n_groups), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_n_threads), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_state)));
   END_CPP11
 }
 // sir.cpp
-SEXP dust2_filter_sir_alloc(cpp11::list r_pars, cpp11::sexp r_time_start, cpp11::sexp r_time, cpp11::sexp r_dt, cpp11::list r_data, cpp11::sexp r_n_particles, cpp11::sexp r_n_groups, cpp11::sexp r_n_threads, cpp11::sexp r_index, cpp11::sexp r_seed);
-extern "C" SEXP _dust2_dust2_filter_sir_alloc(SEXP r_pars, SEXP r_time_start, SEXP r_time, SEXP r_dt, SEXP r_data, SEXP r_n_particles, SEXP r_n_groups, SEXP r_n_threads, SEXP r_index, SEXP r_seed) {
+SEXP dust2_filter_sir_alloc(cpp11::list r_pars, cpp11::sexp r_time_start, cpp11::sexp r_time, cpp11::sexp r_dt, cpp11::list r_data, cpp11::sexp r_n_particles, cpp11::sexp r_n_groups, cpp11::sexp r_n_threads, cpp11::sexp r_index_state, cpp11::sexp r_seed);
+extern "C" SEXP _dust2_dust2_filter_sir_alloc(SEXP r_pars, SEXP r_time_start, SEXP r_time, SEXP r_dt, SEXP r_data, SEXP r_n_particles, SEXP r_n_groups, SEXP r_n_threads, SEXP r_index_state, SEXP r_seed) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust2_filter_sir_alloc(cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(r_pars), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_time_start), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_time), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_dt), cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(r_data), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_n_particles), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_n_groups), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_n_threads), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_seed)));
+    return cpp11::as_sexp(dust2_filter_sir_alloc(cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(r_pars), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_time_start), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_time), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_dt), cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(r_data), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_n_particles), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_n_groups), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_n_threads), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_state), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_seed)));
   END_CPP11
 }
 // sir.cpp

--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -27,10 +27,10 @@ extern "C" SEXP _dust2_dust2_system_logistic_run_to_time(SEXP ptr, SEXP r_time) 
   END_CPP11
 }
 // logistic.cpp
-SEXP dust2_system_logistic_state(cpp11::sexp ptr, cpp11::sexp r_index_state, cpp11::sexp r_index_particle, cpp11::sexp r_index_group, bool grouped);
-extern "C" SEXP _dust2_dust2_system_logistic_state(SEXP ptr, SEXP r_index_state, SEXP r_index_particle, SEXP r_index_group, SEXP grouped) {
+SEXP dust2_system_logistic_state(cpp11::sexp ptr, cpp11::sexp r_index_state, cpp11::sexp r_index_particle, cpp11::sexp r_index_group, bool preserve_group_dimension);
+extern "C" SEXP _dust2_dust2_system_logistic_state(SEXP ptr, SEXP r_index_state, SEXP r_index_particle, SEXP r_index_group, SEXP preserve_group_dimension) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust2_system_logistic_state(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_state), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_particle), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_group), cpp11::as_cpp<cpp11::decay_t<bool>>(grouped)));
+    return cpp11::as_sexp(dust2_system_logistic_state(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_state), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_particle), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_group), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_group_dimension)));
   END_CPP11
 }
 // logistic.cpp
@@ -48,10 +48,10 @@ extern "C" SEXP _dust2_dust2_system_logistic_set_state_initial(SEXP ptr) {
   END_CPP11
 }
 // logistic.cpp
-SEXP dust2_system_logistic_set_state(cpp11::sexp ptr, cpp11::sexp r_state, bool grouped);
-extern "C" SEXP _dust2_dust2_system_logistic_set_state(SEXP ptr, SEXP r_state, SEXP grouped) {
+SEXP dust2_system_logistic_set_state(cpp11::sexp ptr, cpp11::sexp r_state);
+extern "C" SEXP _dust2_dust2_system_logistic_set_state(SEXP ptr, SEXP r_state) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust2_system_logistic_set_state(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_state), cpp11::as_cpp<cpp11::decay_t<bool>>(grouped)));
+    return cpp11::as_sexp(dust2_system_logistic_set_state(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_state)));
   END_CPP11
 }
 // logistic.cpp
@@ -83,17 +83,17 @@ extern "C" SEXP _dust2_dust2_system_logistic_set_time(SEXP ptr, SEXP r_time) {
   END_CPP11
 }
 // logistic.cpp
-SEXP dust2_system_logistic_update_pars(cpp11::sexp ptr, cpp11::list pars, bool grouped);
-extern "C" SEXP _dust2_dust2_system_logistic_update_pars(SEXP ptr, SEXP pars, SEXP grouped) {
+SEXP dust2_system_logistic_update_pars(cpp11::sexp ptr, cpp11::list pars);
+extern "C" SEXP _dust2_dust2_system_logistic_update_pars(SEXP ptr, SEXP pars) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust2_system_logistic_update_pars(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(pars), cpp11::as_cpp<cpp11::decay_t<bool>>(grouped)));
+    return cpp11::as_sexp(dust2_system_logistic_update_pars(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(pars)));
   END_CPP11
 }
 // logistic.cpp
-SEXP dust2_system_logistic_simulate(cpp11::sexp ptr, cpp11::sexp r_times, cpp11::sexp r_index, bool grouped);
-extern "C" SEXP _dust2_dust2_system_logistic_simulate(SEXP ptr, SEXP r_times, SEXP r_index, SEXP grouped) {
+SEXP dust2_system_logistic_simulate(cpp11::sexp ptr, cpp11::sexp r_times, cpp11::sexp r_index, bool preserve_group_dimension);
+extern "C" SEXP _dust2_dust2_system_logistic_simulate(SEXP ptr, SEXP r_times, SEXP r_index, SEXP preserve_group_dimension) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust2_system_logistic_simulate(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_times), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index), cpp11::as_cpp<cpp11::decay_t<bool>>(grouped)));
+    return cpp11::as_sexp(dust2_system_logistic_simulate(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_times), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_group_dimension)));
   END_CPP11
 }
 // sir.cpp
@@ -111,10 +111,10 @@ extern "C" SEXP _dust2_dust2_system_sir_run_to_time(SEXP ptr, SEXP r_time) {
   END_CPP11
 }
 // sir.cpp
-SEXP dust2_system_sir_state(cpp11::sexp ptr, cpp11::sexp r_index_state, cpp11::sexp r_index_particle, cpp11::sexp r_index_group, bool grouped);
-extern "C" SEXP _dust2_dust2_system_sir_state(SEXP ptr, SEXP r_index_state, SEXP r_index_particle, SEXP r_index_group, SEXP grouped) {
+SEXP dust2_system_sir_state(cpp11::sexp ptr, cpp11::sexp r_index_state, cpp11::sexp r_index_particle, cpp11::sexp r_index_group, bool preserve_group_dimension);
+extern "C" SEXP _dust2_dust2_system_sir_state(SEXP ptr, SEXP r_index_state, SEXP r_index_particle, SEXP r_index_group, SEXP preserve_group_dimension) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust2_system_sir_state(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_state), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_particle), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_group), cpp11::as_cpp<cpp11::decay_t<bool>>(grouped)));
+    return cpp11::as_sexp(dust2_system_sir_state(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_state), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_particle), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_group), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_group_dimension)));
   END_CPP11
 }
 // sir.cpp
@@ -132,10 +132,10 @@ extern "C" SEXP _dust2_dust2_system_sir_set_state_initial(SEXP ptr) {
   END_CPP11
 }
 // sir.cpp
-SEXP dust2_system_sir_set_state(cpp11::sexp ptr, cpp11::sexp r_state, bool grouped);
-extern "C" SEXP _dust2_dust2_system_sir_set_state(SEXP ptr, SEXP r_state, SEXP grouped) {
+SEXP dust2_system_sir_set_state(cpp11::sexp ptr, cpp11::sexp r_state);
+extern "C" SEXP _dust2_dust2_system_sir_set_state(SEXP ptr, SEXP r_state) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust2_system_sir_set_state(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_state), cpp11::as_cpp<cpp11::decay_t<bool>>(grouped)));
+    return cpp11::as_sexp(dust2_system_sir_set_state(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_state)));
   END_CPP11
 }
 // sir.cpp
@@ -167,17 +167,17 @@ extern "C" SEXP _dust2_dust2_system_sir_set_time(SEXP ptr, SEXP r_time) {
   END_CPP11
 }
 // sir.cpp
-SEXP dust2_system_sir_update_pars(cpp11::sexp ptr, cpp11::list pars, bool grouped);
-extern "C" SEXP _dust2_dust2_system_sir_update_pars(SEXP ptr, SEXP pars, SEXP grouped) {
+SEXP dust2_system_sir_update_pars(cpp11::sexp ptr, cpp11::list pars);
+extern "C" SEXP _dust2_dust2_system_sir_update_pars(SEXP ptr, SEXP pars) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust2_system_sir_update_pars(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(pars), cpp11::as_cpp<cpp11::decay_t<bool>>(grouped)));
+    return cpp11::as_sexp(dust2_system_sir_update_pars(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(pars)));
   END_CPP11
 }
 // sir.cpp
-SEXP dust2_system_sir_simulate(cpp11::sexp ptr, cpp11::sexp r_times, cpp11::sexp r_index, bool grouped);
-extern "C" SEXP _dust2_dust2_system_sir_simulate(SEXP ptr, SEXP r_times, SEXP r_index, SEXP grouped) {
+SEXP dust2_system_sir_simulate(cpp11::sexp ptr, cpp11::sexp r_times, cpp11::sexp r_index, bool preserve_group_dimension);
+extern "C" SEXP _dust2_dust2_system_sir_simulate(SEXP ptr, SEXP r_times, SEXP r_index, SEXP preserve_group_dimension) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust2_system_sir_simulate(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_times), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index), cpp11::as_cpp<cpp11::decay_t<bool>>(grouped)));
+    return cpp11::as_sexp(dust2_system_sir_simulate(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_times), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_group_dimension)));
   END_CPP11
 }
 // sir.cpp
@@ -195,52 +195,52 @@ extern "C" SEXP _dust2_dust2_filter_sir_alloc(SEXP r_pars, SEXP r_time_start, SE
   END_CPP11
 }
 // sir.cpp
-SEXP dust2_system_sir_compare_data(cpp11::sexp ptr, cpp11::sexp r_data, bool grouped);
-extern "C" SEXP _dust2_dust2_system_sir_compare_data(SEXP ptr, SEXP r_data, SEXP grouped) {
+SEXP dust2_system_sir_compare_data(cpp11::sexp ptr, cpp11::sexp r_data, bool preserve_group_dimension);
+extern "C" SEXP _dust2_dust2_system_sir_compare_data(SEXP ptr, SEXP r_data, SEXP preserve_group_dimension) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust2_system_sir_compare_data(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_data), cpp11::as_cpp<cpp11::decay_t<bool>>(grouped)));
+    return cpp11::as_sexp(dust2_system_sir_compare_data(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_data), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_group_dimension)));
   END_CPP11
 }
 // sir.cpp
-SEXP dust2_unfilter_sir_update_pars(cpp11::sexp ptr, cpp11::list r_pars, bool grouped);
-extern "C" SEXP _dust2_dust2_unfilter_sir_update_pars(SEXP ptr, SEXP r_pars, SEXP grouped) {
+SEXP dust2_unfilter_sir_update_pars(cpp11::sexp ptr, cpp11::list r_pars);
+extern "C" SEXP _dust2_dust2_unfilter_sir_update_pars(SEXP ptr, SEXP r_pars) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust2_unfilter_sir_update_pars(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(r_pars), cpp11::as_cpp<cpp11::decay_t<bool>>(grouped)));
+    return cpp11::as_sexp(dust2_unfilter_sir_update_pars(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(r_pars)));
   END_CPP11
 }
 // sir.cpp
-SEXP dust2_unfilter_sir_run(cpp11::sexp ptr, cpp11::sexp r_initial, bool save_history, bool adjoint, bool grouped);
-extern "C" SEXP _dust2_dust2_unfilter_sir_run(SEXP ptr, SEXP r_initial, SEXP save_history, SEXP adjoint, SEXP grouped) {
+SEXP dust2_unfilter_sir_run(cpp11::sexp ptr, cpp11::sexp r_initial, bool save_history, bool adjoint, bool preserve_group_dimension);
+extern "C" SEXP _dust2_dust2_unfilter_sir_run(SEXP ptr, SEXP r_initial, SEXP save_history, SEXP adjoint, SEXP preserve_group_dimension) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust2_unfilter_sir_run(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_initial), cpp11::as_cpp<cpp11::decay_t<bool>>(save_history), cpp11::as_cpp<cpp11::decay_t<bool>>(adjoint), cpp11::as_cpp<cpp11::decay_t<bool>>(grouped)));
+    return cpp11::as_sexp(dust2_unfilter_sir_run(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_initial), cpp11::as_cpp<cpp11::decay_t<bool>>(save_history), cpp11::as_cpp<cpp11::decay_t<bool>>(adjoint), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_group_dimension)));
   END_CPP11
 }
 // sir.cpp
-SEXP dust2_unfilter_sir_last_history(cpp11::sexp ptr, bool grouped);
-extern "C" SEXP _dust2_dust2_unfilter_sir_last_history(SEXP ptr, SEXP grouped) {
+SEXP dust2_unfilter_sir_last_history(cpp11::sexp ptr, bool preserve_group_dimension);
+extern "C" SEXP _dust2_dust2_unfilter_sir_last_history(SEXP ptr, SEXP preserve_group_dimension) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust2_unfilter_sir_last_history(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<bool>>(grouped)));
+    return cpp11::as_sexp(dust2_unfilter_sir_last_history(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_group_dimension)));
   END_CPP11
 }
 // sir.cpp
-SEXP dust2_filter_sir_update_pars(cpp11::sexp ptr, cpp11::list r_pars, bool grouped);
-extern "C" SEXP _dust2_dust2_filter_sir_update_pars(SEXP ptr, SEXP r_pars, SEXP grouped) {
+SEXP dust2_filter_sir_update_pars(cpp11::sexp ptr, cpp11::list r_pars);
+extern "C" SEXP _dust2_dust2_filter_sir_update_pars(SEXP ptr, SEXP r_pars) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust2_filter_sir_update_pars(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(r_pars), cpp11::as_cpp<cpp11::decay_t<bool>>(grouped)));
+    return cpp11::as_sexp(dust2_filter_sir_update_pars(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(r_pars)));
   END_CPP11
 }
 // sir.cpp
-SEXP dust2_filter_sir_run(cpp11::sexp ptr, cpp11::sexp r_initial, bool save_history, bool grouped);
-extern "C" SEXP _dust2_dust2_filter_sir_run(SEXP ptr, SEXP r_initial, SEXP save_history, SEXP grouped) {
+SEXP dust2_filter_sir_run(cpp11::sexp ptr, cpp11::sexp r_initial, bool save_history);
+extern "C" SEXP _dust2_dust2_filter_sir_run(SEXP ptr, SEXP r_initial, SEXP save_history) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust2_filter_sir_run(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_initial), cpp11::as_cpp<cpp11::decay_t<bool>>(save_history), cpp11::as_cpp<cpp11::decay_t<bool>>(grouped)));
+    return cpp11::as_sexp(dust2_filter_sir_run(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_initial), cpp11::as_cpp<cpp11::decay_t<bool>>(save_history)));
   END_CPP11
 }
 // sir.cpp
-SEXP dust2_filter_sir_last_history(cpp11::sexp ptr, bool grouped);
-extern "C" SEXP _dust2_dust2_filter_sir_last_history(SEXP ptr, SEXP grouped) {
+SEXP dust2_filter_sir_last_history(cpp11::sexp ptr, bool preserve_group_dimension);
+extern "C" SEXP _dust2_dust2_filter_sir_last_history(SEXP ptr, SEXP preserve_group_dimension) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust2_filter_sir_last_history(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<bool>>(grouped)));
+    return cpp11::as_sexp(dust2_filter_sir_last_history(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_group_dimension)));
   END_CPP11
 }
 // sir.cpp
@@ -286,10 +286,10 @@ extern "C" SEXP _dust2_dust2_system_sirode_run_to_time(SEXP ptr, SEXP r_time) {
   END_CPP11
 }
 // sirode.cpp
-SEXP dust2_system_sirode_state(cpp11::sexp ptr, cpp11::sexp r_index_state, cpp11::sexp r_index_particle, cpp11::sexp r_index_group, bool grouped);
-extern "C" SEXP _dust2_dust2_system_sirode_state(SEXP ptr, SEXP r_index_state, SEXP r_index_particle, SEXP r_index_group, SEXP grouped) {
+SEXP dust2_system_sirode_state(cpp11::sexp ptr, cpp11::sexp r_index_state, cpp11::sexp r_index_particle, cpp11::sexp r_index_group, bool preserve_group_dimension);
+extern "C" SEXP _dust2_dust2_system_sirode_state(SEXP ptr, SEXP r_index_state, SEXP r_index_particle, SEXP r_index_group, SEXP preserve_group_dimension) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust2_system_sirode_state(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_state), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_particle), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_group), cpp11::as_cpp<cpp11::decay_t<bool>>(grouped)));
+    return cpp11::as_sexp(dust2_system_sirode_state(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_state), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_particle), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_group), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_group_dimension)));
   END_CPP11
 }
 // sirode.cpp
@@ -307,10 +307,10 @@ extern "C" SEXP _dust2_dust2_system_sirode_set_state_initial(SEXP ptr) {
   END_CPP11
 }
 // sirode.cpp
-SEXP dust2_system_sirode_set_state(cpp11::sexp ptr, cpp11::sexp r_state, bool grouped);
-extern "C" SEXP _dust2_dust2_system_sirode_set_state(SEXP ptr, SEXP r_state, SEXP grouped) {
+SEXP dust2_system_sirode_set_state(cpp11::sexp ptr, cpp11::sexp r_state);
+extern "C" SEXP _dust2_dust2_system_sirode_set_state(SEXP ptr, SEXP r_state) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust2_system_sirode_set_state(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_state), cpp11::as_cpp<cpp11::decay_t<bool>>(grouped)));
+    return cpp11::as_sexp(dust2_system_sirode_set_state(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_state)));
   END_CPP11
 }
 // sirode.cpp
@@ -342,17 +342,17 @@ extern "C" SEXP _dust2_dust2_system_sirode_set_time(SEXP ptr, SEXP r_time) {
   END_CPP11
 }
 // sirode.cpp
-SEXP dust2_system_sirode_update_pars(cpp11::sexp ptr, cpp11::list pars, bool grouped);
-extern "C" SEXP _dust2_dust2_system_sirode_update_pars(SEXP ptr, SEXP pars, SEXP grouped) {
+SEXP dust2_system_sirode_update_pars(cpp11::sexp ptr, cpp11::list pars);
+extern "C" SEXP _dust2_dust2_system_sirode_update_pars(SEXP ptr, SEXP pars) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust2_system_sirode_update_pars(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(pars), cpp11::as_cpp<cpp11::decay_t<bool>>(grouped)));
+    return cpp11::as_sexp(dust2_system_sirode_update_pars(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(pars)));
   END_CPP11
 }
 // sirode.cpp
-SEXP dust2_system_sirode_simulate(cpp11::sexp ptr, cpp11::sexp r_times, cpp11::sexp r_index, bool grouped);
-extern "C" SEXP _dust2_dust2_system_sirode_simulate(SEXP ptr, SEXP r_times, SEXP r_index, SEXP grouped) {
+SEXP dust2_system_sirode_simulate(cpp11::sexp ptr, cpp11::sexp r_times, cpp11::sexp r_index, bool preserve_group_dimension);
+extern "C" SEXP _dust2_dust2_system_sirode_simulate(SEXP ptr, SEXP r_times, SEXP r_index, SEXP preserve_group_dimension) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust2_system_sirode_simulate(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_times), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index), cpp11::as_cpp<cpp11::decay_t<bool>>(grouped)));
+    return cpp11::as_sexp(dust2_system_sirode_simulate(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_times), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_group_dimension)));
   END_CPP11
 }
 // test.cpp
@@ -391,10 +391,10 @@ extern "C" SEXP _dust2_dust2_system_walk_run_to_time(SEXP ptr, SEXP r_time) {
   END_CPP11
 }
 // walk.cpp
-SEXP dust2_system_walk_state(cpp11::sexp ptr, cpp11::sexp r_index_state, cpp11::sexp r_index_particle, cpp11::sexp r_index_group, bool grouped);
-extern "C" SEXP _dust2_dust2_system_walk_state(SEXP ptr, SEXP r_index_state, SEXP r_index_particle, SEXP r_index_group, SEXP grouped) {
+SEXP dust2_system_walk_state(cpp11::sexp ptr, cpp11::sexp r_index_state, cpp11::sexp r_index_particle, cpp11::sexp r_index_group, bool preserve_group_dimension);
+extern "C" SEXP _dust2_dust2_system_walk_state(SEXP ptr, SEXP r_index_state, SEXP r_index_particle, SEXP r_index_group, SEXP preserve_group_dimension) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust2_system_walk_state(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_state), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_particle), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_group), cpp11::as_cpp<cpp11::decay_t<bool>>(grouped)));
+    return cpp11::as_sexp(dust2_system_walk_state(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_state), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_particle), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_group), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_group_dimension)));
   END_CPP11
 }
 // walk.cpp
@@ -412,10 +412,10 @@ extern "C" SEXP _dust2_dust2_system_walk_set_state_initial(SEXP ptr) {
   END_CPP11
 }
 // walk.cpp
-SEXP dust2_system_walk_set_state(cpp11::sexp ptr, cpp11::sexp r_state, bool grouped);
-extern "C" SEXP _dust2_dust2_system_walk_set_state(SEXP ptr, SEXP r_state, SEXP grouped) {
+SEXP dust2_system_walk_set_state(cpp11::sexp ptr, cpp11::sexp r_state);
+extern "C" SEXP _dust2_dust2_system_walk_set_state(SEXP ptr, SEXP r_state) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust2_system_walk_set_state(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_state), cpp11::as_cpp<cpp11::decay_t<bool>>(grouped)));
+    return cpp11::as_sexp(dust2_system_walk_set_state(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_state)));
   END_CPP11
 }
 // walk.cpp
@@ -447,17 +447,17 @@ extern "C" SEXP _dust2_dust2_system_walk_set_time(SEXP ptr, SEXP r_time) {
   END_CPP11
 }
 // walk.cpp
-SEXP dust2_system_walk_update_pars(cpp11::sexp ptr, cpp11::list pars, bool grouped);
-extern "C" SEXP _dust2_dust2_system_walk_update_pars(SEXP ptr, SEXP pars, SEXP grouped) {
+SEXP dust2_system_walk_update_pars(cpp11::sexp ptr, cpp11::list pars);
+extern "C" SEXP _dust2_dust2_system_walk_update_pars(SEXP ptr, SEXP pars) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust2_system_walk_update_pars(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(pars), cpp11::as_cpp<cpp11::decay_t<bool>>(grouped)));
+    return cpp11::as_sexp(dust2_system_walk_update_pars(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(pars)));
   END_CPP11
 }
 // walk.cpp
-SEXP dust2_system_walk_simulate(cpp11::sexp ptr, cpp11::sexp r_times, cpp11::sexp r_index, bool grouped);
-extern "C" SEXP _dust2_dust2_system_walk_simulate(SEXP ptr, SEXP r_times, SEXP r_index, SEXP grouped) {
+SEXP dust2_system_walk_simulate(cpp11::sexp ptr, cpp11::sexp r_times, cpp11::sexp r_index, bool preserve_group_dimension);
+extern "C" SEXP _dust2_dust2_system_walk_simulate(SEXP ptr, SEXP r_times, SEXP r_index, SEXP preserve_group_dimension) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust2_system_walk_simulate(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_times), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index), cpp11::as_cpp<cpp11::decay_t<bool>>(grouped)));
+    return cpp11::as_sexp(dust2_system_walk_simulate(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_times), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_group_dimension)));
   END_CPP11
 }
 
@@ -466,65 +466,65 @@ static const R_CallMethodDef CallEntries[] = {
     {"_dust2_dust2_filter_sir_alloc",                  (DL_FUNC) &_dust2_dust2_filter_sir_alloc,                  10},
     {"_dust2_dust2_filter_sir_last_history",           (DL_FUNC) &_dust2_dust2_filter_sir_last_history,            2},
     {"_dust2_dust2_filter_sir_rng_state",              (DL_FUNC) &_dust2_dust2_filter_sir_rng_state,               1},
-    {"_dust2_dust2_filter_sir_run",                    (DL_FUNC) &_dust2_dust2_filter_sir_run,                     4},
+    {"_dust2_dust2_filter_sir_run",                    (DL_FUNC) &_dust2_dust2_filter_sir_run,                     3},
     {"_dust2_dust2_filter_sir_set_rng_state",          (DL_FUNC) &_dust2_dust2_filter_sir_set_rng_state,           2},
-    {"_dust2_dust2_filter_sir_update_pars",            (DL_FUNC) &_dust2_dust2_filter_sir_update_pars,             3},
+    {"_dust2_dust2_filter_sir_update_pars",            (DL_FUNC) &_dust2_dust2_filter_sir_update_pars,             2},
     {"_dust2_dust2_system_logistic_alloc",             (DL_FUNC) &_dust2_dust2_system_logistic_alloc,              8},
     {"_dust2_dust2_system_logistic_internals",         (DL_FUNC) &_dust2_dust2_system_logistic_internals,          2},
     {"_dust2_dust2_system_logistic_reorder",           (DL_FUNC) &_dust2_dust2_system_logistic_reorder,            2},
     {"_dust2_dust2_system_logistic_rng_state",         (DL_FUNC) &_dust2_dust2_system_logistic_rng_state,          1},
     {"_dust2_dust2_system_logistic_run_to_time",       (DL_FUNC) &_dust2_dust2_system_logistic_run_to_time,        2},
     {"_dust2_dust2_system_logistic_set_rng_state",     (DL_FUNC) &_dust2_dust2_system_logistic_set_rng_state,      2},
-    {"_dust2_dust2_system_logistic_set_state",         (DL_FUNC) &_dust2_dust2_system_logistic_set_state,          3},
+    {"_dust2_dust2_system_logistic_set_state",         (DL_FUNC) &_dust2_dust2_system_logistic_set_state,          2},
     {"_dust2_dust2_system_logistic_set_state_initial", (DL_FUNC) &_dust2_dust2_system_logistic_set_state_initial,  1},
     {"_dust2_dust2_system_logistic_set_time",          (DL_FUNC) &_dust2_dust2_system_logistic_set_time,           2},
     {"_dust2_dust2_system_logistic_simulate",          (DL_FUNC) &_dust2_dust2_system_logistic_simulate,           4},
     {"_dust2_dust2_system_logistic_state",             (DL_FUNC) &_dust2_dust2_system_logistic_state,              5},
     {"_dust2_dust2_system_logistic_time",              (DL_FUNC) &_dust2_dust2_system_logistic_time,               1},
-    {"_dust2_dust2_system_logistic_update_pars",       (DL_FUNC) &_dust2_dust2_system_logistic_update_pars,        3},
+    {"_dust2_dust2_system_logistic_update_pars",       (DL_FUNC) &_dust2_dust2_system_logistic_update_pars,        2},
     {"_dust2_dust2_system_sir_alloc",                  (DL_FUNC) &_dust2_dust2_system_sir_alloc,                   8},
     {"_dust2_dust2_system_sir_compare_data",           (DL_FUNC) &_dust2_dust2_system_sir_compare_data,            3},
     {"_dust2_dust2_system_sir_reorder",                (DL_FUNC) &_dust2_dust2_system_sir_reorder,                 2},
     {"_dust2_dust2_system_sir_rng_state",              (DL_FUNC) &_dust2_dust2_system_sir_rng_state,               1},
     {"_dust2_dust2_system_sir_run_to_time",            (DL_FUNC) &_dust2_dust2_system_sir_run_to_time,             2},
     {"_dust2_dust2_system_sir_set_rng_state",          (DL_FUNC) &_dust2_dust2_system_sir_set_rng_state,           2},
-    {"_dust2_dust2_system_sir_set_state",              (DL_FUNC) &_dust2_dust2_system_sir_set_state,               3},
+    {"_dust2_dust2_system_sir_set_state",              (DL_FUNC) &_dust2_dust2_system_sir_set_state,               2},
     {"_dust2_dust2_system_sir_set_state_initial",      (DL_FUNC) &_dust2_dust2_system_sir_set_state_initial,       1},
     {"_dust2_dust2_system_sir_set_time",               (DL_FUNC) &_dust2_dust2_system_sir_set_time,                2},
     {"_dust2_dust2_system_sir_simulate",               (DL_FUNC) &_dust2_dust2_system_sir_simulate,                4},
     {"_dust2_dust2_system_sir_state",                  (DL_FUNC) &_dust2_dust2_system_sir_state,                   5},
     {"_dust2_dust2_system_sir_time",                   (DL_FUNC) &_dust2_dust2_system_sir_time,                    1},
-    {"_dust2_dust2_system_sir_update_pars",            (DL_FUNC) &_dust2_dust2_system_sir_update_pars,             3},
+    {"_dust2_dust2_system_sir_update_pars",            (DL_FUNC) &_dust2_dust2_system_sir_update_pars,             2},
     {"_dust2_dust2_system_sirode_alloc",               (DL_FUNC) &_dust2_dust2_system_sirode_alloc,                8},
     {"_dust2_dust2_system_sirode_internals",           (DL_FUNC) &_dust2_dust2_system_sirode_internals,            2},
     {"_dust2_dust2_system_sirode_reorder",             (DL_FUNC) &_dust2_dust2_system_sirode_reorder,              2},
     {"_dust2_dust2_system_sirode_rng_state",           (DL_FUNC) &_dust2_dust2_system_sirode_rng_state,            1},
     {"_dust2_dust2_system_sirode_run_to_time",         (DL_FUNC) &_dust2_dust2_system_sirode_run_to_time,          2},
     {"_dust2_dust2_system_sirode_set_rng_state",       (DL_FUNC) &_dust2_dust2_system_sirode_set_rng_state,        2},
-    {"_dust2_dust2_system_sirode_set_state",           (DL_FUNC) &_dust2_dust2_system_sirode_set_state,            3},
+    {"_dust2_dust2_system_sirode_set_state",           (DL_FUNC) &_dust2_dust2_system_sirode_set_state,            2},
     {"_dust2_dust2_system_sirode_set_state_initial",   (DL_FUNC) &_dust2_dust2_system_sirode_set_state_initial,    1},
     {"_dust2_dust2_system_sirode_set_time",            (DL_FUNC) &_dust2_dust2_system_sirode_set_time,             2},
     {"_dust2_dust2_system_sirode_simulate",            (DL_FUNC) &_dust2_dust2_system_sirode_simulate,             4},
     {"_dust2_dust2_system_sirode_state",               (DL_FUNC) &_dust2_dust2_system_sirode_state,                5},
     {"_dust2_dust2_system_sirode_time",                (DL_FUNC) &_dust2_dust2_system_sirode_time,                 1},
-    {"_dust2_dust2_system_sirode_update_pars",         (DL_FUNC) &_dust2_dust2_system_sirode_update_pars,          3},
+    {"_dust2_dust2_system_sirode_update_pars",         (DL_FUNC) &_dust2_dust2_system_sirode_update_pars,          2},
     {"_dust2_dust2_system_walk_alloc",                 (DL_FUNC) &_dust2_dust2_system_walk_alloc,                  8},
     {"_dust2_dust2_system_walk_reorder",               (DL_FUNC) &_dust2_dust2_system_walk_reorder,                2},
     {"_dust2_dust2_system_walk_rng_state",             (DL_FUNC) &_dust2_dust2_system_walk_rng_state,              1},
     {"_dust2_dust2_system_walk_run_to_time",           (DL_FUNC) &_dust2_dust2_system_walk_run_to_time,            2},
     {"_dust2_dust2_system_walk_set_rng_state",         (DL_FUNC) &_dust2_dust2_system_walk_set_rng_state,          2},
-    {"_dust2_dust2_system_walk_set_state",             (DL_FUNC) &_dust2_dust2_system_walk_set_state,              3},
+    {"_dust2_dust2_system_walk_set_state",             (DL_FUNC) &_dust2_dust2_system_walk_set_state,              2},
     {"_dust2_dust2_system_walk_set_state_initial",     (DL_FUNC) &_dust2_dust2_system_walk_set_state_initial,      1},
     {"_dust2_dust2_system_walk_set_time",              (DL_FUNC) &_dust2_dust2_system_walk_set_time,               2},
     {"_dust2_dust2_system_walk_simulate",              (DL_FUNC) &_dust2_dust2_system_walk_simulate,               4},
     {"_dust2_dust2_system_walk_state",                 (DL_FUNC) &_dust2_dust2_system_walk_state,                  5},
     {"_dust2_dust2_system_walk_time",                  (DL_FUNC) &_dust2_dust2_system_walk_time,                   1},
-    {"_dust2_dust2_system_walk_update_pars",           (DL_FUNC) &_dust2_dust2_system_walk_update_pars,            3},
+    {"_dust2_dust2_system_walk_update_pars",           (DL_FUNC) &_dust2_dust2_system_walk_update_pars,            2},
     {"_dust2_dust2_unfilter_sir_alloc",                (DL_FUNC) &_dust2_dust2_unfilter_sir_alloc,                 9},
     {"_dust2_dust2_unfilter_sir_last_gradient",        (DL_FUNC) &_dust2_dust2_unfilter_sir_last_gradient,         2},
     {"_dust2_dust2_unfilter_sir_last_history",         (DL_FUNC) &_dust2_dust2_unfilter_sir_last_history,          2},
     {"_dust2_dust2_unfilter_sir_run",                  (DL_FUNC) &_dust2_dust2_unfilter_sir_run,                   5},
-    {"_dust2_dust2_unfilter_sir_update_pars",          (DL_FUNC) &_dust2_dust2_unfilter_sir_update_pars,           3},
+    {"_dust2_dust2_unfilter_sir_update_pars",          (DL_FUNC) &_dust2_dust2_unfilter_sir_update_pars,           2},
     {"_dust2_test_history",                            (DL_FUNC) &_dust2_test_history,                             4},
     {"_dust2_test_resample_weight",                    (DL_FUNC) &_dust2_test_resample_weight,                     2},
     {"_dust2_test_scale_log_weights",                  (DL_FUNC) &_dust2_test_scale_log_weights,                   1},

--- a/src/logistic.cpp
+++ b/src/logistic.cpp
@@ -107,8 +107,8 @@ SEXP dust2_system_logistic_run_to_time(cpp11::sexp ptr, cpp11::sexp r_time) {
 }
 
 [[cpp11::register]]
-SEXP dust2_system_logistic_state(cpp11::sexp ptr, cpp11::sexp r_index_state, cpp11::sexp r_index_particle, cpp11::sexp r_index_group, bool preserve_group_dimension) {
-  return dust2::r::dust2_system_state<dust2::dust_continuous<logistic>>(ptr, r_index_state, r_index_particle, r_index_group, preserve_group_dimension);
+SEXP dust2_system_logistic_state(cpp11::sexp ptr, cpp11::sexp r_index_state, cpp11::sexp r_index_particle, cpp11::sexp r_index_group, bool preserve_particle_dimension, bool preserve_group_dimension) {
+  return dust2::r::dust2_system_state<dust2::dust_continuous<logistic>>(ptr, r_index_state, r_index_particle, r_index_group, preserve_particle_dimension, preserve_group_dimension);
 }
 
 [[cpp11::register]]
@@ -152,6 +152,6 @@ SEXP dust2_system_logistic_update_pars(cpp11::sexp ptr, cpp11::list pars) {
 }
 
 [[cpp11::register]]
-SEXP dust2_system_logistic_simulate(cpp11::sexp ptr, cpp11::sexp r_times, cpp11::sexp r_index, bool preserve_group_dimension) {
-  return dust2::r::dust2_system_simulate<dust2::dust_continuous<logistic>>(ptr, r_times, r_index, preserve_group_dimension);
+SEXP dust2_system_logistic_simulate(cpp11::sexp ptr, cpp11::sexp r_times, cpp11::sexp r_index, bool preserve_particle_dimension, bool preserve_group_dimension) {
+  return dust2::r::dust2_system_simulate<dust2::dust_continuous<logistic>>(ptr, r_times, r_index, preserve_particle_dimension, preserve_group_dimension);
 }

--- a/src/logistic.cpp
+++ b/src/logistic.cpp
@@ -122,8 +122,8 @@ SEXP dust2_system_logistic_set_state_initial(cpp11::sexp ptr) {
 }
 
 [[cpp11::register]]
-SEXP dust2_system_logistic_set_state(cpp11::sexp ptr, cpp11::sexp r_state) {
-  return dust2::r::dust2_system_set_state<dust2::dust_continuous<logistic>>(ptr, r_state);
+SEXP dust2_system_logistic_set_state(cpp11::sexp ptr, cpp11::sexp r_state, bool preserve_group_dimension) {
+  return dust2::r::dust2_system_set_state<dust2::dust_continuous<logistic>>(ptr, r_state, preserve_group_dimension);
 }
 
 [[cpp11::register]]

--- a/src/logistic.cpp
+++ b/src/logistic.cpp
@@ -107,8 +107,8 @@ SEXP dust2_system_logistic_run_to_time(cpp11::sexp ptr, cpp11::sexp r_time) {
 }
 
 [[cpp11::register]]
-SEXP dust2_system_logistic_state(cpp11::sexp ptr, cpp11::sexp r_index_state, cpp11::sexp r_index_particle, cpp11::sexp r_index_group, bool grouped) {
-  return dust2::r::dust2_system_state<dust2::dust_continuous<logistic>>(ptr, r_index_state, r_index_particle, r_index_group, grouped);
+SEXP dust2_system_logistic_state(cpp11::sexp ptr, cpp11::sexp r_index_state, cpp11::sexp r_index_particle, cpp11::sexp r_index_group, bool preserve_group_dimension) {
+  return dust2::r::dust2_system_state<dust2::dust_continuous<logistic>>(ptr, r_index_state, r_index_particle, r_index_group, preserve_group_dimension);
 }
 
 [[cpp11::register]]
@@ -122,8 +122,8 @@ SEXP dust2_system_logistic_set_state_initial(cpp11::sexp ptr) {
 }
 
 [[cpp11::register]]
-SEXP dust2_system_logistic_set_state(cpp11::sexp ptr, cpp11::sexp r_state, bool grouped) {
-  return dust2::r::dust2_system_set_state<dust2::dust_continuous<logistic>>(ptr, r_state, grouped);
+SEXP dust2_system_logistic_set_state(cpp11::sexp ptr, cpp11::sexp r_state) {
+  return dust2::r::dust2_system_set_state<dust2::dust_continuous<logistic>>(ptr, r_state);
 }
 
 [[cpp11::register]]
@@ -147,11 +147,11 @@ SEXP dust2_system_logistic_set_time(cpp11::sexp ptr, cpp11::sexp r_time) {
 }
 
 [[cpp11::register]]
-SEXP dust2_system_logistic_update_pars(cpp11::sexp ptr, cpp11::list pars, bool grouped) {
-  return dust2::r::dust2_system_update_pars<dust2::dust_continuous<logistic>>(ptr, pars, grouped);
+SEXP dust2_system_logistic_update_pars(cpp11::sexp ptr, cpp11::list pars) {
+  return dust2::r::dust2_system_update_pars<dust2::dust_continuous<logistic>>(ptr, pars);
 }
 
 [[cpp11::register]]
-SEXP dust2_system_logistic_simulate(cpp11::sexp ptr, cpp11::sexp r_times, cpp11::sexp r_index, bool grouped) {
-  return dust2::r::dust2_system_simulate<dust2::dust_continuous<logistic>>(ptr, r_times, r_index, grouped);
+SEXP dust2_system_logistic_simulate(cpp11::sexp ptr, cpp11::sexp r_times, cpp11::sexp r_index, bool preserve_group_dimension) {
+  return dust2::r::dust2_system_simulate<dust2::dust_continuous<logistic>>(ptr, r_times, r_index, preserve_group_dimension);
 }

--- a/src/sir.cpp
+++ b/src/sir.cpp
@@ -274,13 +274,13 @@ SEXP dust2_system_sir_simulate(cpp11::sexp ptr, cpp11::sexp r_times, cpp11::sexp
 }
 
 [[cpp11::register]]
-SEXP dust2_unfilter_sir_alloc(cpp11::list r_pars, cpp11::sexp r_time_start, cpp11::sexp r_time, cpp11::sexp r_dt, cpp11::list r_data, cpp11::sexp r_n_particles, cpp11::sexp r_n_groups, cpp11::sexp r_n_threads, cpp11::sexp r_index) {
-  return dust2::r::dust2_discrete_unfilter_alloc<sir>(r_pars, r_time_start, r_time, r_dt, r_data, r_n_particles, r_n_groups, r_n_threads, r_index);
+SEXP dust2_unfilter_sir_alloc(cpp11::list r_pars, cpp11::sexp r_time_start, cpp11::sexp r_time, cpp11::sexp r_dt, cpp11::list r_data, cpp11::sexp r_n_particles, cpp11::sexp r_n_groups, cpp11::sexp r_n_threads, cpp11::sexp r_index_state) {
+  return dust2::r::dust2_discrete_unfilter_alloc<sir>(r_pars, r_time_start, r_time, r_dt, r_data, r_n_particles, r_n_groups, r_n_threads, r_index_state);
 }
 
 [[cpp11::register]]
-SEXP dust2_filter_sir_alloc(cpp11::list r_pars, cpp11::sexp r_time_start, cpp11::sexp r_time, cpp11::sexp r_dt, cpp11::list r_data, cpp11::sexp r_n_particles, cpp11::sexp r_n_groups, cpp11::sexp r_n_threads, cpp11::sexp r_index, cpp11::sexp r_seed) {
-  return dust2::r::dust2_discrete_filter_alloc<sir>(r_pars, r_time_start, r_time, r_dt, r_data, r_n_particles, r_n_groups, r_n_threads, r_index, r_seed);
+SEXP dust2_filter_sir_alloc(cpp11::list r_pars, cpp11::sexp r_time_start, cpp11::sexp r_time, cpp11::sexp r_dt, cpp11::list r_data, cpp11::sexp r_n_particles, cpp11::sexp r_n_groups, cpp11::sexp r_n_threads, cpp11::sexp r_index_state, cpp11::sexp r_seed) {
+  return dust2::r::dust2_discrete_filter_alloc<sir>(r_pars, r_time_start, r_time, r_dt, r_data, r_n_particles, r_n_groups, r_n_threads, r_index_state, r_seed);
 }
 [[cpp11::register]]
 SEXP dust2_system_sir_compare_data(cpp11::sexp ptr, cpp11::list r_data, bool preserve_particle_dimension, bool preserve_group_dimension) {

--- a/src/sir.cpp
+++ b/src/sir.cpp
@@ -239,8 +239,8 @@ SEXP dust2_system_sir_set_state_initial(cpp11::sexp ptr) {
 }
 
 [[cpp11::register]]
-SEXP dust2_system_sir_set_state(cpp11::sexp ptr, cpp11::sexp r_state) {
-  return dust2::r::dust2_system_set_state<dust2::dust_discrete<sir>>(ptr, r_state);
+SEXP dust2_system_sir_set_state(cpp11::sexp ptr, cpp11::sexp r_state, bool preserve_group_dimension) {
+  return dust2::r::dust2_system_set_state<dust2::dust_discrete<sir>>(ptr, r_state, preserve_group_dimension);
 }
 
 [[cpp11::register]]
@@ -308,8 +308,8 @@ SEXP dust2_filter_sir_update_pars(cpp11::sexp ptr, cpp11::list r_pars) {
 }
 
 [[cpp11::register]]
-SEXP dust2_filter_sir_run(cpp11::sexp ptr, cpp11::sexp r_initial, bool save_history) {
-  return dust2::r::dust2_filter_run<dust2::dust_discrete<sir>>(ptr, r_initial, save_history);
+SEXP dust2_filter_sir_run(cpp11::sexp ptr, cpp11::sexp r_initial, bool save_history, bool preserve_group_dimension) {
+  return dust2::r::dust2_filter_run<dust2::dust_discrete<sir>>(ptr, r_initial, save_history, preserve_group_dimension);
 }
 
 [[cpp11::register]]

--- a/src/sir.cpp
+++ b/src/sir.cpp
@@ -293,8 +293,8 @@ SEXP dust2_unfilter_sir_update_pars(cpp11::sexp ptr, cpp11::list r_pars) {
 }
 
 [[cpp11::register]]
-SEXP dust2_unfilter_sir_run(cpp11::sexp ptr, cpp11::sexp r_initial, bool save_history, bool adjoint, bool preserve_group_dimension) {
-  return dust2::r::dust2_unfilter_run<dust2::dust_discrete<sir>>(ptr, r_initial, save_history, adjoint, preserve_group_dimension);
+SEXP dust2_unfilter_sir_run(cpp11::sexp ptr, cpp11::sexp r_initial, bool save_history, bool adjoint, bool preserve_particle_dimension, bool preserve_group_dimension) {
+  return dust2::r::dust2_unfilter_run<dust2::dust_discrete<sir>>(ptr, r_initial, save_history, adjoint, preserve_particle_dimension, preserve_group_dimension);
 }
 
 [[cpp11::register]]

--- a/src/sir.cpp
+++ b/src/sir.cpp
@@ -224,8 +224,8 @@ SEXP dust2_system_sir_run_to_time(cpp11::sexp ptr, cpp11::sexp r_time) {
 }
 
 [[cpp11::register]]
-SEXP dust2_system_sir_state(cpp11::sexp ptr, cpp11::sexp r_index_state, cpp11::sexp r_index_particle, cpp11::sexp r_index_group, bool preserve_group_dimension) {
-  return dust2::r::dust2_system_state<dust2::dust_discrete<sir>>(ptr, r_index_state, r_index_particle, r_index_group, preserve_group_dimension);
+SEXP dust2_system_sir_state(cpp11::sexp ptr, cpp11::sexp r_index_state, cpp11::sexp r_index_particle, cpp11::sexp r_index_group, bool preserve_particle_dimension, bool preserve_group_dimension) {
+  return dust2::r::dust2_system_state<dust2::dust_discrete<sir>>(ptr, r_index_state, r_index_particle, r_index_group, preserve_particle_dimension, preserve_group_dimension);
 }
 
 [[cpp11::register]]
@@ -269,8 +269,8 @@ SEXP dust2_system_sir_update_pars(cpp11::sexp ptr, cpp11::list pars) {
 }
 
 [[cpp11::register]]
-SEXP dust2_system_sir_simulate(cpp11::sexp ptr, cpp11::sexp r_times, cpp11::sexp r_index, bool preserve_group_dimension) {
-  return dust2::r::dust2_system_simulate<dust2::dust_discrete<sir>>(ptr, r_times, r_index, preserve_group_dimension);
+SEXP dust2_system_sir_simulate(cpp11::sexp ptr, cpp11::sexp r_times, cpp11::sexp r_index, bool preserve_particle_dimension, bool preserve_group_dimension) {
+  return dust2::r::dust2_system_simulate<dust2::dust_discrete<sir>>(ptr, r_times, r_index, preserve_particle_dimension, preserve_group_dimension);
 }
 
 [[cpp11::register]]
@@ -283,8 +283,8 @@ SEXP dust2_filter_sir_alloc(cpp11::list r_pars, cpp11::sexp r_time_start, cpp11:
   return dust2::r::dust2_discrete_filter_alloc<sir>(r_pars, r_time_start, r_time, r_dt, r_data, r_n_particles, r_n_groups, r_n_threads, r_index, r_seed);
 }
 [[cpp11::register]]
-SEXP dust2_system_sir_compare_data(cpp11::sexp ptr, cpp11::sexp r_data, bool preserve_group_dimension) {
-  return dust2::r::dust2_system_compare_data<dust2::dust_discrete<sir>>(ptr, r_data, preserve_group_dimension);
+SEXP dust2_system_sir_compare_data(cpp11::sexp ptr, cpp11::list r_data, bool preserve_particle_dimension, bool preserve_group_dimension) {
+  return dust2::r::dust2_system_compare_data<dust2::dust_discrete<sir>>(ptr, r_data, preserve_particle_dimension, preserve_group_dimension);
 }
 
 [[cpp11::register]]

--- a/src/sir.cpp
+++ b/src/sir.cpp
@@ -298,8 +298,8 @@ SEXP dust2_unfilter_sir_run(cpp11::sexp ptr, cpp11::sexp r_initial, bool save_hi
 }
 
 [[cpp11::register]]
-SEXP dust2_unfilter_sir_last_history(cpp11::sexp ptr, bool preserve_group_dimension) {
-  return dust2::r::dust2_unfilter_last_history<dust2::dust_discrete<sir>>(ptr, preserve_group_dimension);
+SEXP dust2_unfilter_sir_last_history(cpp11::sexp ptr, bool preserve_particle_dimension, bool preserve_group_dimension) {
+  return dust2::r::dust2_unfilter_last_history<dust2::dust_discrete<sir>>(ptr, preserve_particle_dimension, preserve_group_dimension);
 }
 
 [[cpp11::register]]

--- a/src/sir.cpp
+++ b/src/sir.cpp
@@ -224,8 +224,8 @@ SEXP dust2_system_sir_run_to_time(cpp11::sexp ptr, cpp11::sexp r_time) {
 }
 
 [[cpp11::register]]
-SEXP dust2_system_sir_state(cpp11::sexp ptr, cpp11::sexp r_index_state, cpp11::sexp r_index_particle, cpp11::sexp r_index_group, bool grouped) {
-  return dust2::r::dust2_system_state<dust2::dust_discrete<sir>>(ptr, r_index_state, r_index_particle, r_index_group, grouped);
+SEXP dust2_system_sir_state(cpp11::sexp ptr, cpp11::sexp r_index_state, cpp11::sexp r_index_particle, cpp11::sexp r_index_group, bool preserve_group_dimension) {
+  return dust2::r::dust2_system_state<dust2::dust_discrete<sir>>(ptr, r_index_state, r_index_particle, r_index_group, preserve_group_dimension);
 }
 
 [[cpp11::register]]
@@ -239,8 +239,8 @@ SEXP dust2_system_sir_set_state_initial(cpp11::sexp ptr) {
 }
 
 [[cpp11::register]]
-SEXP dust2_system_sir_set_state(cpp11::sexp ptr, cpp11::sexp r_state, bool grouped) {
-  return dust2::r::dust2_system_set_state<dust2::dust_discrete<sir>>(ptr, r_state, grouped);
+SEXP dust2_system_sir_set_state(cpp11::sexp ptr, cpp11::sexp r_state) {
+  return dust2::r::dust2_system_set_state<dust2::dust_discrete<sir>>(ptr, r_state);
 }
 
 [[cpp11::register]]
@@ -264,13 +264,13 @@ SEXP dust2_system_sir_set_time(cpp11::sexp ptr, cpp11::sexp r_time) {
 }
 
 [[cpp11::register]]
-SEXP dust2_system_sir_update_pars(cpp11::sexp ptr, cpp11::list pars, bool grouped) {
-  return dust2::r::dust2_system_update_pars<dust2::dust_discrete<sir>>(ptr, pars, grouped);
+SEXP dust2_system_sir_update_pars(cpp11::sexp ptr, cpp11::list pars) {
+  return dust2::r::dust2_system_update_pars<dust2::dust_discrete<sir>>(ptr, pars);
 }
 
 [[cpp11::register]]
-SEXP dust2_system_sir_simulate(cpp11::sexp ptr, cpp11::sexp r_times, cpp11::sexp r_index, bool grouped) {
-  return dust2::r::dust2_system_simulate<dust2::dust_discrete<sir>>(ptr, r_times, r_index, grouped);
+SEXP dust2_system_sir_simulate(cpp11::sexp ptr, cpp11::sexp r_times, cpp11::sexp r_index, bool preserve_group_dimension) {
+  return dust2::r::dust2_system_simulate<dust2::dust_discrete<sir>>(ptr, r_times, r_index, preserve_group_dimension);
 }
 
 [[cpp11::register]]
@@ -283,38 +283,38 @@ SEXP dust2_filter_sir_alloc(cpp11::list r_pars, cpp11::sexp r_time_start, cpp11:
   return dust2::r::dust2_discrete_filter_alloc<sir>(r_pars, r_time_start, r_time, r_dt, r_data, r_n_particles, r_n_groups, r_n_threads, r_index, r_seed);
 }
 [[cpp11::register]]
-SEXP dust2_system_sir_compare_data(cpp11::sexp ptr, cpp11::sexp r_data, bool grouped) {
-  return dust2::r::dust2_system_compare_data<dust2::dust_discrete<sir>>(ptr, r_data, grouped);
+SEXP dust2_system_sir_compare_data(cpp11::sexp ptr, cpp11::sexp r_data, bool preserve_group_dimension) {
+  return dust2::r::dust2_system_compare_data<dust2::dust_discrete<sir>>(ptr, r_data, preserve_group_dimension);
 }
 
 [[cpp11::register]]
-SEXP dust2_unfilter_sir_update_pars(cpp11::sexp ptr, cpp11::list r_pars, bool grouped) {
-  return dust2::r::dust2_unfilter_update_pars<dust2::dust_discrete<sir>>(ptr, r_pars, grouped);
+SEXP dust2_unfilter_sir_update_pars(cpp11::sexp ptr, cpp11::list r_pars) {
+  return dust2::r::dust2_unfilter_update_pars<dust2::dust_discrete<sir>>(ptr, r_pars);
 }
 
 [[cpp11::register]]
-SEXP dust2_unfilter_sir_run(cpp11::sexp ptr, cpp11::sexp r_initial, bool save_history, bool adjoint, bool grouped) {
-  return dust2::r::dust2_unfilter_run<dust2::dust_discrete<sir>>(ptr, r_initial, save_history, adjoint, grouped);
+SEXP dust2_unfilter_sir_run(cpp11::sexp ptr, cpp11::sexp r_initial, bool save_history, bool adjoint, bool preserve_group_dimension) {
+  return dust2::r::dust2_unfilter_run<dust2::dust_discrete<sir>>(ptr, r_initial, save_history, adjoint, preserve_group_dimension);
 }
 
 [[cpp11::register]]
-SEXP dust2_unfilter_sir_last_history(cpp11::sexp ptr, bool grouped) {
-  return dust2::r::dust2_unfilter_last_history<dust2::dust_discrete<sir>>(ptr, grouped);
+SEXP dust2_unfilter_sir_last_history(cpp11::sexp ptr, bool preserve_group_dimension) {
+  return dust2::r::dust2_unfilter_last_history<dust2::dust_discrete<sir>>(ptr, preserve_group_dimension);
 }
 
 [[cpp11::register]]
-SEXP dust2_filter_sir_update_pars(cpp11::sexp ptr, cpp11::list r_pars, bool grouped) {
-  return dust2::r::dust2_filter_update_pars<dust2::dust_discrete<sir>>(ptr, r_pars, grouped);
+SEXP dust2_filter_sir_update_pars(cpp11::sexp ptr, cpp11::list r_pars) {
+  return dust2::r::dust2_filter_update_pars<dust2::dust_discrete<sir>>(ptr, r_pars);
 }
 
 [[cpp11::register]]
-SEXP dust2_filter_sir_run(cpp11::sexp ptr, cpp11::sexp r_initial, bool save_history, bool grouped) {
-  return dust2::r::dust2_filter_run<dust2::dust_discrete<sir>>(ptr, r_initial, save_history, grouped);
+SEXP dust2_filter_sir_run(cpp11::sexp ptr, cpp11::sexp r_initial, bool save_history) {
+  return dust2::r::dust2_filter_run<dust2::dust_discrete<sir>>(ptr, r_initial, save_history);
 }
 
 [[cpp11::register]]
-SEXP dust2_filter_sir_last_history(cpp11::sexp ptr, bool grouped) {
-  return dust2::r::dust2_filter_last_history<dust2::dust_discrete<sir>>(ptr, grouped);
+SEXP dust2_filter_sir_last_history(cpp11::sexp ptr, bool preserve_group_dimension) {
+  return dust2::r::dust2_filter_last_history<dust2::dust_discrete<sir>>(ptr, preserve_group_dimension);
 }
 
 [[cpp11::register]]

--- a/src/sir.cpp
+++ b/src/sir.cpp
@@ -328,6 +328,6 @@ SEXP dust2_filter_sir_set_rng_state(cpp11::sexp ptr, cpp11::sexp r_rng_state) {
 }
 
 [[cpp11::register]]
-SEXP dust2_unfilter_sir_last_gradient(cpp11::sexp ptr, bool grouped) {
-  return dust2::r::dust2_discrete_unfilter_last_gradient<dust2::dust_discrete<sir>>(ptr, grouped);
+SEXP dust2_unfilter_sir_last_gradient(cpp11::sexp ptr, bool preserve_particle_dimension, bool preserve_group_dimension) {
+  return dust2::r::dust2_discrete_unfilter_last_gradient<dust2::dust_discrete<sir>>(ptr, preserve_particle_dimension, preserve_group_dimension);
 }

--- a/src/sirode.cpp
+++ b/src/sirode.cpp
@@ -113,8 +113,8 @@ SEXP dust2_system_sirode_run_to_time(cpp11::sexp ptr, cpp11::sexp r_time) {
 }
 
 [[cpp11::register]]
-SEXP dust2_system_sirode_state(cpp11::sexp ptr, cpp11::sexp r_index_state, cpp11::sexp r_index_particle, cpp11::sexp r_index_group, bool grouped) {
-  return dust2::r::dust2_system_state<dust2::dust_continuous<sirode>>(ptr, r_index_state, r_index_particle, r_index_group, grouped);
+SEXP dust2_system_sirode_state(cpp11::sexp ptr, cpp11::sexp r_index_state, cpp11::sexp r_index_particle, cpp11::sexp r_index_group, bool preserve_group_dimension) {
+  return dust2::r::dust2_system_state<dust2::dust_continuous<sirode>>(ptr, r_index_state, r_index_particle, r_index_group, preserve_group_dimension);
 }
 
 [[cpp11::register]]
@@ -128,8 +128,8 @@ SEXP dust2_system_sirode_set_state_initial(cpp11::sexp ptr) {
 }
 
 [[cpp11::register]]
-SEXP dust2_system_sirode_set_state(cpp11::sexp ptr, cpp11::sexp r_state, bool grouped) {
-  return dust2::r::dust2_system_set_state<dust2::dust_continuous<sirode>>(ptr, r_state, grouped);
+SEXP dust2_system_sirode_set_state(cpp11::sexp ptr, cpp11::sexp r_state) {
+  return dust2::r::dust2_system_set_state<dust2::dust_continuous<sirode>>(ptr, r_state);
 }
 
 [[cpp11::register]]
@@ -153,11 +153,11 @@ SEXP dust2_system_sirode_set_time(cpp11::sexp ptr, cpp11::sexp r_time) {
 }
 
 [[cpp11::register]]
-SEXP dust2_system_sirode_update_pars(cpp11::sexp ptr, cpp11::list pars, bool grouped) {
-  return dust2::r::dust2_system_update_pars<dust2::dust_continuous<sirode>>(ptr, pars, grouped);
+SEXP dust2_system_sirode_update_pars(cpp11::sexp ptr, cpp11::list pars) {
+  return dust2::r::dust2_system_update_pars<dust2::dust_continuous<sirode>>(ptr, pars);
 }
 
 [[cpp11::register]]
-SEXP dust2_system_sirode_simulate(cpp11::sexp ptr, cpp11::sexp r_times, cpp11::sexp r_index, bool grouped) {
-  return dust2::r::dust2_system_simulate<dust2::dust_continuous<sirode>>(ptr, r_times, r_index, grouped);
+SEXP dust2_system_sirode_simulate(cpp11::sexp ptr, cpp11::sexp r_times, cpp11::sexp r_index, bool preserve_group_dimension) {
+  return dust2::r::dust2_system_simulate<dust2::dust_continuous<sirode>>(ptr, r_times, r_index, preserve_group_dimension);
 }

--- a/src/sirode.cpp
+++ b/src/sirode.cpp
@@ -113,8 +113,8 @@ SEXP dust2_system_sirode_run_to_time(cpp11::sexp ptr, cpp11::sexp r_time) {
 }
 
 [[cpp11::register]]
-SEXP dust2_system_sirode_state(cpp11::sexp ptr, cpp11::sexp r_index_state, cpp11::sexp r_index_particle, cpp11::sexp r_index_group, bool preserve_group_dimension) {
-  return dust2::r::dust2_system_state<dust2::dust_continuous<sirode>>(ptr, r_index_state, r_index_particle, r_index_group, preserve_group_dimension);
+SEXP dust2_system_sirode_state(cpp11::sexp ptr, cpp11::sexp r_index_state, cpp11::sexp r_index_particle, cpp11::sexp r_index_group, bool preserve_particle_dimension, bool preserve_group_dimension) {
+  return dust2::r::dust2_system_state<dust2::dust_continuous<sirode>>(ptr, r_index_state, r_index_particle, r_index_group, preserve_particle_dimension, preserve_group_dimension);
 }
 
 [[cpp11::register]]
@@ -158,6 +158,6 @@ SEXP dust2_system_sirode_update_pars(cpp11::sexp ptr, cpp11::list pars) {
 }
 
 [[cpp11::register]]
-SEXP dust2_system_sirode_simulate(cpp11::sexp ptr, cpp11::sexp r_times, cpp11::sexp r_index, bool preserve_group_dimension) {
-  return dust2::r::dust2_system_simulate<dust2::dust_continuous<sirode>>(ptr, r_times, r_index, preserve_group_dimension);
+SEXP dust2_system_sirode_simulate(cpp11::sexp ptr, cpp11::sexp r_times, cpp11::sexp r_index, bool preserve_particle_dimension, bool preserve_group_dimension) {
+  return dust2::r::dust2_system_simulate<dust2::dust_continuous<sirode>>(ptr, r_times, r_index, preserve_particle_dimension, preserve_group_dimension);
 }

--- a/src/sirode.cpp
+++ b/src/sirode.cpp
@@ -128,8 +128,8 @@ SEXP dust2_system_sirode_set_state_initial(cpp11::sexp ptr) {
 }
 
 [[cpp11::register]]
-SEXP dust2_system_sirode_set_state(cpp11::sexp ptr, cpp11::sexp r_state) {
-  return dust2::r::dust2_system_set_state<dust2::dust_continuous<sirode>>(ptr, r_state);
+SEXP dust2_system_sirode_set_state(cpp11::sexp ptr, cpp11::sexp r_state, bool preserve_group_dimension) {
+  return dust2::r::dust2_system_set_state<dust2::dust_continuous<sirode>>(ptr, r_state, preserve_group_dimension);
 }
 
 [[cpp11::register]]

--- a/src/walk.cpp
+++ b/src/walk.cpp
@@ -121,8 +121,8 @@ SEXP dust2_system_walk_run_to_time(cpp11::sexp ptr, cpp11::sexp r_time) {
 }
 
 [[cpp11::register]]
-SEXP dust2_system_walk_state(cpp11::sexp ptr, cpp11::sexp r_index_state, cpp11::sexp r_index_particle, cpp11::sexp r_index_group, bool grouped) {
-  return dust2::r::dust2_system_state<dust2::dust_discrete<walk>>(ptr, r_index_state, r_index_particle, r_index_group, grouped);
+SEXP dust2_system_walk_state(cpp11::sexp ptr, cpp11::sexp r_index_state, cpp11::sexp r_index_particle, cpp11::sexp r_index_group, bool preserve_group_dimension) {
+  return dust2::r::dust2_system_state<dust2::dust_discrete<walk>>(ptr, r_index_state, r_index_particle, r_index_group, preserve_group_dimension);
 }
 
 [[cpp11::register]]
@@ -136,8 +136,8 @@ SEXP dust2_system_walk_set_state_initial(cpp11::sexp ptr) {
 }
 
 [[cpp11::register]]
-SEXP dust2_system_walk_set_state(cpp11::sexp ptr, cpp11::sexp r_state, bool grouped) {
-  return dust2::r::dust2_system_set_state<dust2::dust_discrete<walk>>(ptr, r_state, grouped);
+SEXP dust2_system_walk_set_state(cpp11::sexp ptr, cpp11::sexp r_state) {
+  return dust2::r::dust2_system_set_state<dust2::dust_discrete<walk>>(ptr, r_state);
 }
 
 [[cpp11::register]]
@@ -161,11 +161,11 @@ SEXP dust2_system_walk_set_time(cpp11::sexp ptr, cpp11::sexp r_time) {
 }
 
 [[cpp11::register]]
-SEXP dust2_system_walk_update_pars(cpp11::sexp ptr, cpp11::list pars, bool grouped) {
-  return dust2::r::dust2_system_update_pars<dust2::dust_discrete<walk>>(ptr, pars, grouped);
+SEXP dust2_system_walk_update_pars(cpp11::sexp ptr, cpp11::list pars) {
+  return dust2::r::dust2_system_update_pars<dust2::dust_discrete<walk>>(ptr, pars);
 }
 
 [[cpp11::register]]
-SEXP dust2_system_walk_simulate(cpp11::sexp ptr, cpp11::sexp r_times, cpp11::sexp r_index, bool grouped) {
-  return dust2::r::dust2_system_simulate<dust2::dust_discrete<walk>>(ptr, r_times, r_index, grouped);
+SEXP dust2_system_walk_simulate(cpp11::sexp ptr, cpp11::sexp r_times, cpp11::sexp r_index, bool preserve_group_dimension) {
+  return dust2::r::dust2_system_simulate<dust2::dust_discrete<walk>>(ptr, r_times, r_index, preserve_group_dimension);
 }

--- a/src/walk.cpp
+++ b/src/walk.cpp
@@ -136,8 +136,8 @@ SEXP dust2_system_walk_set_state_initial(cpp11::sexp ptr) {
 }
 
 [[cpp11::register]]
-SEXP dust2_system_walk_set_state(cpp11::sexp ptr, cpp11::sexp r_state) {
-  return dust2::r::dust2_system_set_state<dust2::dust_discrete<walk>>(ptr, r_state);
+SEXP dust2_system_walk_set_state(cpp11::sexp ptr, cpp11::sexp r_state, bool preserve_group_dimension) {
+  return dust2::r::dust2_system_set_state<dust2::dust_discrete<walk>>(ptr, r_state, preserve_group_dimension);
 }
 
 [[cpp11::register]]

--- a/src/walk.cpp
+++ b/src/walk.cpp
@@ -121,8 +121,8 @@ SEXP dust2_system_walk_run_to_time(cpp11::sexp ptr, cpp11::sexp r_time) {
 }
 
 [[cpp11::register]]
-SEXP dust2_system_walk_state(cpp11::sexp ptr, cpp11::sexp r_index_state, cpp11::sexp r_index_particle, cpp11::sexp r_index_group, bool preserve_group_dimension) {
-  return dust2::r::dust2_system_state<dust2::dust_discrete<walk>>(ptr, r_index_state, r_index_particle, r_index_group, preserve_group_dimension);
+SEXP dust2_system_walk_state(cpp11::sexp ptr, cpp11::sexp r_index_state, cpp11::sexp r_index_particle, cpp11::sexp r_index_group, bool preserve_particle_dimension, bool preserve_group_dimension) {
+  return dust2::r::dust2_system_state<dust2::dust_discrete<walk>>(ptr, r_index_state, r_index_particle, r_index_group, preserve_particle_dimension, preserve_group_dimension);
 }
 
 [[cpp11::register]]
@@ -166,6 +166,6 @@ SEXP dust2_system_walk_update_pars(cpp11::sexp ptr, cpp11::list pars) {
 }
 
 [[cpp11::register]]
-SEXP dust2_system_walk_simulate(cpp11::sexp ptr, cpp11::sexp r_times, cpp11::sexp r_index, bool preserve_group_dimension) {
-  return dust2::r::dust2_system_simulate<dust2::dust_discrete<walk>>(ptr, r_times, r_index, preserve_group_dimension);
+SEXP dust2_system_walk_simulate(cpp11::sexp ptr, cpp11::sexp r_times, cpp11::sexp r_index, bool preserve_particle_dimension, bool preserve_group_dimension) {
+  return dust2::r::dust2_system_simulate<dust2::dust_discrete<walk>>(ptr, r_times, r_index, preserve_particle_dimension, preserve_group_dimension);
 }

--- a/tests/testthat/test-filter-support.R
+++ b/tests/testthat/test-filter-support.R
@@ -41,20 +41,25 @@ test_that("can validate time sequence", {
 
 
 test_that("can validate data", {
-  expect_no_error(check_data(vector("list", 5), 5, n_groups = 0))
-  expect_error(check_data(vector("list", 3), 5, n_groups = 0),
+  expect_no_error(check_data(vector("list", 5), 5,
+                             n_groups = 1, preserve_group_dimension = FALSE))
+  expect_error(check_data(vector("list", 3), 5,
+                          n_groups = 1, preserve_group_dimension = FALSE),
                "Expected 'data' to have length 5, but was length 3")
-  expect_error(check_data(NULL, 5, n_groups = 0),
+  expect_error(check_data(NULL, 5,
+                          n_groups = 1, preserve_group_dimension = FALSE),
                "Expected 'data' to be a list")
 
   err <- expect_error(
-    check_data(vector("list", 3), 3, n_groups = 2),
+    check_data(vector("list", 3), 3,
+               n_groups = 2, preserve_group_dimension = TRUE),
     "Expected all elements of 'data' to have length 2")
   expect_equal(tail(err$body, 2),
                c(x = "Error for element 2, which has length 0",
                  x = "Error for element 3, which has length 0"))
   err <- expect_error(
-    check_data(vector("list", 10), 10, n_groups = 2),
+    check_data(vector("list", 10), 10,
+               n_groups = 2, preserve_group_dimension = TRUE),
     "Expected all elements of 'data' to have length 2")
   expect_equal(tail(err$body, 2),
                c(x = "Error for element 4, which has length 0",

--- a/tests/testthat/test-filter-support.R
+++ b/tests/testthat/test-filter-support.R
@@ -67,6 +67,28 @@ test_that("can validate data", {
 })
 
 
+test_that("sensible explanation about expected data size", {
+  err <- expect_error(
+    check_data(vector("list", 3), 3,
+               n_groups = 2, preserve_group_dimension = TRUE),
+    "Expected all elements of 'data' to have length 2")
+  expect_match(
+    conditionMessage(err),
+    "You have a grouped system ('n_groups' is greater than one)",
+    fixed = TRUE)
+
+  err <- expect_error(
+    check_data(vector("list", 3), 3,
+               n_groups = 1, preserve_group_dimension = TRUE),
+    "Expected all elements of 'data' to have length 1")
+  expect_match(
+    conditionMessage(err),
+    "You have a grouped system ('preserve_group_dimension' was TRUE)",
+    fixed = TRUE)
+
+})
+
+
 test_that("check index", {
   expect_no_error(check_index(NULL))
   expect_no_error(check_index(1:4))

--- a/tests/testthat/test-filter.R
+++ b/tests/testthat/test-filter.R
@@ -123,6 +123,8 @@ test_that("can run a nested particle filter and get the same result", {
   s <- dust_filter_rng_state(obj)
   expect_equal(s, r)
 
+  expect_true(obj$preserve_group_dimension)
+
   res <- replicate(20, dust_filter_run(obj, pars, save_history = TRUE))
 
   ## now compare:

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -70,7 +70,7 @@ test_that("error if non-dust system given to dust function", {
 })
 
 
-test_that("can control dropping of single-element dimensions", {
+test_that("can control dropping of single-element group dimensions", {
   pars <- list(len = 3, sd = 1, random_initial = TRUE)
   obj1 <- dust_system_create(walk(), list(pars), n_particles = 10,
                              preserve_group_dimension = TRUE,
@@ -85,4 +85,43 @@ test_that("can control dropping of single-element dimensions", {
 
   expect_equal(dust_system_state(obj1), array(r, c(3, 10, 1)))
   expect_equal(dust_system_state(obj2), r)
+})
+
+
+test_that("can control dropping of single-element particle dimensions", {
+  pars <- list(list(len = 3, sd = 1, random_initial = TRUE),
+               list(len = 3, sd = 1, random_initial = TRUE))
+  obj1 <- dust_system_create(walk(), pars, n_particles = 1, n_groups = 2,
+                             preserve_particle_dimension = TRUE,
+                             seed = 42)
+  obj2 <- dust_system_create(walk(), pars, n_particles = 1, n_groups = 2,
+                             seed = 42)
+  dust_system_set_state_initial(obj1)
+  dust_system_set_state_initial(obj2)
+  r <- mcstate2::mcstate_rng$new(seed = 42, n_streams = 2)$normal(3, 0, 1)
+  expect_equal(dim(obj1), c(3, 1, 2))
+  expect_equal(dim(obj2), c(3, 2))
+
+  expect_equal(dust_system_state(obj1), array(r, c(3, 1, 2)))
+  expect_equal(dust_system_state(obj2), r)
+})
+
+
+test_that("can control dropping of all dimensions", {
+  pars <- list(len = 3, sd = 1, random_initial = TRUE)
+  obj1 <- dust_system_create(walk(), list(pars), n_particles = 1, n_groups = 1,
+                             preserve_group_dimension = TRUE,
+                             preserve_particle_dimension = TRUE,
+                             seed = 42)
+  obj2 <- dust_system_create(walk(), pars, n_particles = 1, n_groups = 1,
+                             seed = 42)
+
+  dust_system_set_state_initial(obj1)
+  dust_system_set_state_initial(obj2)
+  r <- mcstate2::mcstate_rng$new(seed = 42, n_streams = 1)$normal(3, 0, 1)
+  expect_equal(dim(obj1), c(3, 1, 1))
+  expect_equal(dim(obj2), 3)
+
+  expect_equal(dust_system_state(obj1), array(r, c(3, 1, 1)))
+  expect_equal(dust_system_state(obj2), drop(r))
 })

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -40,8 +40,12 @@ test_that("can print information about dust systems", {
   expect_match(msgs(list(), n_particles = 10),
                "5 state x 10 particles\\b",
                all = FALSE)
-  expect_match(msgs(list(list()), n_particles = 10, n_groups = 1),
+  expect_match(msgs(list(list()), n_particles = 10, n_groups = 1,
+                    preserve_group_dimension = TRUE),
                "5 state x 10 particles x 1 group\\b",
+               all = FALSE)
+  expect_match(msgs(list(list()), n_particles = 10, n_groups = 1),
+               "5 state x 10 particles\\b",
                all = FALSE)
   expect_match(msgs(list(list(), list()), n_particles = 10, n_groups = 2),
                "5 state x 10 particles x 2 groups\\b",

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -68,3 +68,21 @@ test_that("error if non-dust system given to dust function", {
   expect_error(dust_filter_run(NULL),
                "Expected 'filter' to be a 'dust_filter' object")
 })
+
+
+test_that("can control dropping of single-element dimensions", {
+  pars <- list(len = 3, sd = 1, random_initial = TRUE)
+  obj1 <- dust_system_create(walk(), list(pars), n_particles = 10,
+                             preserve_group_dimension = TRUE,
+                             seed = 42)
+  obj2 <- dust_system_create(walk(), pars, n_particles = 10,
+                             seed = 42)
+  dust_system_set_state_initial(obj1)
+  dust_system_set_state_initial(obj2)
+  r <- mcstate2::mcstate_rng$new(seed = 42, n_streams = 10)$normal(3, 0, 1)
+  expect_equal(dim(obj1), c(3, 10, 1))
+  expect_equal(dim(obj2), c(3, 10))
+
+  expect_equal(dust_system_state(obj1), array(r, c(3, 10, 1)))
+  expect_equal(dust_system_state(obj2), r)
+})

--- a/tests/testthat/test-logistic.R
+++ b/tests/testthat/test-logistic.R
@@ -1,6 +1,7 @@
 test_that("can run simple logistic system", {
   pars <- list(n = 3, r = c(0.1, 0.2, 0.3), K = rep(100, 3))
   obj <- dust_system_create(logistic(), pars, n_particles = 1,
+                            preserve_particle_dimension = TRUE,
                             deterministic = TRUE)
   expect_s3_class(obj, "dust_system")
 
@@ -25,6 +26,7 @@ test_that("can run simple logistic system", {
 test_that("can extract statistics from solver", {
   pars <- list(n = 3, r = c(0.1, 0.2, 0.3), K = rep(100, 3))
   obj <- dust_system_create(logistic(), pars, n_particles = 1,
+                            preserve_particle_dimension = TRUE,
                             deterministic = TRUE)
 
   d <- dust_system_internals(obj)
@@ -53,6 +55,7 @@ test_that("can extract statistics from solver", {
 test_that("can set system state from a vector", {
   pars <- list(n = 3, r = c(0.1, 0.2, 0.3), K = rep(100, 3))
   obj <- dust_system_create(logistic(), pars, n_particles = 1,
+                            preserve_particle_dimension = TRUE,
                             deterministic = TRUE)
   expect_s3_class(obj, "dust_system")
 
@@ -107,7 +110,8 @@ test_that("can set rng state", {
 test_that("can update parameters", {
   pars1 <- list(n = 3, r = c(0.1, 0.2, 0.3), K = rep(100, 3))
   pars2 <- list(r = pars1$r * 5)
-  obj <- dust_system_create(logistic(), pars1, n_particles = 1, seed = 42)
+  obj <- dust_system_create(logistic(), pars1, n_particles = 1, seed = 42,
+                            preserve_particle_dimension = TRUE)
 
   dust_system_set_state_initial(obj)
   expect_null(dust_system_run_to_time(obj, 5))
@@ -142,8 +146,10 @@ test_that("can accept a vector of parameters", {
 test_that("can convert integer vectors to numeric", {
   pars1 <- list(n = 3, r = c(0.1, 0.2, 0.3), K = c(100L, 200L, 300L))
   pars2 <- list(n = 3, r = c(0.1, 0.2, 0.3), K = c(100, 200, 300))
-  obj1 <- dust_system_create(logistic(), pars1, n_particles = 1)
-  obj2 <- dust_system_create(logistic(), pars2, n_particles = 1)
+  obj1 <- dust_system_create(logistic(), pars1, n_particles = 1,
+                             preserve_particle_dimension = TRUE)
+  obj2 <- dust_system_create(logistic(), pars2, n_particles = 1,
+                             preserve_particle_dimension = TRUE)
   dust_system_set_state_initial(obj1)
   dust_system_set_state_initial(obj2)
   dust_system_run_to_time(obj1, 10)
@@ -258,8 +264,10 @@ test_that("can set ode control", {
   ctl1 <- dust_ode_control(atol = 1e-8, rtol = 1e-8)
   ctl2 <- dust_ode_control(atol = 1e-3, rtol = 1e-3)
   obj1 <- dust_system_create(logistic(), pars, n_particles = 1,
+                             preserve_particle_dimension = TRUE,
                              ode_control = ctl1)
   obj2 <- dust_system_create(logistic(), pars, n_particles = 1,
+                             preserve_particle_dimension = TRUE,
                              ode_control = ctl2)
   dust_system_set_state_initial(obj1)
   dust_system_set_state_initial(obj2)
@@ -283,7 +291,8 @@ test_that("can error if too many steps taken", {
   pars <- list(n = 3, r = c(0.1, 0.2, 0.3), K = rep(100, 3))
   ctl <- dust_ode_control(max_steps = 2)
   obj <- dust_system_create(logistic(), pars, n_particles = 1,
-                             ode_control = ctl)
+                            preserve_particle_dimension = TRUE,
+                            ode_control = ctl)
   dust_system_set_state_initial(obj)
   expect_error(dust_system_run_to_time(obj, 10),
                "too many steps")
@@ -294,7 +303,8 @@ test_that("can error if steps are too small", {
   pars <- list(n = 3, r = c(0.1, 0.2, 0.3), K = rep(100, 3))
   ctl <- dust_ode_control(step_size_min = 10)
   obj <- dust_system_create(logistic(), pars, n_particles = 1,
-                             ode_control = ctl)
+                            preserve_particle_dimension = TRUE,
+                            ode_control = ctl)
   dust_system_set_state_initial(obj)
   expect_error(dust_system_run_to_time(obj, 10),
                "step too small")
@@ -304,6 +314,7 @@ test_that("can error if steps are too small", {
 test_that("can error if initial step size calculation fails", {
   pars <- list(n = 3, r = c(0.1, 0.2, 0.3), K = rep(100, 3))
   obj <- dust_system_create(logistic(), pars, n_particles = 1,
+                            preserve_particle_dimension = TRUE,
                             deterministic = TRUE)
   y0 <- matrix(NA_real_, 3, 1)
   expect_error(dust_system_set_state(obj, y0),
@@ -315,6 +326,7 @@ test_that("can save step times for debugging", {
   pars <- list(n = 3, r = c(0.1, 0.2, 0.3), K = rep(100, 3))
   ctl <- dust_ode_control(debug_record_step_times = TRUE)
   obj <- dust_system_create(logistic(), pars, n_particles = 1,
+                            preserve_particle_dimension = TRUE,
                             deterministic = TRUE, ode_control = ctl)
 
   dust_system_set_state_initial(obj)

--- a/tests/testthat/test-sirode.R
+++ b/tests/testthat/test-sirode.R
@@ -1,6 +1,7 @@
 test_that("can run sirode model", {
   pars <- list(beta = 0.2, gamma = 0.1, N = 1000, I0 = 10, exp_noise = 1e6)
   obj <- dust_system_create(sirode(), pars, n_particles = 1,
+                            preserve_particle_dimension = TRUE,
                             ode_control = dust_ode_control(step_size_max = 0.8),
                             deterministic = TRUE)
   dust_system_set_state_initial(obj)
@@ -20,6 +21,7 @@ test_that("can cope with multiple resets within a step", {
 
   f <- function(t) {
     obj1 <- dust_system_create(sirode(), pars, n_particles = 1,
+                               preserve_particle_dimension = TRUE,
                                ode_control = ctl, deterministic = TRUE)
     dust_system_set_state_initial(obj1)
     dust_system_run_to_time(obj1, t)
@@ -30,7 +32,8 @@ test_that("can cope with multiple resets within a step", {
   res <- lapply(1:10, f)
 
   obj2 <- dust_system_create(sirode(), pars, n_particles = 1,
-                            ode_control = ctl, deterministic = TRUE)
+                             preserve_particle_dimension = TRUE,
+                             ode_control = ctl, deterministic = TRUE)
   dust_system_set_state_initial(obj2)
   cmp <- dust_system_simulate(obj2, 1:10)
 

--- a/tests/testthat/test-unfilter-adjoint.R
+++ b/tests/testthat/test-unfilter-adjoint.R
@@ -76,6 +76,14 @@ test_that("can compute multiple gradients at once", {
   }, numeric(3))
 
   expect_equal(dust_unfilter_last_gradient(obj1), cmp)
+
+  obj3 <- dust_unfilter_create(sir(), time_start, time, data, n_groups = 4,
+                               preserve_particle_dimension = TRUE)
+  ll3 <- dust_unfilter_run(obj3, pars, adjoint = TRUE)
+  expect_equal(dim(ll3), c(1, 4))
+  expect_equal(ll3, matrix(ll1, 1, 4))
+  expect_equal(dust_unfilter_last_gradient(obj3),
+               array(cmp, c(3, 1, 4)))
 })
 
 

--- a/tests/testthat/test-unfilter.R
+++ b/tests/testthat/test-unfilter.R
@@ -71,7 +71,6 @@ test_that("can get unfilter history", {
     "History is not current")
 
   m <- dust_system_create(sir(), pars, time = time_start, n_particles = 1,
-                          preserve_particle_dimension = TRUE,
                           deterministic = TRUE)
   dust_system_set_state_initial(m)
   cmp <- dust_system_simulate(m, time)
@@ -95,9 +94,9 @@ test_that("can get partial unfilter history", {
 
   h1 <- dust_unfilter_last_history(obj1)
   h2 <- dust_unfilter_last_history(obj2)
-  expect_equal(dim(h1), c(5, 1, 4))
-  expect_equal(dim(h2), c(2, 1, 4))
-  expect_equal(h2, h1[c(2, 4), , , drop = FALSE])
+  expect_equal(dim(h1), c(5, 4))
+  expect_equal(dim(h2), c(2, 4))
+  expect_equal(h2, h1[c(2, 4), , drop = FALSE])
 })
 
 
@@ -223,9 +222,9 @@ test_that("can save history from structured unfilter", {
   h1 <- dust_unfilter_last_history(obj1)
   h2 <- dust_unfilter_last_history(obj2)
 
-  expect_equal(dim(h), c(5, 1, 2, 4))
-  expect_equal(dim(h1), c(5, 1, 4))
-  expect_equal(dim(h2), c(5, 1, 4))
-  expect_equal(array(h[, , 1, ], dim(h1)), h1)
-  expect_equal(array(h[, , 2, ], dim(h2)), h2)
+  expect_equal(dim(h), c(5, 2, 4))
+  expect_equal(dim(h1), c(5, 4))
+  expect_equal(dim(h2), c(5, 4))
+  expect_equal(array(h[, 1, ], dim(h1)), h1)
+  expect_equal(array(h[, 2, ], dim(h2)), h2)
 })

--- a/tests/testthat/test-unfilter.R
+++ b/tests/testthat/test-unfilter.R
@@ -88,7 +88,7 @@ test_that("can get partial unfilter history", {
 
   obj1 <- dust_unfilter_create(sir(), time_start, time, data)
   obj2 <- dust_unfilter_create(sir(), time_start, time, data,
-                               index = c(2, 4))
+                               index_state = c(2, 4))
   expect_equal(dust_unfilter_run(obj1, pars, save_history = TRUE),
                dust_unfilter_run(obj2, pars, save_history = TRUE))
 

--- a/tests/testthat/test-unfilter.R
+++ b/tests/testthat/test-unfilter.R
@@ -228,3 +228,47 @@ test_that("can save history from structured unfilter", {
   expect_equal(array(h[, 1, ], dim(h1)), h1)
   expect_equal(array(h[, 2, ], dim(h2)), h2)
 })
+
+
+test_that("history output can have dimensions preserved", {
+  pars <- list(beta = 0.1, gamma = 0.2, N = 1000, I0 = 10, exp_noise = 1e6)
+  time_start <- 0
+  time <- c(4, 8, 12, 16)
+  data <- lapply(1:4, function(i) list(incidence = i))
+  dt <- 1
+  data_grouped <- lapply(data, list)
+
+  obj1 <- dust_unfilter_create(sir(), time_start, time, data)
+  ll1 <- dust_unfilter_run(obj1, pars, save_history = TRUE)
+
+  obj2 <- dust_unfilter_create(sir(), time_start, time, data,
+                               preserve_particle_dimension = TRUE)
+  ll2 <- dust_unfilter_run(obj2, pars, save_history = TRUE)
+  expect_equal(ll2, ll1)
+
+  obj3 <- dust_unfilter_create(sir(), time_start, time, data_grouped,
+                               preserve_group_dimension = TRUE)
+  ll3 <- dust_unfilter_run(obj3, list(pars), save_history = TRUE)
+  expect_equal(ll3, ll1)
+
+  obj4 <- dust_unfilter_create(sir(), time_start, time, data_grouped,
+                               preserve_group_dimension = TRUE,
+                               preserve_particle_dimension = TRUE)
+  ll4 <- dust_unfilter_run(obj4, list(pars), save_history = TRUE)
+  expect_equal(ll4, matrix(ll1, 1, 1))
+
+  h1 <- dust_unfilter_last_history(obj1)
+  expect_equal(dim(h1), c(5, 4))
+
+  h2 <- dust_unfilter_last_history(obj2)
+  expect_equal(dim(h2), c(5, 1, 4))
+  expect_equal(drop(h2), h1)
+
+  h3 <- dust_unfilter_last_history(obj3)
+  expect_equal(dim(h3), c(5, 1, 4))
+  expect_equal(drop(h3), h1)
+
+  h4 <- dust_unfilter_last_history(obj4)
+  expect_equal(dim(h4), c(5, 1, 1, 4))
+  expect_equal(drop(h4), h1)
+})

--- a/tests/testthat/test-unfilter.R
+++ b/tests/testthat/test-unfilter.R
@@ -18,7 +18,7 @@ test_that("can run an unfilter", {
     time0 <- c(time_start, time)
     for (i in seq_along(time)) {
       dust_system_run_to_time(obj, time[i])
-      incidence[i] <- dust_system_state(obj)[5, , drop = TRUE]
+      incidence[i] <- dust_system_state(obj)[5]
     }
     sum(dpois(1:4, incidence + 1e-6, log = TRUE))
   }
@@ -71,6 +71,7 @@ test_that("can get unfilter history", {
     "History is not current")
 
   m <- dust_system_create(sir(), pars, time = time_start, n_particles = 1,
+                          preserve_particle_dimension = TRUE,
                           deterministic = TRUE)
   dust_system_set_state_initial(m)
   cmp <- dust_system_simulate(m, time)
@@ -118,7 +119,7 @@ test_that("can run an unfilter with manually set state", {
     time0 <- c(time_start, time)
     for (i in seq_along(time)) {
       dust_system_run_to_time(obj, time[i])
-      incidence[i] <- dust_system_state(obj)[5, , drop = TRUE]
+      incidence[i] <- dust_system_state(obj)[5]
     }
     sum(dpois(1:4, incidence + 1e-6, log = TRUE))
   }
@@ -151,7 +152,7 @@ test_that("can run unfilter on structured system", {
     time0 <- c(time_start, time)
     for (i in seq_along(time)) {
       dust_system_run_to_time(obj, time[i])
-      incidence[, i] <- dust_system_state(obj)[5, , , drop = TRUE]
+      incidence[, i] <- dust_system_state(obj)[5, , drop = TRUE]
     }
     observed <- matrix(unlist(data, use.names = FALSE), n_groups)
     rowSums(dpois(observed, incidence + 1e-6, log = TRUE))

--- a/tests/testthat/test-walk.R
+++ b/tests/testthat/test-walk.R
@@ -130,13 +130,13 @@ test_that("validate inputs", {
     matrix(0, 1, 10))
   expect_error(
     dust_system_create(walk(), pars, n_particles = 9.5),
-    "'n_particles' must be integer-like")
+    "Expected 'n_particles' to be integer")
   expect_error(
     dust_system_create(walk(), pars, n_particles = "10"),
-    "'n_particles' must be scalar integer")
+    "Expected 'n_particles' to be integer")
   expect_error(
     dust_system_create(walk(), pars, n_particles = -5),
-    "'n_particles' must be non-negative")
+    "'n_particles' must be at least 1")
 
   expect_error(
     dust_system_create(walk(), pars, n_particles = 10, deterministic = 1),
@@ -164,16 +164,6 @@ test_that("can initialise multiple groups with different parameter sets", {
   expect_equal(dust_system_time(obj), 3)
 
   expect_identical(dim(obj), c(1L, 10L, 4L))
-})
-
-
-test_that("return names passed in with groups", {
-  pars <- lapply(1:4, function(sd) list(sd = sd, random_initial = TRUE))
-  names(pars) <- letters[1:4]
-  obj <- dust_system_create(walk(), pars, n_particles = 10, n_groups = 4)
-  ## This interface will change/improve soon
-  expect_true(obj$grouped)
-  expect_equal(obj$group_names, letters[1:4])
 })
 
 


### PR DESCRIPTION
Merge after #44, contains those commits.

This is one of those PRs that just kept sprawling - I've tried to draw a line here but there's more to do I think.

This PR allows graceful control over when we treat a system that has "one" group has having a group dimension or not.  This basically the same issue as R's vector/scalar problem and the indexing problem we see that requires use of `drop = FALSE` with `[`.  The approach here is that when the user creates a system/filter/unfilter they can pass a flag `preserve_group_dimension = TRUE` (or `preserve_particle_dimension = TRUE`) which will retain the dimension even in the case where there is only a single group or particle in their system.  This generalises and removes the previous use of `n_groups = 0` for this, without having to do as much weird magic

In order to make this work, some input validation has moved from C++ back to R, which results in nicer errors anyway - I had looked at splitting the PR there but the two problems are quite closely linked.