### PR TITLE
Cope with multiple zero_every better

### DIFF
--- a/inst/include/dust2/zero.hpp
+++ b/inst/include/dust2/zero.hpp
@@ -1,13 +1,13 @@
 #pragma once
 
 #include <cstddef>
-#include <map>
+#include <utility>
 #include <vector>
 
 namespace dust2 {
 
 template <typename real_type>
-using zero_every_type = std::map<real_type, std::vector<size_t>>;
+using zero_every_type = std::vector<std::pair<real_type, std::vector<size_t>>>;
 
 template <typename T>
 auto zero_every_vec(const std::vector<typename T::shared_state>& shared) {

--- a/tests/testthat/examples/zerotwice.cpp
+++ b/tests/testthat/examples/zerotwice.cpp
@@ -1,0 +1,67 @@
+#include <dust2/common.hpp>
+
+// [[dust2::class(zerotwice)]]
+// [[dust2::time_type(discrete)]]
+class zerotwice {
+public:
+  zerotwice() = delete;
+
+  using real_type = double;
+
+  struct shared_state {
+    real_type a;
+    real_type b;
+  };
+  using internal_state = dust2::no_internal_state;
+  using data_type = dust2::no_data;
+  using rng_state_type = monty::random::generator<real_type>;
+
+  static dust2::packing packing_state(const shared_state& shared) {
+    return dust2::packing{{"x", {}}, {"y", {}}};
+  }
+
+  static dust2::packing packing_gradient(const shared_state& shared) {
+    return dust2::packing{};
+  }
+
+  static void update_shared(cpp11::list pars, shared_state& shared) {
+  }
+
+  static void update_internal(const shared_state& shared, internal_state& internal) {
+  }
+
+  static void initial(real_type time,
+                      real_type dt,
+                      const shared_state& shared,
+                      internal_state& internal,
+                      rng_state_type& rng_state,
+                      real_type * state_next) {
+    state_next[0] = 0;
+    state_next[1] = 0;
+  }
+
+  static void update(real_type time,
+                     real_type dt,
+                     const real_type * state,
+                     const shared_state& shared,
+                     internal_state& internal,
+                     rng_state_type& rng_state,
+                     real_type * state_next) {
+    state_next[0] = state[0] + 1;
+    state_next[1] = state[1] + 1;
+  }
+
+  static shared_state build_shared(cpp11::list pars) {
+    const auto a = dust2::r::read_real(pars, "a");
+    const auto b = dust2::r::read_real(pars, "b");
+    return shared_state{a, b};
+  }
+
+  static internal_state build_internal(const shared_state& shared) {
+    return internal_state{};
+  }
+
+  static auto zero_every(const shared_state& shared) {
+    return dust2::zero_every_type<real_type>{{shared.a, {0}}, {shared.b, {1}}};
+  }
+};

--- a/tests/testthat/test-zzz-slow.R
+++ b/tests/testthat/test-zzz-slow.R
@@ -1,0 +1,24 @@
+test_that("can use two zero_every", {
+  skip_for_compilation()
+  gen <- dust_compile("examples/zerotwice.cpp", quiet = TRUE, debug = TRUE)
+
+  sys <- dust_system_create(gen(), list(a = 2, b = 300), 1)
+  y <- dust_system_simulate(sys, 1:20)
+  expect_equal(y[1, ], rep(1:2, length.out = 20))
+  expect_equal(y[2, ], 1:20)
+
+  sys <- dust_system_create(gen(), list(a = 300, b = 5), 1)
+  y <- dust_system_simulate(sys, 1:20)
+  expect_equal(y[1, ], 1:20)
+  expect_equal(y[2, ], rep(1:5, length.out = 20))
+
+  sys <- dust_system_create(gen(), list(a = 2, b = 2), 1)
+  y <- dust_system_simulate(sys, 1:20)
+  expect_equal(y[1, ], rep(1:2, length.out = 20))
+  expect_equal(y[2, ], y[1, ])
+
+  sys <- dust_system_create(gen(), list(a = 2, b = 5), 1)
+  y <- dust_system_simulate(sys, 1:20)
+  expect_equal(y[1, ], rep(1:2, length.out = 20))
+  expect_equal(y[2, ], rep(1:5, length.out = 20))
+})


### PR DESCRIPTION
This was reported by Ed (see mrc-5641), and I've split the fix into odin2 and dust2.

We were storing reset times as a map which meant if two resets had the same interval only one made it through the constructor! We never actually use anything taking advantage of this being a mapping type so the fix is just to store as a vector of pairs.