### PR TITLE
Build mcstate interface for models with gradients

### DIFF
--- a/R/interface-unfilter.R
+++ b/R/interface-unfilter.R
@@ -54,6 +54,7 @@ dust_unfilter_create <- function(generator, time_start, data,
          n_particles = as.integer(n_particles),
          n_groups = as.integer(n_groups),
          deterministic = TRUE,
+         has_adjoint = generator$properties$has_adjoint,
          methods = generator$methods$unfilter,
          index_state = index_state,
          preserve_particle_dimension = preserve_particle_dimension,
@@ -89,10 +90,11 @@ unfilter_create <- function(unfilter, pars) {
 ##' @param unfilter A `dust_unfilter` object, created by
 ##'   [dust_unfilter_create]
 ##'
-##' @param adjoint Logical, indicating if we should enable adjoint
-##'   history saving.  This can be enabled even when your model does not
-##'   support adjoints!  But you will not be able to compute
-##'   gradients.
+##' @param adjoint Optional logical, indicating if we should enable
+##'   adjoint history saving.  This is enabled by default if your
+##'   model has an adjoint, but can be disabled or enabled even when
+##'   your model does not support adjoints!  But if you don't actually
+##'   have an adjoint you will not be able to compute gradients.
 ##'
 ##' @inheritParams dust_filter_run
 ##'
@@ -101,7 +103,7 @@ unfilter_create <- function(unfilter, pars) {
 ##'
 ##' @export
 dust_unfilter_run <- function(unfilter, pars, initial = NULL,
-                              save_history = FALSE, adjoint = FALSE,
+                              save_history = FALSE, adjoint = NULL,
                               index_group = NULL) {
   check_is_dust_unfilter(unfilter)
   index_group <- check_index(index_group, max = unfilter$n_groups,
@@ -123,6 +125,11 @@ dust_unfilter_run <- function(unfilter, pars, initial = NULL,
     unfilter_create(unfilter, pars)
   } else if (!is.null(pars)) {
     unfilter$methods$update_pars(unfilter$ptr, pars, index_group)
+  }
+  if (is.null(adjoint)) {
+    adjoint <- unfilter$has_adjoint
+  } else {
+    assert_scalar_logical(adjoint, call = environment())
   }
   unfilter$methods$run(unfilter$ptr,
                        initial,

--- a/R/interface.R
+++ b/R/interface.R
@@ -549,6 +549,10 @@ print.dust_system <- function(x, ...) {
     cli::cli_bullets(c(
       i = "This system has 'compare_data' support"))
   }
+  if (x$properties$has_adjoint) {
+    cli::cli_bullets(c(
+      i = "This system has 'adjoint' support, and can compute gradients"))
+  }
   cli::cli_bullets(c(
     i = "This system runs in {x$properties$time_type} time"))
   ## Later, we might print some additional capabilities of the system

--- a/R/mcstate.R
+++ b/R/mcstate.R
@@ -110,6 +110,7 @@ dust_filter_mcstate <- function(filter, packer, initial = NULL,
     ## but us should be depending on the internal structures of
     ## filter.
     density <- function(x) {
+      pars <- packer$unpack(x)
       if (!identical(x, attr(filter$ptr, "last_pars"))) {
         ret <- dust_unfilter_run(
           filter,
@@ -133,6 +134,7 @@ dust_filter_mcstate <- function(filter, packer, initial = NULL,
     }
   } else {
     density <- function(x) {
+      pars <- packer$unpack(x)
       dust_filter_run(
         filter,
         pars,

--- a/man/dust_unfilter_run.Rd
+++ b/man/dust_unfilter_run.Rd
@@ -9,7 +9,7 @@ dust_unfilter_run(
   pars,
   initial = NULL,
   save_history = FALSE,
-  adjoint = FALSE,
+  adjoint = NULL,
   index_group = NULL
 )
 }
@@ -31,10 +31,11 @@ trajectories) will be saved at each time in the filter.  If the
 filter was constructed using a non-\code{NULL} \code{index_state} parameter,
 the history is restricted to these states.}
 
-\item{adjoint}{Logical, indicating if we should enable adjoint
-history saving.  This can be enabled even when your model does not
-support adjoints!  But you will not be able to compute
-gradients.}
+\item{adjoint}{Optional logical, indicating if we should enable
+adjoint history saving.  This is enabled by default if your
+model has an adjoint, but can be disabled or enabled even when
+your model does not support adjoints!  But if you don't actually
+have an adjoint you will not be able to compute gradients.}
 
 \item{index_group}{An optional vector of group indices to run the
 filter for.  You can use this to run a subset of possible

--- a/tests/testthat/test-mcstate.R
+++ b/tests/testthat/test-mcstate.R
@@ -42,6 +42,10 @@ test_that("can create deterministic model", {
 
   m <- dust_filter_mcstate(obj, packer)
   expect_false(m$properties$is_stochastic)
+  expect_true(m$properties$has_gradient)
+
+  expect_length(m$density(c(0.2, 0.1)), 1)
+  expect_length(m$gradient(c(0.2, 0.1)), 3)
 
   expect_s3_class(m, "mcstate_model")
   sampler <- mcstate2::mcstate_sampler_random_walk(diag(2) * c(0.02, 0.02))

--- a/tests/testthat/test-unfilter-adjoint.R
+++ b/tests/testthat/test-unfilter-adjoint.R
@@ -5,7 +5,7 @@ test_that("can run an unfilter via the adjoint method", {
   data <- data.frame(time = c(4, 8, 12, 16), incidence = 1:4)
 
   obj <- dust_unfilter_create(sir(), time_start, data)
-  ll1 <- dust_unfilter_run(obj, pars)
+  ll1 <- dust_unfilter_run(obj, pars, adjoint = FALSE)
   ll2 <- dust_unfilter_run(obj, pars, adjoint = TRUE)
   expect_identical(ll2, ll1)
 })
@@ -38,9 +38,25 @@ test_that("can't compute adjoint where it was not enabled in the unfilter", {
   obj <- dust_unfilter_create(sir(), time_start, data)
   expect_error(dust_unfilter_last_gradient(obj),
                "Gradient is not current")
-  ll1 <- dust_unfilter_run(obj, pars)
+  ll1 <- dust_unfilter_run(obj, pars, adjoint = FALSE)
   expect_error(dust_unfilter_last_gradient(obj),
                "System was not run with 'adjoint = TRUE'")
+})
+
+
+test_that("adjoint is enabled in unfilter by default", {
+  pars <- list(beta = 0.1, gamma = 0.2, N = 1000, I0 = 10, exp_noise = 1e6)
+
+  time_start <- 0
+  data <- data.frame(time = c(4, 8, 12, 16), incidence = 1:4)
+
+  ## TODO: these errors end up quite different, but that's
+  ## unavoidable?
+  obj <- dust_unfilter_create(sir(), time_start, data)
+  expect_error(dust_unfilter_last_gradient(obj),
+               "Gradient is not current")
+  ll <- dust_unfilter_run(obj, pars)
+  expect_length(dust_unfilter_last_gradient(obj), 3)
 })
 
 
@@ -61,7 +77,7 @@ test_that("can compute multiple gradients at once", {
     dust_unfilter_create(sir(), time_start, data[data$group == i, -2])
   })
 
-  ll1 <- dust_unfilter_run(obj1, pars)
+  ll1 <- dust_unfilter_run(obj1, pars, adjoint = FALSE)
   ll2 <- dust_unfilter_run(obj1, pars, adjoint = TRUE)
   expect_equal(ll1, ll2)
 
@@ -89,7 +105,7 @@ test_that("can save history while running unfilter with adjoint", {
   data <- data.frame(time = c(4, 8, 12, 16), incidence = 1:4)
 
   obj <- dust_unfilter_create(sir(), time_start, data)
-  ll1 <- dust_unfilter_run(obj, pars, save_history = TRUE)
+  ll1 <- dust_unfilter_run(obj, pars, adjoint = FALSE, save_history = TRUE)
   h1 <- dust_unfilter_last_history(obj)
 
   ll2 <- dust_unfilter_run(obj, pars, adjoint = TRUE, save_history = TRUE)


### PR DESCRIPTION
Small but worth looking through - there's some unplesantness around the last_gradient bit, and I wonder if eventually we should move to a "density-with-gradient" interface for some of this?  I think the solution is ok, but I also think we can do better in future by pushing this logic into the C++ code.  For now it does the right thing at least.

Note that the behaviour of the 'adjoint' argument to running the unfilter has changed, along with the default.