### PR TITLE
Select random  particle from filter

### DIFF
--- a/R/cpp11.R
+++ b/R/cpp11.R
@@ -132,8 +132,8 @@ dust2_filter_sir_run <- function(ptr, r_initial, save_history, index_group, pres
   .Call(`_dust2_dust2_filter_sir_run`, ptr, r_initial, save_history, index_group, preserve_group_dimension)
 }
 
-dust2_filter_sir_last_history <- function(ptr, r_index_group, preserve_group_dimension) {
-  .Call(`_dust2_dust2_filter_sir_last_history`, ptr, r_index_group, preserve_group_dimension)
+dust2_filter_sir_last_history <- function(ptr, r_index_group, select_random_particle, preserve_group_dimension) {
+  .Call(`_dust2_dust2_filter_sir_last_history`, ptr, r_index_group, select_random_particle, preserve_group_dimension)
 }
 
 dust2_filter_sir_rng_state <- function(ptr) {
@@ -208,8 +208,8 @@ test_scale_log_weights <- function(w) {
   .Call(`_dust2_test_scale_log_weights`, w)
 }
 
-test_history_ <- function(r_time, r_state, r_order, r_index_group, reorder) {
-  .Call(`_dust2_test_history_`, r_time, r_state, r_order, r_index_group, reorder)
+test_history_ <- function(r_time, r_state, r_order, r_index_group, r_index_particle, reorder) {
+  .Call(`_dust2_test_history_`, r_time, r_state, r_order, r_index_group, r_index_particle, reorder)
 }
 
 test_interpolate_search <- function(target, x) {

--- a/R/cpp11.R
+++ b/R/cpp11.R
@@ -208,8 +208,8 @@ test_scale_log_weights <- function(w) {
   .Call(`_dust2_test_scale_log_weights`, w)
 }
 
-test_history_ <- function(r_time, r_state, r_order, r_index_group, r_index_particle, reorder) {
-  .Call(`_dust2_test_history_`, r_time, r_state, r_order, r_index_group, r_index_particle, reorder)
+test_history_ <- function(r_time, r_state, r_order, r_index_group, r_select_particle, reorder) {
+  .Call(`_dust2_test_history_`, r_time, r_state, r_order, r_index_group, r_select_particle, reorder)
 }
 
 test_interpolate_search <- function(target, x) {

--- a/R/interface-filter.R
+++ b/R/interface-filter.R
@@ -193,10 +193,22 @@ dust_filter_run <- function(filter, pars, initial = NULL,
 ##'
 ##' @inheritParams dust_filter_run
 ##'
-##' @return An array
+##' @inheritParams select_random_particle Logical, indicating if we
+##'   should return a history for one randomly selected particle
+##'   (rather than the entire history).  If this is `TRUE`, the
+##'   particle will be selected independently for each group, if the
+##'   filter is grouped.  This option is intended to help select a
+##'   representative trajectory during an MCMC.  When `TRUE`, we drop
+##'   the `particle` dimension of the return value.
+##'
+##' @return An array.  If ungrouped this will have dimensions `state`
+##'   x `particle` x `time`, and if grouped then `state` x `particle`
+##'   x `group` x `time`.  If `select_random_particle = TRUE`, the
+##'   second (particle) dimension will be dropped.
 ##'
 ##' @export
-dust_filter_last_history <- function(filter, index_group = NULL) {
+dust_filter_last_history <- function(filter, index_group = NULL,
+                                     select_random_particle = FALSE) {
   check_is_dust_filter(filter)
   if (is.null(filter$ptr)) {
     cli::cli_abort(c(
@@ -205,7 +217,9 @@ dust_filter_last_history <- function(filter, index_group = NULL) {
   }
   index_group <- check_index(index_group, max = filter$n_groups,
                              unique = TRUE)
+  assert_scalar_logical(select_random_particle)
   filter$methods$last_history(filter$ptr, index_group,
+                              select_random_particle,
                               filter$preserve_group_dimension)
 }
 

--- a/R/interface-filter.R
+++ b/R/interface-filter.R
@@ -193,13 +193,13 @@ dust_filter_run <- function(filter, pars, initial = NULL,
 ##'
 ##' @inheritParams dust_filter_run
 ##'
-##' @inheritParams select_random_particle Logical, indicating if we
-##'   should return a history for one randomly selected particle
-##'   (rather than the entire history).  If this is `TRUE`, the
-##'   particle will be selected independently for each group, if the
-##'   filter is grouped.  This option is intended to help select a
-##'   representative trajectory during an MCMC.  When `TRUE`, we drop
-##'   the `particle` dimension of the return value.
+##' @param select_random_particle Logical, indicating if we should
+##'   return a history for one randomly selected particle (rather than
+##'   the entire history).  If this is `TRUE`, the particle will be
+##'   selected independently for each group, if the filter is grouped.
+##'   This option is intended to help select a representative
+##'   trajectory during an MCMC.  When `TRUE`, we drop the `particle`
+##'   dimension of the return value.
 ##'
 ##' @return An array.  If ungrouped this will have dimensions `state`
 ##'   x `particle` x `time`, and if grouped then `state` x `particle`

--- a/R/test.R
+++ b/R/test.R
@@ -1,4 +1,6 @@
 test_history <- function(time, state, order = NULL, index_group = NULL,
-                         reorder = FALSE) {
-  test_history_(time, state, order, index_group, reorder)
+                         index_particle = NULL, reorder = FALSE) {
+  ## TODO: move index_particle ahead of index_group everywhere, once
+  ## we're stable.
+  test_history_(time, state, order, index_group, index_particle, reorder)
 }

--- a/R/test.R
+++ b/R/test.R
@@ -1,6 +1,4 @@
 test_history <- function(time, state, order = NULL, index_group = NULL,
-                         index_particle = NULL, reorder = FALSE) {
-  ## TODO: move index_particle ahead of index_group everywhere, once
-  ## we're stable.
-  test_history_(time, state, order, index_group, index_particle, reorder)
+                         select_particle = NULL, reorder = FALSE) {
+  test_history_(time, state, order, index_group, select_particle, reorder)
 }

--- a/R/util_assert.R
+++ b/R/util_assert.R
@@ -86,7 +86,7 @@ assert_scalar_numeric <- function(x, name = deparse(substitute(x)),
 
 
 assert_scalar_logical <- function(x, name = deparse(substitute(x)),
-                                  arg = name, call = NULL) {
+                                  arg = name, call = parent.frame()) {
   assert_scalar(x, name, arg = arg, call = call)
   assert_logical(x, name, arg = arg, call = call)
   assert_nonmissing(x, name, arg = arg, call = call)

--- a/inst/include/dust2/filter.hpp
+++ b/inst/include/dust2/filter.hpp
@@ -124,7 +124,7 @@ public:
   }
 
   auto select_random_particle(size_t group) {
-    const auto u = mcstate::random::random_real<real_type>(rng_.state(group));
+    const auto u = monty::random::random_real<real_type>(rng_.state(group));
     return static_cast<size_t>(std::floor(u * n_particles_));
   }
 

--- a/inst/include/dust2/filter.hpp
+++ b/inst/include/dust2/filter.hpp
@@ -123,6 +123,11 @@ public:
     return rng_.import_state(rng_state);
   }
 
+  auto select_random_particle(size_t group) {
+    const auto u = mcstate::random::random_real<real_type>(rng_.state(group));
+    return static_cast<size_t>(std::floor(u * n_particles_));
+  }
+
 private:
   real_type time_start_;
   std::vector<real_type> time_;

--- a/inst/include/dust2/history.hpp
+++ b/inst/include/dust2/history.hpp
@@ -176,8 +176,8 @@ public:
 	for (auto j : index_group) {
 	  const auto offset_state = j * n_state_ * n_particles_;
 	  if (use_select_particle) {
-	    const auto offset_i = select_particle[i] * n_state_;
-	    iter = std::copy_n(iter_state + offset_state + offset_i,
+	    const auto offset_j = select_particle[j] * n_state_;
+	    iter = std::copy_n(iter_state + offset_state + offset_j,
 			       n_state_,
 			       iter);
 	  } else {

--- a/inst/include/dust2/history.hpp
+++ b/inst/include/dust2/history.hpp
@@ -156,10 +156,11 @@ public:
           const auto offset_output =
             i * len_state_output + j * n_state_ * n_particles_out;
 	  if (use_select_particle) {
-	    std::copy_n(iter_state + offset_state + index_particle[j] * n_state_, n_state_, iter + offset_output);
-	    if (reorder) {
-	      index_particle[j] = *(iter_order + index_particle[j]);
-	    }
+	    reorder_single_(iter_state + offset_state,
+			    iter_order + offset_index,
+			    reorder_[i],
+			    iter + offset_output,
+			    index_particle[j]);
 	  } else {
 	    reorder_group_(iter_state + offset_state,
 			   iter_order + offset_index,
@@ -224,6 +225,20 @@ private:
         const auto index_particle_i = index_particle + i;
         *index_particle_i = *(iter_order + *index_particle_i);
       }
+    }
+  }
+
+  template <typename Iter>
+  void reorder_single_(typename std::vector<real_type>::const_iterator iter_state,
+		       typename std::vector<size_t>::const_iterator iter_order,
+		       bool reorder,
+		       Iter iter_dest,
+		       size_t& index_particle) const {
+    std::copy_n(iter_state + index_particle * n_state_,
+		n_state_,
+		iter_dest);
+    if (reorder) {
+      index_particle = *(iter_order + index_particle);
     }
   }
 

--- a/inst/include/dust2/r/filter.hpp
+++ b/inst/include/dust2/r/filter.hpp
@@ -47,8 +47,8 @@ cpp11::sexp dust2_filter_run(cpp11::sexp ptr, cpp11::sexp r_initial,
 template <typename T>
 cpp11::sexp dust2_filter_last_history(cpp11::sexp ptr,
                                       cpp11::sexp r_index_group,
-				      bool select_random_particle,
-				      bool preserve_group_dimension) {
+                                      bool select_random_particle,
+                                      bool preserve_group_dimension) {
   auto *obj =
     cpp11::as_cpp<cpp11::external_pointer<filter<T>>>(ptr).get();
   const auto index_group = r_index_group == R_NilValue ? obj->sys.all_groups() :

--- a/inst/include/dust2/r/filter.hpp
+++ b/inst/include/dust2/r/filter.hpp
@@ -47,6 +47,7 @@ cpp11::sexp dust2_filter_run(cpp11::sexp ptr, cpp11::sexp r_initial,
 template <typename T>
 cpp11::sexp dust2_filter_last_history(cpp11::sexp ptr,
                                       cpp11::sexp r_index_group,
+				      bool select_random_particle,
 				      bool preserve_group_dimension) {
   auto *obj =
     cpp11::as_cpp<cpp11::external_pointer<filter<T>>>(ptr).get();
@@ -71,17 +72,33 @@ cpp11::sexp dust2_filter_last_history(cpp11::sexp ptr,
   const auto& history = obj->last_history();
 
   const auto n_state = history.n_state(); // might be filtered
-  const auto n_particles = obj->sys.n_particles();
+  const auto n_particles = select_random_particle ? 1 : obj->sys.n_particles();
   const auto n_groups = index_group.size();
   const auto n_times = history.n_times();
 
+  std::vector<size_t> index_particle;
+  if (select_random_particle) {
+    index_particle.resize(n_groups);
+    for (auto i : index_group) {
+      index_particle[i] = obj->select_random_particle(i);
+    }
+  }
+
   const auto len = n_state * n_particles * n_groups * n_times;
   cpp11::sexp ret = cpp11::writable::doubles(len);
-  history.export_state(REAL(ret), reorder, index_group);
-  if (preserve_group_dimension) {
-    set_array_dims(ret, {n_state, n_particles, n_groups, n_times});
+  history.export_state(REAL(ret), reorder, index_group, index_particle);
+  if (select_random_particle) {
+    if (preserve_group_dimension) {
+      set_array_dims(ret, {n_state, n_particles * n_groups, n_times});
+    } else {
+      set_array_dims(ret, {n_state, n_particles * n_groups * n_times});
+    }
   } else {
-    set_array_dims(ret, {n_state, n_particles * n_groups, n_times});
+    if (preserve_group_dimension) {
+      set_array_dims(ret, {n_state, n_particles, n_groups, n_times});
+    } else {
+      set_array_dims(ret, {n_state, n_particles * n_groups, n_times});
+    }
   }
   return ret;
 }

--- a/inst/include/dust2/r/system.hpp
+++ b/inst/include/dust2/r/system.hpp
@@ -261,7 +261,7 @@ SEXP dust2_system_simulate(cpp11::sexp ptr,
   // make later.
   const auto len = n_state_save * n_particles * n_groups * n_times;
   cpp11::sexp ret = cpp11::writable::doubles(len);
-  h.export_state(REAL(ret), false, index_group);
+  h.export_state(REAL(ret), false, index_group, {});
   if (preserve_group_dimension && preserve_particle_dimension) {
     set_array_dims(ret, {n_state_save, n_particles, n_groups, n_times});
   } else if (preserve_group_dimension || preserve_particle_dimension) {

--- a/inst/include/dust2/r/unfilter.hpp
+++ b/inst/include/dust2/r/unfilter.hpp
@@ -85,7 +85,7 @@ cpp11::sexp dust2_unfilter_last_history(cpp11::sexp ptr,
 
   const auto len = n_state * n_particles * n_groups * n_times;
   cpp11::sexp ret = cpp11::writable::doubles(len);
-  history.export_state(REAL(ret), reorder, index_group);
+  history.export_state(REAL(ret), reorder, index_group, {});
   if (preserve_group_dimension && preserve_particle_dimension) {
     set_array_dims(ret, {n_state, n_particles, n_groups, n_times});
   } else if (preserve_group_dimension || preserve_particle_dimension) {

--- a/inst/template/compare.cpp
+++ b/inst/template/compare.cpp
@@ -29,8 +29,8 @@ SEXP dust2_filter_{{name}}_run(cpp11::sexp ptr, cpp11::sexp r_initial, bool save
 }
 
 [[cpp11::register]]
-SEXP dust2_filter_{{name}}_last_history(cpp11::sexp ptr, cpp11::sexp r_index_group, bool preserve_group_dimension) {
-  return dust2::r::dust2_filter_last_history<dust2::dust_{{time_type}}<{{class}}>>(ptr, r_index_group, preserve_group_dimension);
+SEXP dust2_filter_{{name}}_last_history(cpp11::sexp ptr, cpp11::sexp r_index_group, bool select_random_particle, bool preserve_group_dimension) {
+  return dust2::r::dust2_filter_last_history<dust2::dust_{{time_type}}<{{class}}>>(ptr, r_index_group, select_random_particle, preserve_group_dimension);
 }
 
 [[cpp11::register]]

--- a/man/dust_filter_last_history.Rd
+++ b/man/dust_filter_last_history.Rd
@@ -4,7 +4,11 @@
 \alias{dust_filter_last_history}
 \title{Fetch last filter history}
 \usage{
-dust_filter_last_history(filter, index_group = NULL)
+dust_filter_last_history(
+  filter,
+  index_group = NULL,
+  select_random_particle = FALSE
+)
 }
 \arguments{
 \item{filter}{A \code{dust_filter} object, created by
@@ -14,9 +18,20 @@ dust_filter_last_history(filter, index_group = NULL)
 filter for.  You can use this to run a subset of possible
 groups, once the filter is initialised (this argument must be
 \code{NULL} on the \strong{first} call).}
+
+\item{select_random_particle}{Logical, indicating if we should
+return a history for one randomly selected particle (rather than
+the entire history).  If this is \code{TRUE}, the particle will be
+selected independently for each group, if the filter is grouped.
+This option is intended to help select a representative
+trajectory during an MCMC.  When \code{TRUE}, we drop the \code{particle}
+dimension of the return value.}
 }
 \value{
-An array
+An array.  If ungrouped this will have dimensions \code{state}
+x \code{particle} x \code{time}, and if grouped then \code{state} x \code{particle}
+x \code{group} x \code{time}.  If \code{select_random_particle = TRUE}, the
+second (particle) dimension will be dropped.
 }
 \description{
 Fetch the last history created by running a filter.  This

--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -237,10 +237,10 @@ extern "C" SEXP _dust2_dust2_filter_sir_run(SEXP ptr, SEXP r_initial, SEXP save_
   END_CPP11
 }
 // sir.cpp
-SEXP dust2_filter_sir_last_history(cpp11::sexp ptr, cpp11::sexp r_index_group, bool preserve_group_dimension);
-extern "C" SEXP _dust2_dust2_filter_sir_last_history(SEXP ptr, SEXP r_index_group, SEXP preserve_group_dimension) {
+SEXP dust2_filter_sir_last_history(cpp11::sexp ptr, cpp11::sexp r_index_group, bool select_random_particle, bool preserve_group_dimension);
+extern "C" SEXP _dust2_dust2_filter_sir_last_history(SEXP ptr, SEXP r_index_group, SEXP select_random_particle, SEXP preserve_group_dimension) {
   BEGIN_CPP11
-    return cpp11::as_sexp(dust2_filter_sir_last_history(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_group), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_group_dimension)));
+    return cpp11::as_sexp(dust2_filter_sir_last_history(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_group), cpp11::as_cpp<cpp11::decay_t<bool>>(select_random_particle), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_group_dimension)));
   END_CPP11
 }
 // sir.cpp
@@ -370,10 +370,10 @@ extern "C" SEXP _dust2_test_scale_log_weights(SEXP w) {
   END_CPP11
 }
 // test.cpp
-cpp11::sexp test_history_(cpp11::doubles r_time, cpp11::list r_state, cpp11::sexp r_order, cpp11::sexp r_index_group, bool reorder);
-extern "C" SEXP _dust2_test_history_(SEXP r_time, SEXP r_state, SEXP r_order, SEXP r_index_group, SEXP reorder) {
+cpp11::sexp test_history_(cpp11::doubles r_time, cpp11::list r_state, cpp11::sexp r_order, cpp11::sexp r_index_group, cpp11::sexp r_index_particle, bool reorder);
+extern "C" SEXP _dust2_test_history_(SEXP r_time, SEXP r_state, SEXP r_order, SEXP r_index_group, SEXP r_index_particle, SEXP reorder) {
   BEGIN_CPP11
-    return cpp11::as_sexp(test_history_(cpp11::as_cpp<cpp11::decay_t<cpp11::doubles>>(r_time), cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(r_state), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_order), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_group), cpp11::as_cpp<cpp11::decay_t<bool>>(reorder)));
+    return cpp11::as_sexp(test_history_(cpp11::as_cpp<cpp11::decay_t<cpp11::doubles>>(r_time), cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(r_state), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_order), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_group), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_particle), cpp11::as_cpp<cpp11::decay_t<bool>>(reorder)));
   END_CPP11
 }
 // test_interpolate.cpp
@@ -492,7 +492,7 @@ extern "C" SEXP _dust2_dust2_system_walk_simulate(SEXP ptr, SEXP r_times, SEXP r
 extern "C" {
 static const R_CallMethodDef CallEntries[] = {
     {"_dust2_dust2_filter_sir_alloc",                  (DL_FUNC) &_dust2_dust2_filter_sir_alloc,                  10},
-    {"_dust2_dust2_filter_sir_last_history",           (DL_FUNC) &_dust2_dust2_filter_sir_last_history,            3},
+    {"_dust2_dust2_filter_sir_last_history",           (DL_FUNC) &_dust2_dust2_filter_sir_last_history,            4},
     {"_dust2_dust2_filter_sir_rng_state",              (DL_FUNC) &_dust2_dust2_filter_sir_rng_state,               1},
     {"_dust2_dust2_filter_sir_run",                    (DL_FUNC) &_dust2_dust2_filter_sir_run,                     5},
     {"_dust2_dust2_filter_sir_set_rng_state",          (DL_FUNC) &_dust2_dust2_filter_sir_set_rng_state,           2},
@@ -553,7 +553,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_dust2_dust2_unfilter_sir_last_history",         (DL_FUNC) &_dust2_dust2_unfilter_sir_last_history,          4},
     {"_dust2_dust2_unfilter_sir_run",                  (DL_FUNC) &_dust2_dust2_unfilter_sir_run,                   7},
     {"_dust2_dust2_unfilter_sir_update_pars",          (DL_FUNC) &_dust2_dust2_unfilter_sir_update_pars,           3},
-    {"_dust2_test_history_",                           (DL_FUNC) &_dust2_test_history_,                            5},
+    {"_dust2_test_history_",                           (DL_FUNC) &_dust2_test_history_,                            6},
     {"_dust2_test_interpolate_constant1",              (DL_FUNC) &_dust2_test_interpolate_constant1,               3},
     {"_dust2_test_interpolate_linear1",                (DL_FUNC) &_dust2_test_interpolate_linear1,                 3},
     {"_dust2_test_interpolate_search",                 (DL_FUNC) &_dust2_test_interpolate_search,                  2},

--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -370,10 +370,10 @@ extern "C" SEXP _dust2_test_scale_log_weights(SEXP w) {
   END_CPP11
 }
 // test.cpp
-cpp11::sexp test_history_(cpp11::doubles r_time, cpp11::list r_state, cpp11::sexp r_order, cpp11::sexp r_index_group, cpp11::sexp r_index_particle, bool reorder);
-extern "C" SEXP _dust2_test_history_(SEXP r_time, SEXP r_state, SEXP r_order, SEXP r_index_group, SEXP r_index_particle, SEXP reorder) {
+cpp11::sexp test_history_(cpp11::doubles r_time, cpp11::list r_state, cpp11::sexp r_order, cpp11::sexp r_index_group, cpp11::sexp r_select_particle, bool reorder);
+extern "C" SEXP _dust2_test_history_(SEXP r_time, SEXP r_state, SEXP r_order, SEXP r_index_group, SEXP r_select_particle, SEXP reorder) {
   BEGIN_CPP11
-    return cpp11::as_sexp(test_history_(cpp11::as_cpp<cpp11::decay_t<cpp11::doubles>>(r_time), cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(r_state), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_order), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_group), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_particle), cpp11::as_cpp<cpp11::decay_t<bool>>(reorder)));
+    return cpp11::as_sexp(test_history_(cpp11::as_cpp<cpp11::decay_t<cpp11::doubles>>(r_time), cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(r_state), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_order), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_group), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_select_particle), cpp11::as_cpp<cpp11::decay_t<bool>>(reorder)));
   END_CPP11
 }
 // test_interpolate.cpp

--- a/src/sir.cpp
+++ b/src/sir.cpp
@@ -313,8 +313,8 @@ SEXP dust2_filter_sir_run(cpp11::sexp ptr, cpp11::sexp r_initial, bool save_hist
 }
 
 [[cpp11::register]]
-SEXP dust2_filter_sir_last_history(cpp11::sexp ptr, cpp11::sexp r_index_group, bool preserve_group_dimension) {
-  return dust2::r::dust2_filter_last_history<dust2::dust_discrete<sir>>(ptr, r_index_group, preserve_group_dimension);
+SEXP dust2_filter_sir_last_history(cpp11::sexp ptr, cpp11::sexp r_index_group, bool select_random_particle, bool preserve_group_dimension) {
+  return dust2::r::dust2_filter_last_history<dust2::dust_discrete<sir>>(ptr, r_index_group, select_random_particle, preserve_group_dimension);
 }
 
 [[cpp11::register]]

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -45,7 +45,8 @@ cpp11::sexp test_history_(cpp11::doubles r_time, cpp11::list r_state,
   const auto index_group = r_index_group == R_NilValue ? all_groups :
     dust2::r::check_index(r_index_group, all_groups.size(), "index_group");
   std::vector<size_t> index_particle;
-  if (r_index_particle != R_NilValue) {
+  const bool use_index_particle = r_index_particle != R_NilValue;
+  if (use_index_particle) {
     dust2::r::check_length(r_index_particle, all_groups.size(),
 			   "index_particle");
     index_particle = dust2::r::check_index(r_index_particle, n_particles,
@@ -75,7 +76,12 @@ cpp11::sexp test_history_(cpp11::doubles r_time, cpp11::list r_state,
   cpp11::writable::doubles ret_state(static_cast<int>(len));
   h.export_time(REAL(ret_time));
   h.export_state(REAL(ret_state), reorder, index_group, index_particle);
-  dust2::r::set_array_dims(ret_state, {n_state, n_particles_out, n_groups, n_times_out});
+
+  if (use_index_particle) {
+    dust2::r::set_array_dims(ret_state, {n_state, n_particles_out * n_groups, n_times_out});
+  } else {
+    dust2::r::set_array_dims(ret_state, {n_state, n_particles_out, n_groups, n_times_out});
+  }
 
   return cpp11::writable::list{ret_time, ret_state};
 }

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -44,16 +44,17 @@ cpp11::sexp test_history_(cpp11::doubles r_time, cpp11::list r_state,
 
   const auto index_group = r_index_group == R_NilValue ? all_groups :
     dust2::r::check_index(r_index_group, all_groups.size(), "index_group");
+  const size_t n_groups = index_group.size();
+
   std::vector<size_t> index_particle;
   const bool use_index_particle = r_index_particle != R_NilValue;
   if (use_index_particle) {
-    dust2::r::check_length(r_index_particle, all_groups.size(),
-			   "index_particle");
+    dust2::r::check_length(r_index_particle, n_groups, "index_particle");
     index_particle = dust2::r::check_index(r_index_particle, n_particles,
 					   "index_particle");
   }
 
-  const size_t n_groups = index_group.size();
+
   const size_t n_particles_out = index_particle.empty() ? n_particles : 1;
 
   dust2::history<double> h(n_state, n_particles, n_groups_all, n_times);

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -27,7 +27,7 @@ cpp11::list test_scale_log_weights(std::vector<double> w) {
 cpp11::sexp test_history_(cpp11::doubles r_time, cpp11::list r_state,
                           cpp11::sexp r_order,
                           cpp11::sexp r_index_group,
-			  cpp11::sexp r_index_particle,
+			  cpp11::sexp r_select_particle,
                           bool reorder) {
   const size_t n_times = r_time.size();
   cpp11::sexp el0 = r_state[0];
@@ -38,24 +38,24 @@ cpp11::sexp test_history_(cpp11::doubles r_time, cpp11::list r_state,
   for (size_t i = 0; i < n_groups_all; ++i) {
     all_groups.push_back(i);
   }
+  const auto index_group = r_index_group == R_NilValue ? all_groups :
+    dust2::r::check_index(r_index_group, all_groups.size(), "index_group");
 
   const size_t n_state = r_dim[0];
   const size_t n_particles = r_dim[1];
-
-  const auto index_group = r_index_group == R_NilValue ? all_groups :
-    dust2::r::check_index(r_index_group, all_groups.size(), "index_group");
   const size_t n_groups = index_group.size();
 
-  std::vector<size_t> index_particle;
-  const bool use_index_particle = r_index_particle != R_NilValue;
-  if (use_index_particle) {
-    dust2::r::check_length(r_index_particle, n_groups, "index_particle");
-    index_particle = dust2::r::check_index(r_index_particle, n_particles,
-					   "index_particle");
+  std::vector<size_t> select_particle;
+  const bool use_select_particle = r_select_particle != R_NilValue;
+  if (use_select_particle) {
+    dust2::r::check_length(r_select_particle, all_groups.size(),
+                           "select_particle");
+    select_particle = dust2::r::check_index(r_select_particle, n_particles,
+                                            "select_particle");
   }
 
 
-  const size_t n_particles_out = index_particle.empty() ? n_particles : 1;
+  const size_t n_particles_out = select_particle.empty() ? n_particles : 1;
 
   dust2::history<double> h(n_state, n_particles, n_groups_all, n_times);
   for (size_t i = 0; i < static_cast<size_t>(r_state.size()); ++i) {
@@ -76,9 +76,9 @@ cpp11::sexp test_history_(cpp11::doubles r_time, cpp11::list r_state,
   const size_t len = n_state * n_particles_out * n_groups * n_times_out;
   cpp11::writable::doubles ret_state(static_cast<int>(len));
   h.export_time(REAL(ret_time));
-  h.export_state(REAL(ret_state), reorder, index_group, index_particle);
+  h.export_state(REAL(ret_state), reorder, index_group, select_particle);
 
-  if (use_index_particle) {
+  if (use_select_particle) {
     dust2::r::set_array_dims(ret_state, {n_state, n_particles_out * n_groups, n_times_out});
   } else {
     dust2::r::set_array_dims(ret_state, {n_state, n_particles_out, n_groups, n_times_out});

--- a/tests/testthat/test-filter-details.R
+++ b/tests/testthat/test-filter-details.R
@@ -43,7 +43,7 @@ test_that("can use history", {
                             reorder = TRUE),
                list(time, s_arr))
 
-  res <- test_history(time, s, index_particle = c(6, 4, 2))[[2]]
+  res <- test_history(time, s, select_particle = c(6, 4, 2))[[2]]
   expect_equal(dim(res), c(n_state, n_groups, n_time))
   expect_equal(res[, 1, ], s_arr[, 6, 1, ])
   expect_equal(res[, 2, ], s_arr[, 4, 2, ])
@@ -110,11 +110,11 @@ test_that("can reorder history with no groups", {
 
   expect_equal(
     test_history(time, state, order = order, reorder = FALSE,
-                 index_particle = 3)[[2]],
+                 select_particle = 3)[[2]],
     array(state_arr[, 3, , ], c(n_state, n_groups, n_time)))
   expect_equal(
     test_history(time, state, order = order, reorder = TRUE,
-                 index_particle = 3)[[2]],
+                 select_particle = 3)[[2]],
     array(true[, 3, , ], c(n_state, n_groups, n_time)))
 })
 
@@ -176,18 +176,17 @@ test_that("can extract history with group index, no reordering", {
   expect_equal(test_history(time, s, index_group = c(3, 1)),
                list(time, s_arr[, , c(3, 1), , drop = FALSE]))
 
-  m <- test_history(time, s, index_particle = c(6, 4, 2))[[2]]
+  m <- test_history(time, s, select_particle = c(6, 4, 2))[[2]]
   expect_equal(dim(m), c(n_state, n_groups, n_time))
   expect_equal(m[, 1, ], s_arr[, 6, 1, ])
   expect_equal(m[, 2, ], s_arr[, 4, 2, ])
   expect_equal(m[, 3, ], s_arr[, 2, 3, ])
 
-  ## This needs work:
-  ## expect_equal(
-  ##   test_history(time, s,
-  ##                index_group = c(3, 1),
-  ##                index_particle = c(2, 6))[[2]],
-  ##   m[, c(3, 1), ])
+  expect_equal(
+    test_history(time, s,
+                 index_group = c(3, 1),
+                 select_particle = c(6, 4, 2))[[2]],
+    m[, c(3, 1), ])
 })
 
 
@@ -239,8 +238,15 @@ test_that("can reorder history on the way out", {
     list(time, true[, , 3:1, ]))
 
   m <- test_history(time, state, order = order, reorder = TRUE,
-                    index_particle = c(6, 4, 2))[[2]]
+                    select_particle = c(6, 4, 2))[[2]]
   expect_equal(m[, 1, ], true[, 6, 1, ])
   expect_equal(m[, 2, ], true[, 4, 2, ])
   expect_equal(m[, 3, ], true[, 2, 3, ])
+
+  ## Last error case
+  ## expect_equal(
+  ##   test_history(time, state, order = order, reorder = TRUE,
+  ##                index_group = c(3, 1),
+  ##                select_particle = c(6, 4, 2))[[2]],
+  ##   m[, c(3, 1), ])
 })

--- a/tests/testthat/test-filter-details.R
+++ b/tests/testthat/test-filter-details.R
@@ -175,6 +175,19 @@ test_that("can extract history with group index, no reordering", {
                list(time, s_arr[, , 2, , drop = FALSE]))
   expect_equal(test_history(time, s, index_group = c(3, 1)),
                list(time, s_arr[, , c(3, 1), , drop = FALSE]))
+
+  m <- test_history(time, s, index_particle = c(6, 4, 2))[[2]]
+  expect_equal(dim(m), c(n_state, n_groups, n_time))
+  expect_equal(m[, 1, ], s_arr[, 6, 1, ])
+  expect_equal(m[, 2, ], s_arr[, 4, 2, ])
+  expect_equal(m[, 3, ], s_arr[, 2, 3, ])
+
+  ## This needs work:
+  ## expect_equal(
+  ##   test_history(time, s,
+  ##                index_group = c(3, 1),
+  ##                index_particle = c(2, 6))[[2]],
+  ##   m[, c(3, 1), ])
 })
 
 
@@ -223,5 +236,11 @@ test_that("can reorder history on the way out", {
     list(time, true[, , 3, , drop = FALSE]))
   expect_equal(
     test_history(time, state, order = order, reorder = TRUE, index_group = 3:1),
-               list(time, true[, , 3:1, ]))
+    list(time, true[, , 3:1, ]))
+
+  m <- test_history(time, state, order = order, reorder = TRUE,
+                    index_particle = c(6, 4, 2))[[2]]
+  expect_equal(m[, 1, ], true[, 6, 1, ])
+  expect_equal(m[, 2, ], true[, 4, 2, ])
+  expect_equal(m[, 3, ], true[, 2, 3, ])
 })

--- a/tests/testthat/test-filter-details.R
+++ b/tests/testthat/test-filter-details.R
@@ -112,11 +112,10 @@ test_that("can reorder history with no groups", {
     test_history(time, state, order = order, reorder = FALSE,
                  index_particle = 3)[[2]],
     array(state_arr[, 3, , ], c(n_state, n_groups, n_time)))
-  ## Broken on reorder only:
-  ## expect_equal(
-  ##   test_history(time, state, order = order, reorder = TRUE,
-  ##                index_particle = 3)[[2]],
-  ##   array(state_arr[, 3, , ], c(n_state, n_groups, n_time)))
+  expect_equal(
+    test_history(time, state, order = order, reorder = TRUE,
+                 index_particle = 3)[[2]],
+    array(true[, 3, , ], c(n_state, n_groups, n_time)))
 })
 
 

--- a/tests/testthat/test-filter-details.R
+++ b/tests/testthat/test-filter-details.R
@@ -107,6 +107,16 @@ test_that("can reorder history with no groups", {
   expect_equal(
     test_history(time, state, order = order, reorder = TRUE),
     list(time, true))
+
+  expect_equal(
+    test_history(time, state, order = order, reorder = FALSE,
+                 index_particle = 3)[[2]],
+    array(state_arr[, 3, , ], c(n_state, n_groups, n_time)))
+  ## Broken on reorder only:
+  ## expect_equal(
+  ##   test_history(time, state, order = order, reorder = TRUE,
+  ##                index_particle = 3)[[2]],
+  ##   array(state_arr[, 3, , ], c(n_state, n_groups, n_time)))
 })
 
 

--- a/tests/testthat/test-filter-details.R
+++ b/tests/testthat/test-filter-details.R
@@ -42,6 +42,12 @@ test_that("can use history", {
   expect_equal(test_history(time, s, order = vector("list", length(time)),
                             reorder = TRUE),
                list(time, s_arr))
+
+  res <- test_history(time, s, index_particle = c(6, 4, 2))[[2]]
+  expect_equal(dim(res), c(n_state, n_groups, n_time))
+  expect_equal(res[, 1, ], s_arr[, 6, 1, ])
+  expect_equal(res[, 2, ], s_arr[, 4, 2, ])
+  expect_equal(res[, 3, ], s_arr[, 2, 3, ])
 })
 
 

--- a/tests/testthat/test-filter.R
+++ b/tests/testthat/test-filter.R
@@ -481,9 +481,10 @@ test_that("can extract random trajectory", {
 
   hash1 <- apply(h1, 2:3, rlang::hash)
   hash2 <- vapply(h2, function(x) apply(x, 2, rlang::hash), character(2))
-  ## So we're consistently hitting the first one but not the second,
-  ## looks like we need a test of this in the details.
   i <- cbind(match(hash2[1, ], hash1[, 1]),
              match(hash2[2, ], hash1[, 2]))
   expect_false(any(is.na(i)))
+  expect_false(all(i[, 1] == i[, 2]))
+  expect_true(length(unique(i[, 1])) > 1)
+  expect_true(length(unique(i[, 2])) > 1)
 })


### PR DESCRIPTION
another tedious bit of bookkeeping.  this exists to support the idea of "give me a random history from each parameter group after running a particle filter".  This will be wired into a nice observer we can use with the models in the mcstate2 wrapper in a future PR