### PR TITLE
Allow multidimensional interpolation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust2
 Title: Next Generation dust
-Version: 0.1.6
+Version: 0.1.7
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/R/cpp11.R
+++ b/R/cpp11.R
@@ -236,6 +236,18 @@ test_interpolate_spline1 <- function(t, y, z) {
   .Call(`_dust2_test_interpolate_spline1`, t, y, z)
 }
 
+test_interpolate_constant2 <- function(t, r_y, z) {
+  .Call(`_dust2_test_interpolate_constant2`, t, r_y, z)
+}
+
+test_interpolate_linear2 <- function(t, r_y, z) {
+  .Call(`_dust2_test_interpolate_linear2`, t, r_y, z)
+}
+
+test_interpolate_spline2 <- function(t, r_y, z) {
+  .Call(`_dust2_test_interpolate_spline2`, t, r_y, z)
+}
+
 test_sum <- function(r_x, r_m) {
   .Call(`_dust2_test_sum`, r_x, r_m)
 }

--- a/inst/include/dust2/interpolate/interpolate.hpp
+++ b/inst/include/dust2/interpolate/interpolate.hpp
@@ -5,6 +5,7 @@
 #include <sstream>
 #include <vector>
 
+#include <dust2/array.hpp>
 #include <dust2/interpolate/spline.hpp>
 
 namespace dust2 {
@@ -45,13 +46,13 @@ size_t interpolate_search(T target, std::vector<T> container,
 }
 
 template <typename T>
-void validate_inputs(const std::vector<T>& t, const std::vector<T>& y,
-                     const char * name_t, const char * name_y) {
-  if (t.size() != y.size()) {
+void validate_time(const std::vector<T>& t, size_t len_y,
+                   const char * name_t, const char * name_y) {
+  if (t.size() != len_y) {
     std::stringstream msg;
     msg << "Time variable '" << name_t << "' and interpolation target '" <<
       name_y << "' must have the same length, but do not (" <<
-      t.size() << " vs " << y.size() << ")";
+      t.size() << " vs " << len_y << ")";
     throw std::runtime_error(msg.str());
   }
   for (size_t i = 1; i < t.size(); ++i) {
@@ -75,14 +76,38 @@ public:
   InterpolateConstant(const std::vector<T>& t, const std::vector<T>& y,
                       const char * name_t, const char * name_y) :
     t_(t), y_(y) {
-    internal::validate_inputs(t_, y_, name_t, name_y);
+    internal::validate_time(t_, y_.size(), name_t, name_y);
   }
 
   InterpolateConstant() {}
 
   T eval(T z) const {
-    size_t i = internal::interpolate_search(z, t_, true);
+    const auto i = internal::interpolate_search(z, t_, true);
     return y_[i];
+  }
+};
+
+template <typename T, size_t rank>
+class InterpolateConstantArray {
+private:
+  std::vector<T> t_;
+  std::vector<T> y_;
+  size_t n_;
+public:
+  InterpolateConstantArray(const std::vector<T> t, const std::vector<T>& y,
+                           const array::dimensions<rank>& dim,
+                           const char * name_t, const char * name_y) :
+    t_(t), y_(y), n_(dim.size) {
+    const size_t len_y = y_.size() / n_;
+    internal::validate_time(t, len_y, name_t, name_y);
+  }
+
+  InterpolateConstantArray() {}
+
+  template <typename Iterator>
+  void eval(T z, Iterator dest) const {
+    const auto i = internal::interpolate_search(z, t_, true);
+    std::copy_n(y_.begin() + n_ * i, n_, dest);
   }
 };
 
@@ -95,19 +120,50 @@ public:
   InterpolateLinear(const std::vector<T>& t, const std::vector<T>& y,
                     const char * name_t, const char * name_y) :
     t_(t), y_(y) {
-    internal::validate_inputs(t_, y_, name_t, name_y);
+    internal::validate_time(t_, y_.size(), name_t, name_y);
   }
 
   InterpolateLinear() {}
 
   T eval(T z) const {
-    size_t i = internal::interpolate_search(z, t_, false);
-    const size_t n = t_.size() - 1;
-    if (i == n) {
-      return y_[n];
+    auto i = internal::interpolate_search(z, t_, false);
+    if (i == t_.size() - 1) {
+      return y_[i];
     }
     T t0 = t_[i], t1 = t_[i + 1], y0 = y_[i], y1 = y_[i + 1];
     return y0 + (y1 - y0) * (z - t0) / (t1 - t0);
+  }
+};
+
+template <typename T, size_t rank>
+class InterpolateLinearArray {
+private:
+  std::vector<T> t_;
+  std::vector<T> y_;
+  size_t n_;
+public:
+  InterpolateLinearArray(const std::vector<T> t, const std::vector<T>& y,
+                           const array::dimensions<rank>& dim,
+                           const char * name_t, const char * name_y) :
+    t_(t), y_(y), n_(dim.size) {
+    const size_t len_y = y_.size() / n_;
+    internal::validate_time(t, len_y, name_t, name_y);
+  }
+
+  InterpolateLinearArray() {}
+
+  template <typename Iterator>
+  void eval(T z, Iterator dest) const {
+    const auto i = internal::interpolate_search(z, t_, false);
+    if (i == t_.size() - 1) {
+      std::copy_n(y_.begin() + i * n_, n_, dest);
+    }
+    const T r = (z - t_[i]) / (t_[i + 1] - t_[i]);
+    auto y0 = y_.begin() + i * n_;
+    auto y1 = y0 + n_;
+    for (size_t j = 0; j < n_; ++j, ++y0, ++y1, ++dest) {
+      *dest = *y0 + (*y1 - *y0) * r;
+    }
   }
 };
 
@@ -122,7 +178,7 @@ public:
   InterpolateSpline(const std::vector<T> t, const std::vector<T>& y,
                     const char * name_t, const char * name_y) :
     t_(t), y_(y) {
-    internal::validate_inputs(t_, y_, name_t, name_y);
+    internal::validate_time(t_, y_.size(), name_t, name_y);
     const auto a = spline::calculate_a<T>(t);
     auto b = spline::calculate_b<T>(t, y);
     spline::solve_tridiagonal(a, b);
@@ -133,16 +189,67 @@ public:
 
   T eval(T z) const {
     size_t i = internal::interpolate_search(z, t_, false);
-    const size_t n = t_.size() - 1;
-    if (i == n) {
-      return y_[n];
+    if (i == t_.size() - 1) {
+      return y_[i];
     }
     const T t0 = t_[i], t1 = t_[i + 1], y0 = y_[i], y1 = y_[i + 1];
     const T k0 = k_[i], k1 = k_[i + 1];
-    const T t = (z - t0) / (t1 - t0);
+    const T r = (z - t0) / (t1 - t0);
     const T a =  k0 * (t1 - t0) - (y1 - y0);
     const T b = -k1 * (t1 - t0) + (y1 - y0);
-    return (1 - t) * y0 + t * y1 + t * (1 - t) * (a * (1 - t) + b * t);
+    return (1 - r) * y0 + r * y1 + r * (1 - r) * (a * (1 - r) + b * r);
+  }
+};
+
+template <typename T, size_t rank>
+class InterpolateSplineArray {
+private:
+  std::vector<T> t_;
+  std::vector<T> y_;
+  std::vector<T> k_;
+  size_t n_;
+public:
+  InterpolateSplineArray(const std::vector<T> t, const std::vector<T>& y,
+                           const array::dimensions<rank>& dim,
+                           const char * name_t, const char * name_y) :
+    t_(t), y_(y), k_(y_.size()), n_(dim.size) {
+    const size_t len_y = y_.size() / n_;
+    internal::validate_time(t, len_y, name_t, name_y);
+
+    const auto a = spline::calculate_a<T>(t);
+    std::vector<T> yi(t_.size());
+    for (size_t i = 0; i < n_; ++i) {
+      for (size_t j = 0; j < t_.size(); ++j) {
+        yi[j] = y[i + j * n_];
+      }
+      auto b = spline::calculate_b<T>(t, yi);
+      spline::solve_tridiagonal(a, b);
+      for (size_t j = 0; j < t_.size(); ++j) {
+        k_[i + j * n_] = b[j];
+      }
+    }
+  }
+
+  InterpolateSplineArray() {}
+
+  template <typename Iterator>
+  void eval(T z, Iterator dest) const {
+    const auto i = internal::interpolate_search(z, t_, false);
+    if (i == t_.size() - 1) {
+      std::copy_n(y_.begin() + i * n_, n_, dest);
+    }
+    const auto t0 = t_[i];
+    const auto t1 = t_[i + 1];
+    const T r = (z - t0) / (t1 - t0);
+    auto y0 = y_.begin() + i * n_;
+    auto y1 = y0 + n_;
+    auto k0 = k_.begin() + i * n_;
+    auto k1 = k0 + n_;
+    for (size_t j = 0; j < n_; ++j, ++y0, ++y1, ++k0, ++k1, ++dest) {
+      const T a =  *k0 * (t1 - t0) - (*y1 - *y0);
+      const T b = -*k1 * (t1 - t0) + (*y1 - *y0);
+      *dest = (1 - r) * *y0 + r * *y1 + r * (1 - r) * (a * (1 - r) + b * r);
+    }
   }
 };
 

--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -418,6 +418,27 @@ extern "C" SEXP _dust2_test_interpolate_spline1(SEXP t, SEXP y, SEXP z) {
     return cpp11::as_sexp(test_interpolate_spline1(cpp11::as_cpp<cpp11::decay_t<std::vector<double>>>(t), cpp11::as_cpp<cpp11::decay_t<std::vector<double>>>(y), cpp11::as_cpp<cpp11::decay_t<double>>(z)));
   END_CPP11
 }
+// test_interpolate.cpp
+std::vector<double> test_interpolate_constant2(std::vector<double> t, cpp11::doubles r_y, double z);
+extern "C" SEXP _dust2_test_interpolate_constant2(SEXP t, SEXP r_y, SEXP z) {
+  BEGIN_CPP11
+    return cpp11::as_sexp(test_interpolate_constant2(cpp11::as_cpp<cpp11::decay_t<std::vector<double>>>(t), cpp11::as_cpp<cpp11::decay_t<cpp11::doubles>>(r_y), cpp11::as_cpp<cpp11::decay_t<double>>(z)));
+  END_CPP11
+}
+// test_interpolate.cpp
+std::vector<double> test_interpolate_linear2(std::vector<double> t, cpp11::doubles r_y, double z);
+extern "C" SEXP _dust2_test_interpolate_linear2(SEXP t, SEXP r_y, SEXP z) {
+  BEGIN_CPP11
+    return cpp11::as_sexp(test_interpolate_linear2(cpp11::as_cpp<cpp11::decay_t<std::vector<double>>>(t), cpp11::as_cpp<cpp11::decay_t<cpp11::doubles>>(r_y), cpp11::as_cpp<cpp11::decay_t<double>>(z)));
+  END_CPP11
+}
+// test_interpolate.cpp
+std::vector<double> test_interpolate_spline2(std::vector<double> t, cpp11::doubles r_y, double z);
+extern "C" SEXP _dust2_test_interpolate_spline2(SEXP t, SEXP r_y, SEXP z) {
+  BEGIN_CPP11
+    return cpp11::as_sexp(test_interpolate_spline2(cpp11::as_cpp<cpp11::decay_t<std::vector<double>>>(t), cpp11::as_cpp<cpp11::decay_t<cpp11::doubles>>(r_y), cpp11::as_cpp<cpp11::decay_t<double>>(z)));
+  END_CPP11
+}
 // test_sum.cpp
 double test_sum(cpp11::sexp r_x, cpp11::sexp r_m);
 extern "C" SEXP _dust2_test_sum(SEXP r_x, SEXP r_m) {
@@ -578,9 +599,12 @@ static const R_CallMethodDef CallEntries[] = {
     {"_dust2_dust2_unfilter_sir_update_pars",          (DL_FUNC) &_dust2_dust2_unfilter_sir_update_pars,           3},
     {"_dust2_test_history_",                           (DL_FUNC) &_dust2_test_history_,                            6},
     {"_dust2_test_interpolate_constant1",              (DL_FUNC) &_dust2_test_interpolate_constant1,               3},
+    {"_dust2_test_interpolate_constant2",              (DL_FUNC) &_dust2_test_interpolate_constant2,               3},
     {"_dust2_test_interpolate_linear1",                (DL_FUNC) &_dust2_test_interpolate_linear1,                 3},
+    {"_dust2_test_interpolate_linear2",                (DL_FUNC) &_dust2_test_interpolate_linear2,                 3},
     {"_dust2_test_interpolate_search",                 (DL_FUNC) &_dust2_test_interpolate_search,                  2},
     {"_dust2_test_interpolate_spline1",                (DL_FUNC) &_dust2_test_interpolate_spline1,                 3},
+    {"_dust2_test_interpolate_spline2",                (DL_FUNC) &_dust2_test_interpolate_spline2,                 3},
     {"_dust2_test_resample_weight",                    (DL_FUNC) &_dust2_test_resample_weight,                     2},
     {"_dust2_test_scale_log_weights",                  (DL_FUNC) &_dust2_test_scale_log_weights,                   1},
     {"_dust2_test_sum",                                (DL_FUNC) &_dust2_test_sum,                                 2},

--- a/src/test_interpolate.cpp
+++ b/src/test_interpolate.cpp
@@ -26,3 +26,48 @@ double test_interpolate_spline1(std::vector<double> t, std::vector<double> y,
   auto obj = dust2::interpolate::InterpolateSpline<double>(t, y, "t", "y");
   return obj.eval(z);
 }
+
+[[cpp11::register]]
+std::vector<double> test_interpolate_constant2(std::vector<double> t,
+                                               cpp11::doubles r_y,
+                                               double z) {
+  std::vector<double> y(r_y.begin(), r_y.end());
+  auto r_dim = cpp11::as_cpp<cpp11::integers>(r_y.attr("dim"));
+  const dust2::array::dimensions<2> dim{static_cast<size_t>(r_dim[0]),
+                                        static_cast<size_t>(r_dim[1])};
+  std::vector<double> ret(dim.size);
+  auto obj =
+    dust2::interpolate::InterpolateConstantArray<double, 2>(t, y, dim, "t", "y");
+  obj.eval(z, ret.begin());
+  return ret;
+}
+
+[[cpp11::register]]
+std::vector<double> test_interpolate_linear2(std::vector<double> t,
+                                               cpp11::doubles r_y,
+                                               double z) {
+  std::vector<double> y(r_y.begin(), r_y.end());
+  auto r_dim = cpp11::as_cpp<cpp11::integers>(r_y.attr("dim"));
+  const dust2::array::dimensions<2> dim{static_cast<size_t>(r_dim[0]),
+                                        static_cast<size_t>(r_dim[1])};
+  std::vector<double> ret(dim.size);
+  auto obj =
+    dust2::interpolate::InterpolateLinearArray<double, 2>(t, y, dim, "t", "y");
+  obj.eval(z, ret.begin());
+  return ret;
+}
+
+[[cpp11::register]]
+std::vector<double> test_interpolate_spline2(std::vector<double> t,
+                                               cpp11::doubles r_y,
+                                               double z) {
+  std::vector<double> y(r_y.begin(), r_y.end());
+  auto r_dim = cpp11::as_cpp<cpp11::integers>(r_y.attr("dim"));
+  const dust2::array::dimensions<2> dim{static_cast<size_t>(r_dim[0]),
+                                        static_cast<size_t>(r_dim[1])};
+  std::vector<double> ret(dim.size);
+  auto obj =
+    dust2::interpolate::InterpolateSplineArray<double, 2>(t, y, dim, "t", "y");
+  obj.eval(z, ret.begin());
+  return ret;
+}

--- a/tests/testthat/test-interpolate.R
+++ b/tests/testthat/test-interpolate.R
@@ -109,7 +109,7 @@ test_that("Check that time values are sensible", {
 })
 
 
-test_that("can interpolate an matrix, piecewise constant", {
+test_that("can interpolate a matrix, piecewise constant", {
   t <- c(0, 1, 2, 3, 4)
   nt <- length(t)
   nr <- 7
@@ -122,7 +122,7 @@ test_that("can interpolate an matrix, piecewise constant", {
 })
 
 
-test_that("can interpolate an matrix, piecewise linear", {
+test_that("can interpolate a matrix, piecewise linear", {
   t <- c(0, 1, 2, 3, 4)
   nt <- length(t)
   nr <- 7
@@ -136,7 +136,7 @@ test_that("can interpolate an matrix, piecewise linear", {
 })
 
 
-test_that("can interpolate an matrix, spline", {
+test_that("can interpolate a matrix, spline", {
   t <- c(0, 1, 2, 3, 4)
   nt <- length(t)
   nr <- 7

--- a/tests/testthat/test-interpolate.R
+++ b/tests/testthat/test-interpolate.R
@@ -107,3 +107,48 @@ test_that("Check that time values are sensible", {
     test_interpolate_spline1(t[-2], y, 1),
     "Time variable 't' and interpolation target 'y' must have the same length")
 })
+
+
+test_that("can interpolate an matrix, piecewise constant", {
+  t <- c(0, 1, 2, 3, 4)
+  nt <- length(t)
+  nr <- 7
+  nc <- 3
+  y <- array(runif(nt * nr * nc), c(nr, nc, nt))
+  expect_equal(test_interpolate_constant2(t, y, 0), c(y[, , 1]))
+  expect_equal(test_interpolate_constant2(t, y, 1 - 1e-6), c(y[, , 1]))
+  expect_equal(test_interpolate_constant2(t, y, 1), c(y[, , 2]))
+  expect_equal(test_interpolate_constant2(t, y, 10), c(y[, , 5]))
+})
+
+
+test_that("can interpolate an matrix, piecewise linear", {
+  t <- c(0, 1, 2, 3, 4)
+  nt <- length(t)
+  nr <- 7
+  nc <- 3
+  y <- array(runif(nt * nr * nc), c(nr, nc, nt))
+  expect_equal(test_interpolate_linear2(t, y, 0), c(y[, , 1]))
+  expect_equal(test_interpolate_linear2(t, y, 1), c(y[, , 2]))
+  expect_equal(test_interpolate_linear2(t, y, 4), c(y[, , 5]))
+  expect_equal(test_interpolate_linear2(t, y, 1.3),
+               c(y[, , 2] + (y[, , 3] - y[, , 2]) * 0.3))
+})
+
+
+test_that("can interpolate an matrix, spline", {
+  t <- c(0, 1, 2, 3, 4)
+  nt <- length(t)
+  nr <- 7
+  nc <- 3
+  y <- array(runif(nt * nr * nc), c(nr, nc, nt))
+
+  expect_equal(test_interpolate_spline2(t, y, 0), c(y[, , 1]))
+  expect_equal(test_interpolate_spline2(t, y, 1), c(y[, , 2]))
+  expect_equal(test_interpolate_spline2(t, y, 4), c(y[, , 5]))
+
+  yy <- apply(array(y, c(nr * nc, nt)), 1,
+              function(yi) test_interpolate_spline1(t, yi, 1.3))
+  expect_equal(test_interpolate_spline2(t, y, 1.3),
+               yy)
+})


### PR DESCRIPTION
This PR extends #58 to allow for interpolation of vectors of related things.  There's no covariance in the interpolation (this follows odin1), but you can have a matrix 'y' that is interpolated over time so that at each timestep we get a vector out.  This is done in-place rather than via return values.

There's a small fiddle in the validation code but otherwise this is just a loop at the interpolation step.  In the linear/spline case, we take advantage of some intermediate calculations that are shared over all the values at a given time.

The only real complication is the setup for spline interpolation, which is not very fun.