### PR TITLE
Allocate one internals per thread (per group)

### DIFF
--- a/inst/include/dust2/continuous/system.hpp
+++ b/inst/include/dust2/continuous/system.hpp
@@ -9,6 +9,7 @@
 #include <dust2/continuous/control.hpp>
 #include <dust2/continuous/solver.hpp>
 #include <dust2/errors.hpp>
+#include <dust2/tools.hpp>
 #include <dust2/zero.hpp>
 #include <mcstate/random/random.hpp>
 

--- a/inst/include/dust2/continuous/system.hpp
+++ b/inst/include/dust2/continuous/system.hpp
@@ -73,11 +73,12 @@ public:
       for (size_t j = 0; j < n_particles_; ++j) {
         const auto k = n_particles_ * i + j;
         const auto offset = k * n_state_;
+        auto& internal_i = internal_[tools::thread_index() * n_groups_ + i];
         real_type * y = state_data + offset;
         try {
           solver_.run(time_, time, y, zero_every_[i],
                       ode_internals_[k],
-                      rhs_(shared_[i], internal_[i]));
+                      rhs_(shared_[i], internal_i));
         } catch (std::exception const& e) {
           errors_.capture(e, k);
         }
@@ -97,12 +98,13 @@ public:
       for (size_t j = 0; j < n_particles_; ++j) {
         const auto k = n_particles_ * i + j;
         const auto offset = k * n_state_;
+        auto& internal_i = internal_[tools::thread_index() * n_groups_ + i];
         real_type * y = state_data + offset;
         try {
-          T::initial(time_, shared_[i], internal_[i],
+          T::initial(time_, shared_[i], internal_i,
                      rng_.state(k), y);
           solver_.initialise(time_, y, ode_internals_[k],
-                             rhs_(shared_[i], internal_[i]));
+                             rhs_(shared_[i], internal_i));
         } catch (std::exception const& e) {
           errors_.capture(e, k);
         }
@@ -128,11 +130,12 @@ public:
         const auto offset_read =
           i * offset_read_group + j * offset_read_particle;
         const auto offset_write = k * n_state_;
+        auto& internal_i = internal_[tools::thread_index() * n_groups_ + i];
         real_type* y = state_data + offset_write;
         std::copy_n(iter + offset_read, n_state_, y);
 	try {
 	  solver_.initialise(time_, y, ode_internals_[k],
-			     rhs_(shared_[i], internal_[i]));
+			     rhs_(shared_[i], internal_i));
 	} catch (std::exception const& e) {
 	  errors_.capture(e, k);
 	}
@@ -224,10 +227,11 @@ public:
 	auto data_i = data + i;
         const auto k = n_particles_ * i + j;
         const auto offset = k * n_state_;
+        auto& internal_i = internal_[tools::thread_index() * n_groups_ + i];
 	auto output_ij = output + k;
         try {
           *output_ij = T::compare_data(time_, state_data + offset, *data_i,
-				       shared_[i], internal_[i], rng_.state(k));
+				       shared_[i], internal_i, rng_.state(k));
         } catch (std::exception const& e) {
           errors_.capture(e, k);
         }

--- a/inst/include/dust2/discrete/system.hpp
+++ b/inst/include/dust2/discrete/system.hpp
@@ -64,9 +64,10 @@ public:
       for (size_t j = 0; j < n_particles_; ++j) {
         const auto k = n_particles_ * i + j;
         const auto offset = k * n_state_;
+        auto& internal_i = internal_[tools::thread_index() * n_groups_ + i];
         try {
           run_particle(time_, dt_, n_steps,
-                       shared_[i], internal_[i],
+                       shared_[i], internal_i,
                        zero_every_[i],
                        state_data + offset,
                        rng_.state(k),
@@ -93,9 +94,10 @@ public:
         const auto offset = k * n_state_;
         auto state_model_ij = state_.data() + offset;
         auto state_history_ij = state_history + offset;
+        auto& internal_i = internal_[tools::thread_index() * n_groups_ + i];
         try {
           run_particle(time_, dt_, n_steps, n_state_, stride,
-                       shared_[i], internal_[i], zero_every_[i],
+                       shared_[i], internal_i, zero_every_[i],
                        state_model_ij, state_history_ij,
                        rng_.state(k));
         } catch (std::exception const &e) {
@@ -117,9 +119,10 @@ public:
       for (size_t j = 0; j < n_particles_; ++j) {
         const auto k = n_particles_ * i + j;
         const auto offset = k * n_state_;
+        auto& internal_i = internal_[tools::thread_index() * n_groups_ + i];
         try {
           T::initial(time_, dt_,
-                     shared_[i], internal_[i],
+                     shared_[i], internal_i,
                      rng_.state(k),
                      state_data + offset);
         } catch (std::exception const& e) {
@@ -232,10 +235,11 @@ public:
 	auto data_i = data + i;
         const auto k = n_particles_ * i + j;
         const auto offset = k * n_state_;
-	auto output_ij = output + k;
+        auto& internal_i = internal_[tools::thread_index() * n_groups_ + i];
+        auto output_ij = output + k;
         try {
           *output_ij = T::compare_data(time_, dt_, state + offset, *data_i,
-				       shared_[i], internal_[i], rng_.state(k));
+				       shared_[i], internal_i, rng_.state(k));
         } catch (std::exception const& e) {
           errors_.capture(e, k);
         }
@@ -256,12 +260,13 @@ public:
         const auto k = n_particles_ * i + j;
         const auto offset_state = k * n_state_;
         const auto offset_adjoint = k * n_adjoint;
+        auto& internal_i = internal_[tools::thread_index() * n_groups_ + i];
         try {
           T::adjoint_compare_data(time, dt_,
                                   state + offset_state,
                                   adjoint_curr + offset_adjoint,
                                   *data,
-                                  shared_[i], internal_[i],
+                                  shared_[i], internal_i,
                                   adjoint_next + offset_adjoint);
         } catch (std::exception const& e) {
           errors_.capture(e, k);
@@ -289,9 +294,10 @@ public:
         const auto k = n_particles_ * i + j;
         const auto offset_state = k * n_state_;
         const auto offset_adjoint = k * n_adjoint;
+        auto& internal_i = internal_[tools::thread_index() * n_groups_ + i];
         try {
           adjoint_run_particle(time0, dt_, n_steps, stride,
-                               shared_[i], internal_[i],
+                               shared_[i], internal_i,
                                state + offset_state,
                                adjoint_curr + offset_adjoint,
                                adjoint_next + offset_adjoint);
@@ -314,13 +320,14 @@ public:
         const auto k = n_particles_ * i + j;
         const auto offset_state = k * n_state_;
         const auto offset_adjoint = k * n_adjoint;
+        auto& internal_i = internal_[tools::thread_index() * n_groups_ + i];
         try {
           T::adjoint_initial(time,
                              dt_,
                              state + offset_state,
                              adjoint_curr + offset_adjoint,
                              shared_[i],
-                             internal_[i],
+                             internal_i,
                              adjoint_next + offset_adjoint);
         } catch (std::exception const& e) {
           errors_.capture(e, k);

--- a/inst/include/dust2/discrete/system.hpp
+++ b/inst/include/dust2/discrete/system.hpp
@@ -7,6 +7,7 @@
 #include <map>
 #include <vector>
 #include <dust2/errors.hpp>
+#include <dust2/tools.hpp>
 #include <dust2/zero.hpp>
 #include <mcstate/random/random.hpp>
 

--- a/inst/include/dust2/r/continuous/system.hpp
+++ b/inst/include/dust2/r/continuous/system.hpp
@@ -26,16 +26,15 @@ SEXP dust2_continuous_alloc(cpp11::list r_pars,
 
   const auto n_particles = to_size(r_n_particles, "n_particles");
   const auto n_groups = to_size(r_n_groups, "n_groups");
+  const auto n_threads = to_size(r_n_threads, "n_threads");
 
   const auto shared = build_shared<T>(r_pars, n_groups);
-  // Later, we need one of these per thread
-  const auto internal = build_internal<T>(shared);
+  const auto internal = build_internal<T>(shared, n_threads);
 
   auto seed = mcstate::random::r::as_rng_seed<rng_state_type>(r_seed);
   auto deterministic = to_bool(r_deterministic, "deterministic");
   auto ode_control = validate_ode_control<real_type>(r_ode_control);
 
-  const auto n_threads = to_size(r_n_threads, "n_threads");
 
   auto obj = new dust_continuous<T>(shared, internal, time, ode_control,
                                     n_particles, seed, deterministic,

--- a/inst/include/dust2/r/discrete/filter.hpp
+++ b/inst/include/dust2/r/discrete/filter.hpp
@@ -30,7 +30,7 @@ cpp11::sexp dust2_discrete_filter_alloc(cpp11::list r_pars,
   const auto time = check_time_sequence(time_start, r_time, true, "time");
   const auto dt = check_dt(r_dt);
   const auto shared = build_shared<T>(r_pars, n_groups);
-  const auto internal = build_internal<T>(shared);
+  const auto internal = build_internal<T>(shared, n_threads);
   const auto data = check_data<T>(r_data, time.size(), n_groups, "data");
 
   // It's possible that we don't want to always really be

--- a/inst/include/dust2/r/discrete/system.hpp
+++ b/inst/include/dust2/r/discrete/system.hpp
@@ -35,13 +35,11 @@ SEXP dust2_discrete_alloc(cpp11::list r_pars,
   const auto dt = check_dt(r_dt);
   const auto n_particles = to_size(r_n_particles, "n_particles");
   const auto n_groups = to_size(r_n_groups, "n_groups");
+  const auto n_threads = to_size(r_n_threads, "n_threads");
   const auto shared = build_shared<T>(r_pars, n_groups);
-  // Later, we need one of these per thread
-  const auto internal = build_internal<T>(shared);
+  const auto internal = build_internal<T>(shared, n_threads);
   auto seed = mcstate::random::r::as_rng_seed<rng_state_type>(r_seed);
   auto deterministic = to_bool(r_deterministic, "deterministic");
-
-  const auto n_threads = to_size(r_n_threads, "n_threads");
 
   auto obj = new dust_discrete<T>(shared, internal, time, dt, n_particles,
                                   seed, deterministic, n_threads);

--- a/inst/include/dust2/r/discrete/unfilter.hpp
+++ b/inst/include/dust2/r/discrete/unfilter.hpp
@@ -29,7 +29,7 @@ cpp11::sexp dust2_discrete_unfilter_alloc(cpp11::list r_pars,
   const auto time = check_time_sequence(time_start, r_time, true, "time");
   const auto dt = check_dt(r_dt);
   const auto shared = build_shared<T>(r_pars, n_groups);
-  const auto internal = build_internal<T>(shared);
+  const auto internal = build_internal<T>(shared, n_threads);
   const auto data = check_data<T>(r_data, time.size(), n_groups, "data");
 
   // It's possible that we don't want to always really be

--- a/inst/include/dust2/r/helpers.hpp
+++ b/inst/include/dust2/r/helpers.hpp
@@ -227,11 +227,15 @@ std::vector<typename T::shared_state> build_shared(cpp11::list r_pars,
 }
 
 template <typename T>
-std::vector<typename T::internal_state> build_internal(std::vector<typename T::shared_state> shared) {
+std::vector<typename T::internal_state> build_internal(std::vector<typename T::shared_state> shared, size_t n_threads) {
   std::vector<typename T::internal_state> internal;
-  internal.reserve(shared.size());
-  for (auto& s : shared) {
-    internal.push_back(T::build_internal(s));
+  const size_t n_groups = shared.size();
+  internal.reserve(n_groups * n_threads);
+  // We can parallelise this but it's probably not really wanted.
+  for (size_t i = 0; i < n_threads; ++i) {
+    for (auto& s : shared) {
+      internal.push_back(T::build_internal(s));
+    }
   }
   return internal;
 }

--- a/inst/include/dust2/tools.hpp
+++ b/inst/include/dust2/tools.hpp
@@ -1,5 +1,9 @@
 #pragma once
 
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
 #include <cmath>
 
 namespace dust2 {
@@ -20,6 +24,14 @@ inline bool is_evenly_divisible_by(double num, double by) {
 template <typename T, typename U>
 T accumulate_periodic(T time, T period, U previous, U value) {
   return is_evenly_divisible_by(time, period) ? value : previous + value;
+}
+
+inline size_t thread_index() {
+#ifdef _OPENMP
+  return omp_get_thread_num();
+#else
+  return 0;
+#endif
 }
 
 }


### PR DESCRIPTION
This PR allocates an internals object per group per thread.  This is still fairly theoretical since we don't use internals much anywhere, but we'll want this in place once we are generating models from odin2.

~Merge after #46, as it contains those commits - it's impossible to avoid the fallout from that PR, really~