### PR TITLE
Pass shared when setting data

### DIFF
--- a/inst/examples/sir.cpp
+++ b/inst/examples/sir.cpp
@@ -103,7 +103,7 @@ public:
     return dust2::zero_every_type<real_type>{{1, {4}}}; // zero[1] = {4};
   }
 
-  static data_type build_data(cpp11::list r_data) {
+  static data_type build_data(cpp11::list r_data, const shared_state& shared) {
     auto data = static_cast<cpp11::list>(r_data);
     auto incidence = dust2::r::read_real(data, "incidence", NA_REAL);
     return data_type{incidence};

--- a/inst/include/dust2/continuous/system.hpp
+++ b/inst/include/dust2/continuous/system.hpp
@@ -220,6 +220,10 @@ public:
     return packing_gradient_;
   }
 
+  auto& shared() const {
+    return shared_;
+  }
+
   void set_time(real_type time) {
     time_ = time;
   }

--- a/inst/include/dust2/discrete/system.hpp
+++ b/inst/include/dust2/discrete/system.hpp
@@ -226,6 +226,10 @@ public:
     return packing_gradient_;
   }
 
+  auto& shared() const {
+    return shared_;
+  }
+
   void set_time(real_type time) {
     time_ = time;
   }

--- a/inst/include/dust2/r/discrete/filter.hpp
+++ b/inst/include/dust2/r/discrete/filter.hpp
@@ -31,7 +31,7 @@ cpp11::sexp dust2_discrete_filter_alloc(cpp11::list r_pars,
   const auto dt = check_dt(r_dt);
   const auto shared = build_shared<T>(r_pars, n_groups);
   const auto internal = build_internal<T>(shared, n_threads);
-  const auto data = check_data<T>(r_data, time.size(), n_groups, "data");
+  const auto data = check_data<T>(r_data, shared, time.size(), "data");
 
   // It's possible that we don't want to always really be
   // deterministic here?  Though nooone can think of a case where

--- a/inst/include/dust2/r/discrete/unfilter.hpp
+++ b/inst/include/dust2/r/discrete/unfilter.hpp
@@ -30,7 +30,7 @@ cpp11::sexp dust2_discrete_unfilter_alloc(cpp11::list r_pars,
   const auto dt = check_dt(r_dt);
   const auto shared = build_shared<T>(r_pars, n_groups);
   const auto internal = build_internal<T>(shared, n_threads);
-  const auto data = check_data<T>(r_data, time.size(), n_groups, "data");
+  const auto data = check_data<T>(r_data, shared, time.size(), "data");
 
   // It's possible that we don't want to always really be
   // deterministic here?  Though nooone can think of a case where

--- a/inst/include/dust2/r/helpers.hpp
+++ b/inst/include/dust2/r/helpers.hpp
@@ -257,7 +257,7 @@ std::vector<typename T::shared_state> build_shared(cpp11::list r_pars,
 }
 
 template <typename T>
-std::vector<typename T::internal_state> build_internal(std::vector<typename T::shared_state> shared, size_t n_threads) {
+std::vector<typename T::internal_state> build_internal(const std::vector<typename T::shared_state>& shared, size_t n_threads) {
   std::vector<typename T::internal_state> internal;
   const size_t n_groups = shared.size();
   internal.reserve(n_groups * n_threads);
@@ -290,23 +290,24 @@ void update_pars(T& obj, cpp11::list r_pars, const std::vector<size_t>& index_gr
 
 template <typename T>
 std::vector<typename T::data_type> check_data(cpp11::list r_data,
+                                              const std::vector<typename T::shared_state>& shared,
                                               size_t n_time,
-                                              size_t n_groups,
                                               const char * name) {
+  const size_t n_groups = shared.size();
   std::vector<typename T::data_type> data;
   data.reserve(n_time * n_groups);
 
-  // Errors here are no longer likely to be thrown, as check_data()
-  // should do the work for us.  The exception is that T::build_data()
-  // might fail and we should probably report back the time and group
-  // index that is failing here.
+  // Errors here are no longer likely to be thrown, as the R-side
+  // check_data() should do the work for us.  The exception is that
+  // T::build_data() might fail and we should probably report back the
+  // time and group index that is failing here.
   check_length(r_data, n_time, name);
   for (size_t i = 0; i < n_time; ++i) {
     auto r_data_i = cpp11::as_cpp<cpp11::list>(r_data[i]);
     check_length(r_data_i, n_groups, "data[i]");
     for (size_t j = 0; j < n_groups; ++j) {
       auto r_data_ij = cpp11::as_cpp<cpp11::list>(r_data_i[j]);
-      data.push_back(T::build_data(r_data_ij));
+      data.push_back(T::build_data(r_data_ij, shared[i]));
     }
   }
 

--- a/inst/include/dust2/r/helpers.hpp
+++ b/inst/include/dust2/r/helpers.hpp
@@ -307,7 +307,7 @@ std::vector<typename T::data_type> check_data(cpp11::list r_data,
     check_length(r_data_i, n_groups, "data[i]");
     for (size_t j = 0; j < n_groups; ++j) {
       auto r_data_ij = cpp11::as_cpp<cpp11::list>(r_data_i[j]);
-      data.push_back(T::build_data(r_data_ij, shared[i]));
+      data.push_back(T::build_data(r_data_ij, shared[j]));
     }
   }
 

--- a/inst/include/dust2/r/system.hpp
+++ b/inst/include/dust2/r/system.hpp
@@ -209,12 +209,13 @@ SEXP dust2_system_compare_data(cpp11::sexp ptr,
   auto *obj = cpp11::as_cpp<cpp11::external_pointer<T>>(ptr).get();
   check_errors(obj, "compare data for");
   const auto n_groups = obj->n_groups();
+  const auto& shared = obj->shared();
 
   std::vector<data_type> data;
   check_length(r_data, n_groups, "data");
   for (size_t i = 0; i < n_groups; ++i) {
     auto r_data_i = cpp11::as_cpp<cpp11::list>(r_data[i]);
-    data.push_back(system_type::build_data(r_data_i));
+    data.push_back(system_type::build_data(r_data_i, shared[i]));
   }
 
   cpp11::writable::doubles ret(obj->n_particles() * obj->n_groups());

--- a/src/sir.cpp
+++ b/src/sir.cpp
@@ -105,7 +105,7 @@ public:
     return dust2::zero_every_type<real_type>{{1, {4}}}; // zero[1] = {4};
   }
 
-  static data_type build_data(cpp11::list r_data) {
+  static data_type build_data(cpp11::list r_data, const shared_state& shared) {
     auto data = static_cast<cpp11::list>(r_data);
     auto incidence = dust2::r::read_real(data, "incidence", NA_REAL);
     return data_type{incidence};


### PR DESCRIPTION
This will require a small tweak in odin, I'll sort that out later.

This PR makes `shared` available while processing data, which we found we practically needed when working with Thom's model.  It is plausible that a suitably complicated version of data processing would require internal too, but I'm finding that hard to motivate