### PR TITLE
Allow running a subset of groups in filter/unfilter

### DIFF
--- a/R/check.R
+++ b/R/check.R
@@ -1,12 +1,14 @@
 ## Distinct from the code in util_assert.R which are our generic
 ## validation functions, these are bits of validation that group
 ## together to validate inputs to dust systems.
-check_pars <- function(pars, n_groups, preserve_group_dimension,
+check_pars <- function(pars, n_groups, index_group, preserve_group_dimension,
                        name = deparse(substitute(pars)), call = NULL) {
   if (preserve_group_dimension) {
-    if (length(pars) != n_groups) {
+    expected <- if (is.null(index_group)) n_groups else length(index_group)
+    if (length(pars) != expected) {
+      what <- if (is.null(index_group)) "n_groups" else "index_group"
       cli::cli_abort(
-        paste("Expected 'pars' to have length {n_groups} to match 'n_groups',",
+        paste("Expected 'pars' to have length {expected} to match '{what}',",
               "but it had length {length(pars)}"),
         arg = "pars", call = call)
     }

--- a/R/filter-support.R
+++ b/R/filter-support.R
@@ -56,7 +56,7 @@ check_time_sequence <- function(time_start, time, call = NULL) {
 check_index <- function(index, max = NULL, unique = FALSE,
                         name = deparse(substitute(index)), call = NULL) {
   if (!is.null(index)) {
-    assert_integer(index, call = call)
+    assert_integer(index, name = name, call = call)
     if (any(index < 1)) {
       cli::cli_abort("All elements of '{name}' must be at least 1",
                      arg = name, call = call)

--- a/R/filter-support.R
+++ b/R/filter-support.R
@@ -53,12 +53,21 @@ check_time_sequence <- function(time_start, time, call = NULL) {
 }
 
 
-check_index <- function(index, call = NULL) {
+check_index <- function(index, max = NULL, unique = FALSE,
+                        name = deparse(substitute(index)), call = NULL) {
   if (!is.null(index)) {
     assert_integer(index, call = call)
-    if (any(index < 0)) {
-      cli::cli_abort("All elements of 'index' must be at least 1",
-                     arg = "index", call = call)
+    if (any(index < 1)) {
+      cli::cli_abort("All elements of '{name}' must be at least 1",
+                     arg = name, call = call)
+    }
+    if (!is.null(max) && any(index > max)) {
+      cli::cli_abort("All elements of '{name}' must be at most {max}",
+                     arg = name, call = call)
+    }
+    if (unique && anyDuplicated(index)) {
+      cli::cli_abort("All elements of '{name}' must be distinct",
+                     arg = name, call = call)
     }
   }
   index

--- a/R/interface-unfilter.R
+++ b/R/interface-unfilter.R
@@ -104,15 +104,21 @@ dust_unfilter_run <- function(unfilter, pars, initial = NULL,
                               save_history = FALSE, adjoint = FALSE,
                               index_group = NULL) {
   check_is_dust_unfilter(unfilter)
-  # TODO: parameter checking and updating need to go with our index too.
+  index_group <- check_index(index_group, max = unfilter$n_groups,
+                             unique = TRUE)
   if (!is.null(pars)) {
-    pars <- check_pars(pars, unfilter$n_groups,
+    pars <- check_pars(pars, unfilter$n_groups, index_group,
                        unfilter$preserve_group_dimension)
   }
   if (is.null(unfilter$ptr)) {
     if (is.null(pars)) {
       cli::cli_abort("'pars' cannot be NULL, as unfilter is not initialised",
                      arg = "pars")
+    }
+    if (!is.null(index_group)) {
+      cli::cli_abort(
+        "'index_group' must be NULL, as unfilter is not initialised",
+        arg = "index_group")
     }
     unfilter_create(unfilter, pars)
   } else if (!is.null(pars)) {
@@ -146,6 +152,8 @@ dust_unfilter_last_history <- function(unfilter, index_group = NULL) {
       "History is not current",
       i = "Unfilter has not yet been run"))
   }
+  index_group <- check_index(index_group, max = filter$n_groups,
+                             unique = TRUE)
   unfilter$methods$last_history(unfilter$ptr,
                                 index_group,
                                 unfilter$preserve_particle_dimension,
@@ -173,6 +181,8 @@ dust_unfilter_last_gradient <- function(unfilter, index_group = NULL) {
       "Gradient is not current",
       i = "Unfilter has not yet been run"))
   }
+  index_group <- check_index(index_group, max = filter$n_groups,
+                             unique = TRUE)
   unfilter$methods$last_gradient(unfilter$ptr,
                                  index_group,
                                  unfilter$preserve_particle_dimension,

--- a/R/interface-unfilter.R
+++ b/R/interface-unfilter.R
@@ -152,7 +152,7 @@ dust_unfilter_last_history <- function(unfilter, index_group = NULL) {
       "History is not current",
       i = "Unfilter has not yet been run"))
   }
-  index_group <- check_index(index_group, max = filter$n_groups,
+  index_group <- check_index(index_group, max = unfilter$n_groups,
                              unique = TRUE)
   unfilter$methods$last_history(unfilter$ptr,
                                 index_group,
@@ -181,7 +181,7 @@ dust_unfilter_last_gradient <- function(unfilter, index_group = NULL) {
       "Gradient is not current",
       i = "Unfilter has not yet been run"))
   }
-  index_group <- check_index(index_group, max = filter$n_groups,
+  index_group <- check_index(index_group, max = unfilter$n_groups,
                              unique = TRUE)
   unfilter$methods$last_gradient(unfilter$ptr,
                                  index_group,

--- a/R/interface.R
+++ b/R/interface.R
@@ -156,7 +156,7 @@ dust_system_create <- function(generator, pars, n_particles, n_groups = 1,
   preserve_particle_dimension <- preserve_particle_dimension || n_particles > 1
   preserve_group_dimension <- preserve_group_dimension || n_groups > 1
 
-  pars <- check_pars(pars, n_groups, preserve_group_dimension)
+  pars <- check_pars(pars, n_groups, NULL, preserve_group_dimension)
   if (generator$properties$time_type == "discrete") {
     if (!is.null(ode_control)) {
       cli::cli_abort("Can't use 'ode_control' with discrete-time systems")
@@ -350,7 +350,7 @@ dust_system_set_rng_state <- function(sys, rng_state) {
 ##' @export
 dust_system_update_pars <- function(sys, pars) {
   check_is_dust_system(sys)
-  pars <- check_pars(pars, sys$n_groups, sys$preserve_group_dimension)
+  pars <- check_pars(pars, sys$n_groups, NULL, sys$preserve_group_dimension)
   sys$methods$update_pars(sys$ptr, pars)
   invisible()
 }

--- a/inst/include/dust2/history.hpp
+++ b/inst/include/dust2/history.hpp
@@ -96,6 +96,14 @@ public:
     return position_ * len_order_;
   }
 
+  auto n_state() const {
+    return n_state_;
+  }
+
+  auto n_times() const {
+    return position_;
+  }
+
   auto& dims() const {
     return dims_;
   }

--- a/inst/include/dust2/history.hpp
+++ b/inst/include/dust2/history.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <algorithm>
-#include <array>
 #include <stdexcept>
 #include <vector>
 
@@ -24,8 +23,7 @@ public:
     times_(n_times_),
     state_(len_state_ * n_times_),
     order_(len_order_ * n_times_),
-    reorder_(n_times),
-    dims_({n_state_, n_particles_, n_groups_, position_}) {
+    reorder_(n_times) {
   }
 
   void resize_state(size_t n_state) {
@@ -102,10 +100,6 @@ public:
 
   auto n_times() const {
     return position_;
-  }
-
-  auto& dims() const {
-    return dims_;
   }
 
   template <typename Iter>
@@ -194,7 +188,6 @@ private:
   std::vector<real_type> state_;
   std::vector<size_t> order_;
   std::vector<bool> reorder_;
-  std::array<size_t, 4> dims_;
 
   // Reference implementation for this is mcstate:::history_single and
   // mcstate::history_multiple
@@ -219,7 +212,6 @@ private:
     times_[position_] = time;
     reorder_[position_] = reorder;
     position_++;
-    dims_[3] = position_;
   }
 
   template <typename IterReal>

--- a/inst/include/dust2/r/filter.hpp
+++ b/inst/include/dust2/r/filter.hpp
@@ -69,12 +69,12 @@ cpp11::sexp dust2_filter_last_history(cpp11::sexp ptr,
   constexpr bool reorder = true;
 
   const auto& history = obj->last_history();
-  const auto& dims = history.dims();
-  // Could use destructured bind here in recent C++?
-  const auto n_state = dims[0];
-  const auto n_particles = dims[1];
-  const auto n_groups = dims[2];
-  const auto n_times = dims[3];
+
+  const auto n_state = history.n_state(); // might be filtered
+  const auto n_particles = obj->sys.n_particles();
+  const auto n_groups = index_group.size();
+  const auto n_times = history.n_times();
+
   const auto len = n_state * n_particles * n_groups * n_times;
   cpp11::sexp ret = cpp11::writable::doubles(len);
   history.export_state(REAL(ret), reorder, index_group);

--- a/inst/include/dust2/r/unfilter.hpp
+++ b/inst/include/dust2/r/unfilter.hpp
@@ -76,16 +76,13 @@ cpp11::sexp dust2_unfilter_last_history(cpp11::sexp ptr,
 
   constexpr bool reorder = false; // never needed
 
-  // TODO: this needs an overhaul to work this way, because the
-  // history dims here from the history object is no longer correct -
-  // we'll want this now to come from us.
   const auto& history = obj->last_history();
-  const auto& dims = history.dims();
-  // Could use destructured bind here in recent C++?
-  const auto n_state = dims[0];
-  const auto n_particles = dims[1];
-  const auto n_groups = dims[2];
-  const auto n_times = dims[3];
+
+  const auto n_state = history.n_state(); // might be filtered
+  const auto n_particles = obj->sys.n_particles();
+  const auto n_groups = index_group.size();
+  const auto n_times = history.n_times();
+
   const auto len = n_state * n_particles * n_groups * n_times;
   cpp11::sexp ret = cpp11::writable::doubles(len);
   history.export_state(REAL(ret), reorder, index_group);

--- a/man/dust_filter_last_history.Rd
+++ b/man/dust_filter_last_history.Rd
@@ -12,7 +12,8 @@ dust_filter_last_history(filter, index_group = NULL)
 
 \item{index_group}{An optional vector of group indices to run the
 filter for.  You can use this to run a subset of possible
-groups, though at the moment this will likely crash.}
+groups, once the filter is initialised (this argument must be
+\code{NULL} on the \strong{first} call).}
 }
 \value{
 An array

--- a/man/dust_filter_run.Rd
+++ b/man/dust_filter_run.Rd
@@ -32,7 +32,8 @@ the history is restricted to these states.}
 
 \item{index_group}{An optional vector of group indices to run the
 filter for.  You can use this to run a subset of possible
-groups, though at the moment this will likely crash.}
+groups, once the filter is initialised (this argument must be
+\code{NULL} on the \strong{first} call).}
 }
 \value{
 A vector of likelihood values, with as many elements as

--- a/man/dust_unfilter_last_gradient.Rd
+++ b/man/dust_unfilter_last_gradient.Rd
@@ -12,7 +12,8 @@ dust_unfilter_last_gradient(unfilter, index_group = NULL)
 
 \item{index_group}{An optional vector of group indices to run the
 filter for.  You can use this to run a subset of possible
-groups, though at the moment this will likely crash.}
+groups, once the filter is initialised (this argument must be
+\code{NULL} on the \strong{first} call).}
 }
 \value{
 A vector (if ungrouped) or a matrix (if grouped).

--- a/man/dust_unfilter_last_history.Rd
+++ b/man/dust_unfilter_last_history.Rd
@@ -12,7 +12,8 @@ dust_unfilter_last_history(unfilter, index_group = NULL)
 
 \item{index_group}{An optional vector of group indices to run the
 filter for.  You can use this to run a subset of possible
-groups, though at the moment this will likely crash.}
+groups, once the filter is initialised (this argument must be
+\code{NULL} on the \strong{first} call).}
 }
 \value{
 An array

--- a/man/dust_unfilter_run.Rd
+++ b/man/dust_unfilter_run.Rd
@@ -38,7 +38,8 @@ gradients.}
 
 \item{index_group}{An optional vector of group indices to run the
 filter for.  You can use this to run a subset of possible
-groups, though at the moment this will likely crash.}
+groups, once the filter is initialised (this argument must be
+\code{NULL} on the \strong{first} call).}
 }
 \value{
 A vector of likelihood values, with as many elements as

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -58,12 +58,13 @@ cpp11::sexp test_history_(cpp11::doubles r_time, cpp11::list r_state,
     }
   }
 
-  cpp11::writable::doubles ret_time(static_cast<int>(n_times));
-  const size_t len = n_state * n_particles * n_groups * n_times;
+  const auto n_times_out = h.n_times();
+  cpp11::writable::doubles ret_time(static_cast<int>(n_times_out));
+  const size_t len = n_state * n_particles * n_groups * n_times_out;
   cpp11::writable::doubles ret_state(static_cast<int>(len));
   h.export_time(REAL(ret_time));
   h.export_state(REAL(ret_state), reorder, index_group);
-  dust2::r::set_array_dims(ret_state, {n_state, n_particles, n_groups, n_times});
+  dust2::r::set_array_dims(ret_state, {n_state, n_particles, n_groups, n_times_out});
 
   return cpp11::writable::list{ret_time, ret_state};
 }

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -58,11 +58,12 @@ cpp11::sexp test_history_(cpp11::doubles r_time, cpp11::list r_state,
     }
   }
 
-  cpp11::writable::doubles ret_time(static_cast<int>(h.size_time()));
-  cpp11::writable::doubles ret_state(static_cast<int>(h.size_state()));
+  cpp11::writable::doubles ret_time(static_cast<int>(n_times));
+  const size_t len = n_state * n_particles * n_groups * n_times;
+  cpp11::writable::doubles ret_state(static_cast<int>(len));
   h.export_time(REAL(ret_time));
   h.export_state(REAL(ret_state), reorder, index_group);
-  dust2::r::set_array_dims(ret_state, {n_state, n_particles, n_groups, h.size_time()});
+  dust2::r::set_array_dims(ret_state, {n_state, n_particles, n_groups, n_times});
 
   return cpp11::writable::list{ret_time, ret_state};
 }

--- a/tests/testthat/test-filter-details.R
+++ b/tests/testthat/test-filter-details.R
@@ -161,3 +161,52 @@ test_that("can extract history with group index, no reordering", {
   expect_equal(test_history(time, s, index_group = c(3, 1)),
                list(time, s_arr[, , c(3, 1), , drop = FALSE]))
 })
+
+
+test_that("can reorder history on the way out", {
+  ## This is really hard to get right so let's actually simulate forward:
+  time <- seq(0, 10, length.out = 11)
+  n_time <- length(time)
+  n_state <- 6
+  n_particles <- 7
+  n_groups <- 3
+  state <- vector("list", length(time))
+  order <- vector("list", length(time))
+  true <- array(NA_real_, c(n_state, n_particles, n_groups, n_time))
+  s <- array(0, c(n_state, n_particles, n_groups))
+  set.seed(1)
+  for (i in seq_along(time)) {
+    s <- s + runif(length(s))
+    if (i > 1 && i %% 2 == 0) {
+      k <- replicate(n_groups, sample(n_particles, replace = TRUE))
+      order[[i]] <- as.integer(k - 1L)
+      for (j in seq_len(n_groups)) {
+        s[, , j] <- s[, k[, j], j] + 1
+        true[, , j, seq_len(i - 1)] <- true[, k[, j], j, seq_len(i - 1)]
+      }
+    }
+    state[[i]] <- s
+    true[, , , i] <- s
+  }
+
+  state_arr <- array(unlist(state), dim(true))
+  expect_equal(
+    test_history(time, state, order = order, reorder = TRUE),
+    list(time, true))
+  expect_equal(
+    test_history(time, state, order = order, reorder = TRUE, index_group = 1:3),
+    list(time, true))
+
+  expect_equal(
+    test_history(time, state, order = order, reorder = TRUE, index_group = 1),
+    list(time, true[, , 1, , drop = FALSE]))
+  expect_equal(
+    test_history(time, state, order = order, reorder = TRUE, index_group = 2),
+    list(time, true[, , 2, , drop = FALSE]))
+  expect_equal(
+    test_history(time, state, order = order, reorder = TRUE, index_group = 3),
+    list(time, true[, , 3, , drop = FALSE]))
+  expect_equal(
+    test_history(time, state, order = order, reorder = TRUE, index_group = 3:1),
+               list(time, true[, , 3:1, ]))
+})

--- a/tests/testthat/test-filter-details.R
+++ b/tests/testthat/test-filter-details.R
@@ -136,3 +136,28 @@ test_that("can reorder history on the way out", {
   expect_equal(test_history(time, state, order = order, reorder = TRUE),
                list(time, true))
 })
+
+
+test_that("can extract history with group index, no reordering", {
+  time <- seq(0, 10, length.out = 11)
+  n_state <- 5
+  n_particles <- 7
+  n_groups <- 3
+  n_time <- length(time)
+  s <- lapply(seq_along(time), function(i) {
+    array(runif(n_state * n_particles * n_groups),
+          c(n_state, n_particles, n_groups))
+  })
+
+  s_arr <- array(unlist(s), c(n_state, n_particles, n_groups, n_time))
+
+  expect_equal(test_history(time, s, index_group = NULL),
+               list(time, s_arr))
+  expect_equal(test_history(time, s, index_group = seq_len(n_groups)),
+               list(time, s_arr))
+
+  expect_equal(test_history(time, s, index_group = 2),
+               list(time, s_arr[, , 2, , drop = FALSE]))
+  expect_equal(test_history(time, s, index_group = c(3, 1)),
+               list(time, s_arr[, , c(3, 1), , drop = FALSE]))
+})

--- a/tests/testthat/test-filter-support.R
+++ b/tests/testthat/test-filter-support.R
@@ -43,8 +43,10 @@ test_that("can validate time sequence", {
 test_that("check index", {
   expect_no_error(check_index(NULL))
   expect_no_error(check_index(1:4))
-  expect_error(check_index(c(1, 2, 3.4)),
-               "Expected 'index' to be integer")
-  expect_error(check_index(c(1, 2, -3)),
-               "All elements of 'index' must be at least 1")
+  idx <- c(1, 2, 3.4)
+  expect_error(check_index(idx),
+               "Expected 'idx' to be integer")
+  idx <- c(1, 2, -3)
+  expect_error(check_index(idx),
+               "All elements of 'idx' must be at least 1")
 })

--- a/tests/testthat/test-unfilter.R
+++ b/tests/testthat/test-unfilter.R
@@ -245,3 +245,31 @@ test_that("history output can have dimensions preserved", {
   expect_equal(dim(h4), c(5, 1, 1, 4))
   expect_equal(drop(h4), h1)
 })
+
+
+test_that("can run a subset of an unfilter", {
+  pars <- list(
+    list(beta = 0.1, gamma = 0.2, N = 1000, I0 = 10, exp_noise = 1e6),
+    list(beta = 0.2, gamma = 0.2, N = 1000, I0 = 10, exp_noise = 1e6),
+    list(beta = 0.3, gamma = 0.2, N = 1000, I0 = 10, exp_noise = 1e6))
+
+  time_start <- 0
+  data <- data.frame(time = rep(c(4, 8, 12, 16), 3),
+                     group = rep(1:3, each = 4),
+                     incidence = 1:12)
+
+  obj <- dust_unfilter_create(sir(), time_start, data)
+  ll1 <- dust_unfilter_run(obj, pars)
+  expect_length(ll1, 3)
+
+  expect_equal(
+    dust_unfilter_run(obj, pars, index_group = 1:3),
+    ll1)
+  expect_equal(
+    dust_unfilter_run(obj, pars[3:1], index_group = 3:1),
+    rev(ll1))
+
+  expect_equal(
+    vnapply(1:3, function(i) dust_unfilter_run(obj, pars[i], index_group = i)),
+    ll1)
+})

--- a/tests/testthat/test-unfilter.R
+++ b/tests/testthat/test-unfilter.R
@@ -247,29 +247,79 @@ test_that("history output can have dimensions preserved", {
 })
 
 
-test_that("can run a subset of an unfilter", {
+test_that("can extract a subset of an unfilter run in its entirety", {
   pars <- list(
     list(beta = 0.1, gamma = 0.2, N = 1000, I0 = 10, exp_noise = 1e6),
-    list(beta = 0.2, gamma = 0.2, N = 1000, I0 = 10, exp_noise = 1e6),
-    list(beta = 0.3, gamma = 0.2, N = 1000, I0 = 10, exp_noise = 1e6))
+    list(beta = 0.2, gamma = 0.2, N = 1000, I0 = 10, exp_noise = 1e6))
+  time_start <- 0
+  data <- data.frame(time = rep(c(4, 8, 12, 16), 2),
+                     group = rep(1:2, each = 4),
+                     incidence = 1:8)
+  obj <- dust_unfilter_create(sir(), time_start, data, n_groups = 2)
+  dust_unfilter_run(obj, pars, save_history = TRUE)
+  h1 <- dust_unfilter_last_history(obj, index_group = 1)
+  h2 <- dust_unfilter_last_history(obj, index_group = 2)
+  h <- dust_unfilter_last_history(obj)
+  expect_equal(h1, h[, 1, , drop = FALSE])
+  expect_equal(h2, h[, 2, , drop = FALSE])
+})
+
+
+test_that("can extract a state-filtered subset of an unfilter run", {
+  pars <- list(
+    list(beta = 0.1, gamma = 0.2, N = 1000, I0 = 10, exp_noise = 1e6),
+    list(beta = 0.2, gamma = 0.2, N = 1000, I0 = 10, exp_noise = 1e6))
+  time_start <- 0
+  data <- data.frame(time = rep(c(4, 8, 12, 16), 2),
+                     group = rep(1:2, each = 4),
+                     incidence = 1:8)
+  obj <- dust_unfilter_create(sir(), time_start, data, n_groups = 2,
+                              index_state = c(1, 3, 5))
+  dust_unfilter_run(obj, pars, save_history = TRUE)
+  h1 <- dust_unfilter_last_history(obj, index_group = 1)
+  h2 <- dust_unfilter_last_history(obj, index_group = 2)
+  h <- dust_unfilter_last_history(obj)
+  expect_equal(h1, h[, 1, , drop = FALSE])
+  expect_equal(h2, h[, 2, , drop = FALSE])
+})
+
+
+test_that("can run a subset of an unfilter", {
+  pars0 <- rep(
+    list(list(beta = 0.01, gamma = 0.01, N = 100, I0 = 1, exp_noise = 1e6)),
+    3)
+  pars1 <- list(
+    list(beta = 0.1, gamma = 0.2, I0 = 10, exp_noise = 1e6),
+    list(beta = 0.2, gamma = 0.2, I0 = 10, exp_noise = 1e6),
+    list(beta = 0.3, gamma = 0.2, I0 = 10, exp_noise = 1e6))
 
   time_start <- 0
   data <- data.frame(time = rep(c(4, 8, 12, 16), 3),
                      group = rep(1:3, each = 4),
                      incidence = 1:12)
 
-  obj <- dust_unfilter_create(sir(), time_start, data)
-  ll1 <- dust_unfilter_run(obj, pars)
+  obj1 <- dust_unfilter_create(sir(), time_start, data)
+  ll0 <- dust_unfilter_run(obj1, pars0)
+  ll1 <- dust_unfilter_run(obj1, pars1, save_history = TRUE)
   expect_length(ll1, 3)
+  h1 <- dust_unfilter_last_history(obj1)
 
+  obj2 <- dust_unfilter_create(sir(), time_start, data)
+  ll0 <- dust_unfilter_run(obj2, pars0)
   expect_equal(
-    dust_unfilter_run(obj, pars, index_group = 1:3),
-    ll1)
-  expect_equal(
-    dust_unfilter_run(obj, pars[3:1], index_group = 3:1),
+    dust_unfilter_run(obj2, pars1[3:1], index_group = 3:1, save_history = TRUE),
     rev(ll1))
 
-  expect_equal(
-    vnapply(1:3, function(i) dust_unfilter_run(obj, pars[i], index_group = i)),
-    ll1)
+  expect_equal(dust_unfilter_last_history(obj2, index_group = 3:1),
+               h1[, 3:1, ])
+
+  for (i in 1:3) {
+    ll_i <- dust_unfilter_run(obj2, pars1[i], index_group = i,
+                              save_history = TRUE)
+    expect_equal(dust_unfilter_last_history(obj2, index_group = i),
+                 h1[, i, , drop = FALSE])
+    j <- i %% 3 + 1
+    expect_error(dust_unfilter_last_history(obj2, index_group = j),
+                 sprintf("History for group '%d' is not current", j))
+  }
 })


### PR DESCRIPTION
This PR builds on #49, allowing us to run a filter/unfilter for a subset of parameter groups.  The little test helper for history sorting did a lot of the heavy lifting and you should be able to see the effect in the tests.  Not too bad in the end!