### PR TITLE
Make unfilter less coupled with discrete time model

### DIFF
--- a/inst/include/dust2/adjoint_data.hpp
+++ b/inst/include/dust2/adjoint_data.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <algorithm>
+#include <cmath>
 #include <cstddef>
 #include <vector>
 

--- a/inst/include/dust2/adjoint_data.hpp
+++ b/inst/include/dust2/adjoint_data.hpp
@@ -21,14 +21,25 @@ public:
     n_adjoint_(0),
     n_particles_(n_particles),
     n_groups_(n_groups),
-    n_particles_total_(n_particles_ * n_groups_),
-    n_steps_(0) {
+    n_particles_total_(n_particles_ * n_groups_) {
   }
 
-  void init_history(size_t n_steps) {
-    if (n_steps_ != n_steps) {
-      state_.resize(n_state_ * n_particles_total_ * (n_steps + 1));
-      n_steps_ = n_steps;
+  void init_history(size_t start_time, const std::vector<real_type> times,
+                    real_type dt) {
+    if (offset_.empty()) {
+      offset_.reserve(times.size() + 1);
+      offset_.push_back(0);
+      if (dt == 0) {
+        for (auto i : times) {
+          offset_.push_back(i * n_particles_total_ * n_state_);
+        }
+      } else {
+        for (auto i : times) {
+          const auto j = std::round(std::max(0.0, i - start_time) / dt);
+          offset_.push_back(j * n_particles_total_ * n_state_);
+        }
+      }
+      state_.resize(offset_.back() + n_particles_total_ * n_state_);
     }
     reset();
   }
@@ -41,8 +52,8 @@ public:
     }
   }
 
-  auto state() {
-    return state_.data();
+  auto state(size_t i) {
+    return state_.data() + offset_[i];
   }
 
   auto curr() {
@@ -76,7 +87,7 @@ private:
   size_t n_particles_;
   size_t n_groups_;
   size_t n_particles_total_;
-  size_t n_steps_;
+  std::vector<size_t> offset_;
   std::vector<real_type> state_;
   std::vector<real_type> adjoint_curr_;
   std::vector<real_type> adjoint_next_;

--- a/inst/include/dust2/discrete/system.hpp
+++ b/inst/include/dust2/discrete/system.hpp
@@ -314,7 +314,7 @@ public:
   // Note that this does not affect anything (except internal_) within
   // the model; not time and not state, as we want those to reflect
   // the state of the forwards model.
-  size_t adjoint_run_to_time(const real_type time0,
+  bool adjoint_run_to_time(const real_type time0,
                              const real_type time1,
                              const real_type* state,
                              const size_t n_adjoint,
@@ -343,7 +343,7 @@ public:
       }
     }
     errors_.report();
-    return n_steps;
+    return n_steps % 2 == 1;
   }
 
   void adjoint_initial(const real_type time,

--- a/tests/testthat/test-interpolate.R
+++ b/tests/testthat/test-interpolate.R
@@ -137,6 +137,7 @@ test_that("can interpolate a matrix, piecewise linear", {
 
 
 test_that("can interpolate a matrix, spline", {
+  set.seed(1)
   t <- c(0, 1, 2, 3, 4)
   nt <- length(t)
   nr <- 7


### PR DESCRIPTION
This PR does some housekeeping so that the unfilter is less tightly coupled to running with a discrete time model.  This moves the logic around moving around within the `state` vector into `adjoint_data`, minimises the number of calls to `dt` (only present in continuous time models...for now), and moves the logic about swapping between curr/next in the adjoint.  Fiddly despite the small size, but note no changes in any test code.