### PR TITLE
Filter/unfilter support with continuous time models

### DIFF
--- a/R/cpp11.R
+++ b/R/cpp11.R
@@ -208,6 +208,58 @@ dust2_system_sirode_simulate <- function(ptr, r_times, r_index_state, preserve_p
   .Call(`_dust2_dust2_system_sirode_simulate`, ptr, r_times, r_index_state, preserve_particle_dimension, preserve_group_dimension)
 }
 
+dust2_unfilter_sirode_alloc <- function(r_pars, r_time_start, r_time, r_ode_control, r_data, r_n_particles, r_n_groups, r_n_threads, r_index_state) {
+  .Call(`_dust2_dust2_unfilter_sirode_alloc`, r_pars, r_time_start, r_time, r_ode_control, r_data, r_n_particles, r_n_groups, r_n_threads, r_index_state)
+}
+
+dust2_filter_sirode_alloc <- function(r_pars, r_time_start, r_time, r_ode_control, r_data, r_n_particles, r_n_groups, r_n_threads, r_index_state, r_seed) {
+  .Call(`_dust2_dust2_filter_sirode_alloc`, r_pars, r_time_start, r_time, r_ode_control, r_data, r_n_particles, r_n_groups, r_n_threads, r_index_state, r_seed)
+}
+
+dust2_system_sirode_compare_data <- function(ptr, r_data, preserve_particle_dimension, preserve_group_dimension) {
+  .Call(`_dust2_dust2_system_sirode_compare_data`, ptr, r_data, preserve_particle_dimension, preserve_group_dimension)
+}
+
+dust2_unfilter_sirode_update_pars <- function(ptr, r_pars, r_index_group) {
+  .Call(`_dust2_dust2_unfilter_sirode_update_pars`, ptr, r_pars, r_index_group)
+}
+
+dust2_unfilter_sirode_run <- function(ptr, r_initial, save_history, adjoint, r_index_group, preserve_particle_dimension, preserve_group_dimension) {
+  .Call(`_dust2_dust2_unfilter_sirode_run`, ptr, r_initial, save_history, adjoint, r_index_group, preserve_particle_dimension, preserve_group_dimension)
+}
+
+dust2_unfilter_sirode_last_history <- function(ptr, r_index_group, select_random_particle, preserve_particle_dimension, preserve_group_dimension) {
+  .Call(`_dust2_dust2_unfilter_sirode_last_history`, ptr, r_index_group, select_random_particle, preserve_particle_dimension, preserve_group_dimension)
+}
+
+dust2_unfilter_sirode_last_state <- function(ptr, r_index_group, select_random_particle, preserve_particle_dimension, preserve_group_dimension) {
+  .Call(`_dust2_dust2_unfilter_sirode_last_state`, ptr, r_index_group, select_random_particle, preserve_particle_dimension, preserve_group_dimension)
+}
+
+dust2_filter_sirode_update_pars <- function(ptr, r_pars, r_index_group) {
+  .Call(`_dust2_dust2_filter_sirode_update_pars`, ptr, r_pars, r_index_group)
+}
+
+dust2_filter_sirode_run <- function(ptr, r_initial, save_history, adjoint, index_group, preserve_particle_dimension, preserve_group_dimension) {
+  .Call(`_dust2_dust2_filter_sirode_run`, ptr, r_initial, save_history, adjoint, index_group, preserve_particle_dimension, preserve_group_dimension)
+}
+
+dust2_filter_sirode_last_history <- function(ptr, r_index_group, select_random_particle, preserve_particle_dimension, preserve_group_dimension) {
+  .Call(`_dust2_dust2_filter_sirode_last_history`, ptr, r_index_group, select_random_particle, preserve_particle_dimension, preserve_group_dimension)
+}
+
+dust2_filter_sirode_last_state <- function(ptr, r_index_group, select_random_particle, preserve_particle_dimension, preserve_group_dimension) {
+  .Call(`_dust2_dust2_filter_sirode_last_state`, ptr, r_index_group, select_random_particle, preserve_particle_dimension, preserve_group_dimension)
+}
+
+dust2_filter_sirode_rng_state <- function(ptr) {
+  .Call(`_dust2_dust2_filter_sirode_rng_state`, ptr)
+}
+
+dust2_filter_sirode_set_rng_state <- function(ptr, r_rng_state) {
+  .Call(`_dust2_dust2_filter_sirode_set_rng_state`, ptr, r_rng_state)
+}
+
 test_resample_weight <- function(w, u) {
   .Call(`_dust2_test_resample_weight`, w, u)
 }

--- a/R/interface-unfilter.R
+++ b/R/interface-unfilter.R
@@ -38,9 +38,23 @@ dust_unfilter_create <- function(generator, time_start, data,
   index_state <- check_index(index_state, call = call)
   n_threads <- check_n_threads(n_threads, n_particles, n_groups)
 
+  if (generator$properties$time_type == "discrete") {
+    time_control <- dt
+  } else {
+    ## until we merge mrc-5799 as we'll just conflict annoyingly, then
+    ## move into args.
+    ode_control <- NULL
+    if (is.null(ode_control)) {
+      ode_control <- dust_ode_control()
+    } else {
+      assert_is(ode_control, "dust_ode_control", call = environment())
+    }
+    time_control <- ode_control
+  }
+
   inputs <- list(time_start = time_start,
                  time = data$time,
-                 dt = dt,
+                 time_control = time_control,
                  data = data$data,
                  n_particles = n_particles,
                  n_groups = n_groups,
@@ -73,7 +87,7 @@ unfilter_create <- function(unfilter, pars) {
     unfilter$methods$alloc(pars,
                            inputs$time_start,
                            inputs$time,
-                           inputs$dt,
+                           inputs$time_control,
                            inputs$data,
                            inputs$n_particles,
                            inputs$n_groups,

--- a/inst/examples/sirode.cpp
+++ b/inst/examples/sirode.cpp
@@ -2,6 +2,7 @@
 
 // [[dust2::class(sirode)]]
 // [[dust2::time_type(continuous)]]
+// [[dust2::has_compare()]]
 // [[dust2::parameter(I0)]]
 // [[dust2::parameter(N)]]
 // [[dust2::parameter(beta)]]
@@ -94,5 +95,25 @@ public:
 
   static auto zero_every(const shared_state& shared) {
     return dust2::zero_every_type<real_type>{{1, {4}}}; // zero[1] = {4};
+  }
+
+  static data_type build_data(cpp11::list r_data, const shared_state& shared) {
+    auto data = static_cast<cpp11::list>(r_data);
+    auto incidence = dust2::r::read_real(data, "incidence", NA_REAL);
+    return data_type{incidence};
+  }
+
+  static real_type compare_data(const real_type time,
+                                const real_type * state,
+                                const data_type& data,
+                                const shared_state& shared,
+                                internal_state& internal,
+                                rng_state_type& rng_state) {
+    const auto incidence_observed = data.incidence;
+    if (std::isnan(data.incidence)) {
+      return 0;
+    }
+    const auto incidence_modelled = state[4];
+    return monty::density::poisson(incidence_observed, incidence_modelled, true);
   }
 };

--- a/inst/include/dust2/r/continuous/filter.hpp
+++ b/inst/include/dust2/r/continuous/filter.hpp
@@ -1,0 +1,95 @@
+#pragma once
+
+#include <monty/r/random.hpp>
+#include <dust2/r/helpers.hpp>
+#include <dust2/r/filter.hpp>
+#include <dust2/r/continuous/control.hpp>
+#include <dust2/filter.hpp>
+#include <dust2/continuous/system.hpp>
+
+namespace dust2 {
+namespace r {
+
+template <typename T>
+cpp11::sexp dust2_continuous_filter_alloc(cpp11::list r_pars,
+                                          cpp11::sexp r_time_start,
+                                          cpp11::sexp r_time,
+                                          cpp11::list r_ode_control,
+                                          cpp11::list r_data,
+                                          cpp11::sexp r_n_particles,
+                                          cpp11::sexp r_n_groups,
+                                          cpp11::sexp r_n_threads,
+                                          cpp11::sexp r_index_state,
+                                          cpp11::sexp r_seed) {
+  using rng_state_type = typename T::rng_state_type;
+  using rng_seed_type = std::vector<typename rng_state_type::int_type>;
+  using real_type = typename  T::real_type;
+
+  const auto n_particles = to_size(r_n_particles, "n_particles");
+  const auto n_groups = to_size(r_n_groups, "n_groups");
+  const auto n_threads = to_size(r_n_threads, "n_threads");
+  const auto time_start = check_time(r_time_start, "time_start");
+  const auto time = check_time_sequence(time_start, r_time, true, "time");
+  const auto ode_control = validate_ode_control<real_type>(r_ode_control);
+  const auto shared = build_shared<T>(r_pars, n_groups);
+  const auto internal = build_internal<T>(shared, n_threads);
+  const auto data = check_data<T>(r_data, shared, time.size(), "data");
+
+  // It's possible that we don't want to always really be
+  // deterministic here?  Though nooone can think of a case where
+  // that's actually the behaviour wanted.  For now let's go fully
+  // deterministic.
+  auto seed = monty::random::r::as_rng_seed<rng_state_type>(r_seed);
+  const auto deterministic = false;
+
+  // Create all the required rng states across the filter and the
+  // system, in a reasonable way.  We need to make this slightly easier
+  // to do from monty really.  Expand the state to give all the
+  // state required by the filter (n_groups streams worth) and the
+  // system (n_groups * n_particles worth, though the last bit of
+  // expansion could be done by the system itself instead?)
+  //
+  // There are two ways of sorting out the state here:
+  //
+  // 1. we could take the first n_groups states for the filter and the
+  // remaining for the systems.  This has the nice property that we can
+  // expand the system state later if we support growing systems
+  // (mrc-5355).  However, it has the undesirable consequence that a
+  // filter with multiple groups will stream differently to a filter
+  // containing a the first group only.
+  //
+  // 2. we take each block of (1+n_particles) states for each group,
+  // giving the first to the filter and the rest to the system.  This
+  // means that we can change the number of groups without affecting
+  // the results, though we can't change the number of particles as
+  // easily.
+  const auto n_streams = n_groups * (n_particles + 1);
+  const auto rng_state = monty::random::prng<rng_state_type>(n_streams, seed, deterministic).export_state();
+  const auto rng_len = rng_state_type::size();
+  rng_seed_type seed_filter;
+  rng_seed_type seed_system;
+  for (size_t i = 0; i < n_groups; ++i) {
+    const auto it = rng_state.begin() + i * rng_len * (n_particles + 1);
+    seed_filter.insert(seed_filter.end(),
+                       it, it + rng_len);
+    seed_system.insert(seed_system.end(),
+                       it + rng_len, it + rng_len * (n_particles + 1));
+  }
+
+  const auto system = dust2::dust_continuous<T>(shared, internal, time_start, ode_control, n_particles,
+                                                seed_system, deterministic, n_threads);
+
+  const auto index_state = check_index(r_index_state, system.n_state(),
+                                       "index_state");
+
+  auto obj = new filter<dust_continuous<T>>(system, time_start, time, data, index_state, seed_filter);
+  cpp11::external_pointer<filter<dust_continuous<T>>> ptr(obj, true, false);
+
+  cpp11::sexp r_n_state = cpp11::as_sexp(obj->sys.n_state());
+
+  using namespace cpp11::literals;
+  return cpp11::writable::list{"ptr"_nm = ptr, "n_state"_nm = r_n_state};
+}
+
+}
+}

--- a/inst/include/dust2/r/continuous/filter.hpp
+++ b/inst/include/dust2/r/continuous/filter.hpp
@@ -35,10 +35,6 @@ cpp11::sexp dust2_continuous_filter_alloc(cpp11::list r_pars,
   const auto internal = build_internal<T>(shared, n_threads);
   const auto data = check_data<T>(r_data, shared, time.size(), "data");
 
-  // It's possible that we don't want to always really be
-  // deterministic here?  Though nooone can think of a case where
-  // that's actually the behaviour wanted.  For now let's go fully
-  // deterministic.
   auto seed = monty::random::r::as_rng_seed<rng_state_type>(r_seed);
   const auto deterministic = false;
 

--- a/inst/include/dust2/r/continuous/unfilter.hpp
+++ b/inst/include/dust2/r/continuous/unfilter.hpp
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <monty/r/random.hpp>
+#include <dust2/r/helpers.hpp>
+#include <dust2/r/unfilter.hpp>
+#include <dust2/r/continuous/control.hpp>
+#include <dust2/unfilter.hpp>
+#include <dust2/continuous/system.hpp>
+
+namespace dust2 {
+namespace r {
+
+// TODO: this name must be changed!
+template <typename T>
+cpp11::sexp dust2_continuous_unfilter_alloc(cpp11::list r_pars,
+                                            cpp11::sexp r_time_start,
+                                            cpp11::sexp r_time,
+                                            cpp11::list r_ode_control,
+                                            cpp11::list r_data,
+                                            cpp11::sexp r_n_particles,
+                                            cpp11::sexp r_n_groups,
+                                            cpp11::sexp r_n_threads,
+                                            cpp11::sexp r_index_state) {
+  using rng_state_type = typename T::rng_state_type;
+  using real_type = typename  T::real_type;
+
+  const auto n_particles = to_size(r_n_particles, "n_particles");
+  const auto n_groups = to_size(r_n_groups, "n_groups");
+  const auto n_threads = to_size(r_n_threads, "n_threads");
+  const auto time_start = check_time(r_time_start, "time_start");
+  const auto time = check_time_sequence(time_start, r_time, true, "time");
+  const auto ode_control = validate_ode_control<real_type>(r_ode_control);
+  const auto shared = build_shared<T>(r_pars, n_groups);
+  const auto internal = build_internal<T>(shared, n_threads);
+  const auto data = check_data<T>(r_data, shared, time.size(), "data");
+
+  // It's possible that we don't want to always really be
+  // deterministic here?  Though nooone can think of a case where
+  // that's actually the behaviour wanted.  For now let's go fully
+  // deterministic.
+  auto seed = monty::random::seed_data<rng_state_type>(42);
+  const auto deterministic = true;
+
+  // Then allocate the system; this pulls together almost all the data
+  // we need.  At this point we could have constructed the system out
+  // of one that exists already on the R side, but I think that's
+  // going to feel weirder overall.
+  const auto system = dust2::dust_continuous<T>(shared, internal, time_start, ode_control, n_particles,
+                                                seed, deterministic, n_threads);
+  const auto index_state = check_index(r_index_state, system.n_state(),
+                                       "index_state");
+
+  auto obj = new unfilter<dust_continuous<T>>(system, time_start, time, data,
+                                              index_state);
+  cpp11::external_pointer<unfilter<dust_continuous<T>>> ptr(obj, true, false);
+
+  cpp11::sexp r_n_state = cpp11::as_sexp(obj->sys.n_state());
+
+  using namespace cpp11::literals;
+  return cpp11::writable::list{"ptr"_nm = ptr, "n_state"_nm = r_n_state};
+}
+
+}
+}

--- a/inst/template/continuous/compare.cpp
+++ b/inst/template/continuous/compare.cpp
@@ -1,0 +1,9 @@
+[[cpp11::register]]
+SEXP dust2_unfilter_{{name}}_alloc(cpp11::list r_pars, cpp11::sexp r_time_start, cpp11::sexp r_time, cpp11::list r_ode_control, cpp11::list r_data, cpp11::sexp r_n_particles, cpp11::sexp r_n_groups, cpp11::sexp r_n_threads, cpp11::sexp r_index_state) {
+  return dust2::r::dust2_continuous_unfilter_alloc<{{class}}>(r_pars, r_time_start, r_time, r_ode_control, r_data, r_n_particles, r_n_groups, r_n_threads, r_index_state);
+}
+
+[[cpp11::register]]
+SEXP dust2_filter_{{name}}_alloc(cpp11::list r_pars, cpp11::sexp r_time_start, cpp11::sexp r_time, cpp11::list r_ode_control, cpp11::list r_data, cpp11::sexp r_n_particles, cpp11::sexp r_n_groups, cpp11::sexp r_n_threads, cpp11::sexp r_index_state, cpp11::sexp r_seed) {
+  return dust2::r::dust2_continuous_filter_alloc<{{class}}>(r_pars, r_time_start, r_time, r_ode_control, r_data, r_n_particles, r_n_groups, r_n_threads, r_index_state, r_seed);
+}

--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -369,6 +369,97 @@ extern "C" SEXP _dust2_dust2_system_sirode_simulate(SEXP ptr, SEXP r_times, SEXP
     return cpp11::as_sexp(dust2_system_sirode_simulate(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_times), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_state), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_particle_dimension), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_group_dimension)));
   END_CPP11
 }
+// sirode.cpp
+SEXP dust2_unfilter_sirode_alloc(cpp11::list r_pars, cpp11::sexp r_time_start, cpp11::sexp r_time, cpp11::list r_ode_control, cpp11::list r_data, cpp11::sexp r_n_particles, cpp11::sexp r_n_groups, cpp11::sexp r_n_threads, cpp11::sexp r_index_state);
+extern "C" SEXP _dust2_dust2_unfilter_sirode_alloc(SEXP r_pars, SEXP r_time_start, SEXP r_time, SEXP r_ode_control, SEXP r_data, SEXP r_n_particles, SEXP r_n_groups, SEXP r_n_threads, SEXP r_index_state) {
+  BEGIN_CPP11
+    return cpp11::as_sexp(dust2_unfilter_sirode_alloc(cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(r_pars), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_time_start), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_time), cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(r_ode_control), cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(r_data), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_n_particles), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_n_groups), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_n_threads), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_state)));
+  END_CPP11
+}
+// sirode.cpp
+SEXP dust2_filter_sirode_alloc(cpp11::list r_pars, cpp11::sexp r_time_start, cpp11::sexp r_time, cpp11::list r_ode_control, cpp11::list r_data, cpp11::sexp r_n_particles, cpp11::sexp r_n_groups, cpp11::sexp r_n_threads, cpp11::sexp r_index_state, cpp11::sexp r_seed);
+extern "C" SEXP _dust2_dust2_filter_sirode_alloc(SEXP r_pars, SEXP r_time_start, SEXP r_time, SEXP r_ode_control, SEXP r_data, SEXP r_n_particles, SEXP r_n_groups, SEXP r_n_threads, SEXP r_index_state, SEXP r_seed) {
+  BEGIN_CPP11
+    return cpp11::as_sexp(dust2_filter_sirode_alloc(cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(r_pars), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_time_start), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_time), cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(r_ode_control), cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(r_data), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_n_particles), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_n_groups), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_n_threads), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_state), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_seed)));
+  END_CPP11
+}
+// sirode.cpp
+SEXP dust2_system_sirode_compare_data(cpp11::sexp ptr, cpp11::list r_data, bool preserve_particle_dimension, bool preserve_group_dimension);
+extern "C" SEXP _dust2_dust2_system_sirode_compare_data(SEXP ptr, SEXP r_data, SEXP preserve_particle_dimension, SEXP preserve_group_dimension) {
+  BEGIN_CPP11
+    return cpp11::as_sexp(dust2_system_sirode_compare_data(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(r_data), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_particle_dimension), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_group_dimension)));
+  END_CPP11
+}
+// sirode.cpp
+SEXP dust2_unfilter_sirode_update_pars(cpp11::sexp ptr, cpp11::list r_pars, cpp11::sexp r_index_group);
+extern "C" SEXP _dust2_dust2_unfilter_sirode_update_pars(SEXP ptr, SEXP r_pars, SEXP r_index_group) {
+  BEGIN_CPP11
+    return cpp11::as_sexp(dust2_unfilter_sirode_update_pars(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(r_pars), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_group)));
+  END_CPP11
+}
+// sirode.cpp
+SEXP dust2_unfilter_sirode_run(cpp11::sexp ptr, cpp11::sexp r_initial, bool save_history, bool adjoint, cpp11::sexp r_index_group, bool preserve_particle_dimension, bool preserve_group_dimension);
+extern "C" SEXP _dust2_dust2_unfilter_sirode_run(SEXP ptr, SEXP r_initial, SEXP save_history, SEXP adjoint, SEXP r_index_group, SEXP preserve_particle_dimension, SEXP preserve_group_dimension) {
+  BEGIN_CPP11
+    return cpp11::as_sexp(dust2_unfilter_sirode_run(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_initial), cpp11::as_cpp<cpp11::decay_t<bool>>(save_history), cpp11::as_cpp<cpp11::decay_t<bool>>(adjoint), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_group), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_particle_dimension), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_group_dimension)));
+  END_CPP11
+}
+// sirode.cpp
+SEXP dust2_unfilter_sirode_last_history(cpp11::sexp ptr, cpp11::sexp r_index_group, bool select_random_particle, bool preserve_particle_dimension, bool preserve_group_dimension);
+extern "C" SEXP _dust2_dust2_unfilter_sirode_last_history(SEXP ptr, SEXP r_index_group, SEXP select_random_particle, SEXP preserve_particle_dimension, SEXP preserve_group_dimension) {
+  BEGIN_CPP11
+    return cpp11::as_sexp(dust2_unfilter_sirode_last_history(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_group), cpp11::as_cpp<cpp11::decay_t<bool>>(select_random_particle), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_particle_dimension), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_group_dimension)));
+  END_CPP11
+}
+// sirode.cpp
+SEXP dust2_unfilter_sirode_last_state(cpp11::sexp ptr, cpp11::sexp r_index_group, bool select_random_particle, bool preserve_particle_dimension, bool preserve_group_dimension);
+extern "C" SEXP _dust2_dust2_unfilter_sirode_last_state(SEXP ptr, SEXP r_index_group, SEXP select_random_particle, SEXP preserve_particle_dimension, SEXP preserve_group_dimension) {
+  BEGIN_CPP11
+    return cpp11::as_sexp(dust2_unfilter_sirode_last_state(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_group), cpp11::as_cpp<cpp11::decay_t<bool>>(select_random_particle), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_particle_dimension), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_group_dimension)));
+  END_CPP11
+}
+// sirode.cpp
+SEXP dust2_filter_sirode_update_pars(cpp11::sexp ptr, cpp11::list r_pars, cpp11::sexp r_index_group);
+extern "C" SEXP _dust2_dust2_filter_sirode_update_pars(SEXP ptr, SEXP r_pars, SEXP r_index_group) {
+  BEGIN_CPP11
+    return cpp11::as_sexp(dust2_filter_sirode_update_pars(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::list>>(r_pars), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_group)));
+  END_CPP11
+}
+// sirode.cpp
+SEXP dust2_filter_sirode_run(cpp11::sexp ptr, cpp11::sexp r_initial, bool save_history, bool adjoint, cpp11::sexp index_group, bool preserve_particle_dimension, bool preserve_group_dimension);
+extern "C" SEXP _dust2_dust2_filter_sirode_run(SEXP ptr, SEXP r_initial, SEXP save_history, SEXP adjoint, SEXP index_group, SEXP preserve_particle_dimension, SEXP preserve_group_dimension) {
+  BEGIN_CPP11
+    return cpp11::as_sexp(dust2_filter_sirode_run(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_initial), cpp11::as_cpp<cpp11::decay_t<bool>>(save_history), cpp11::as_cpp<cpp11::decay_t<bool>>(adjoint), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(index_group), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_particle_dimension), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_group_dimension)));
+  END_CPP11
+}
+// sirode.cpp
+SEXP dust2_filter_sirode_last_history(cpp11::sexp ptr, cpp11::sexp r_index_group, bool select_random_particle, bool preserve_particle_dimension, bool preserve_group_dimension);
+extern "C" SEXP _dust2_dust2_filter_sirode_last_history(SEXP ptr, SEXP r_index_group, SEXP select_random_particle, SEXP preserve_particle_dimension, SEXP preserve_group_dimension) {
+  BEGIN_CPP11
+    return cpp11::as_sexp(dust2_filter_sirode_last_history(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_group), cpp11::as_cpp<cpp11::decay_t<bool>>(select_random_particle), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_particle_dimension), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_group_dimension)));
+  END_CPP11
+}
+// sirode.cpp
+SEXP dust2_filter_sirode_last_state(cpp11::sexp ptr, cpp11::sexp r_index_group, bool select_random_particle, bool preserve_particle_dimension, bool preserve_group_dimension);
+extern "C" SEXP _dust2_dust2_filter_sirode_last_state(SEXP ptr, SEXP r_index_group, SEXP select_random_particle, SEXP preserve_particle_dimension, SEXP preserve_group_dimension) {
+  BEGIN_CPP11
+    return cpp11::as_sexp(dust2_filter_sirode_last_state(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_index_group), cpp11::as_cpp<cpp11::decay_t<bool>>(select_random_particle), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_particle_dimension), cpp11::as_cpp<cpp11::decay_t<bool>>(preserve_group_dimension)));
+  END_CPP11
+}
+// sirode.cpp
+SEXP dust2_filter_sirode_rng_state(cpp11::sexp ptr);
+extern "C" SEXP _dust2_dust2_filter_sirode_rng_state(SEXP ptr) {
+  BEGIN_CPP11
+    return cpp11::as_sexp(dust2_filter_sirode_rng_state(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr)));
+  END_CPP11
+}
+// sirode.cpp
+SEXP dust2_filter_sirode_set_rng_state(cpp11::sexp ptr, cpp11::sexp r_rng_state);
+extern "C" SEXP _dust2_dust2_filter_sirode_set_rng_state(SEXP ptr, SEXP r_rng_state) {
+  BEGIN_CPP11
+    return cpp11::as_sexp(dust2_filter_sirode_set_rng_state(cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(ptr), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(r_rng_state)));
+  END_CPP11
+}
 // test.cpp
 cpp11::integers test_resample_weight(std::vector<double> w, double u);
 extern "C" SEXP _dust2_test_resample_weight(SEXP w, SEXP u) {
@@ -561,6 +652,13 @@ static const R_CallMethodDef CallEntries[] = {
     {"_dust2_dust2_filter_sir_run",                    (DL_FUNC) &_dust2_dust2_filter_sir_run,                     7},
     {"_dust2_dust2_filter_sir_set_rng_state",          (DL_FUNC) &_dust2_dust2_filter_sir_set_rng_state,           2},
     {"_dust2_dust2_filter_sir_update_pars",            (DL_FUNC) &_dust2_dust2_filter_sir_update_pars,             3},
+    {"_dust2_dust2_filter_sirode_alloc",               (DL_FUNC) &_dust2_dust2_filter_sirode_alloc,               10},
+    {"_dust2_dust2_filter_sirode_last_history",        (DL_FUNC) &_dust2_dust2_filter_sirode_last_history,         5},
+    {"_dust2_dust2_filter_sirode_last_state",          (DL_FUNC) &_dust2_dust2_filter_sirode_last_state,           5},
+    {"_dust2_dust2_filter_sirode_rng_state",           (DL_FUNC) &_dust2_dust2_filter_sirode_rng_state,            1},
+    {"_dust2_dust2_filter_sirode_run",                 (DL_FUNC) &_dust2_dust2_filter_sirode_run,                  7},
+    {"_dust2_dust2_filter_sirode_set_rng_state",       (DL_FUNC) &_dust2_dust2_filter_sirode_set_rng_state,        2},
+    {"_dust2_dust2_filter_sirode_update_pars",         (DL_FUNC) &_dust2_dust2_filter_sirode_update_pars,          3},
     {"_dust2_dust2_system_logistic_alloc",             (DL_FUNC) &_dust2_dust2_system_logistic_alloc,              8},
     {"_dust2_dust2_system_logistic_internals",         (DL_FUNC) &_dust2_dust2_system_logistic_internals,          2},
     {"_dust2_dust2_system_logistic_reorder",           (DL_FUNC) &_dust2_dust2_system_logistic_reorder,            2},
@@ -588,6 +686,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_dust2_dust2_system_sir_time",                   (DL_FUNC) &_dust2_dust2_system_sir_time,                    1},
     {"_dust2_dust2_system_sir_update_pars",            (DL_FUNC) &_dust2_dust2_system_sir_update_pars,             2},
     {"_dust2_dust2_system_sirode_alloc",               (DL_FUNC) &_dust2_dust2_system_sirode_alloc,                8},
+    {"_dust2_dust2_system_sirode_compare_data",        (DL_FUNC) &_dust2_dust2_system_sirode_compare_data,         4},
     {"_dust2_dust2_system_sirode_internals",           (DL_FUNC) &_dust2_dust2_system_sirode_internals,            2},
     {"_dust2_dust2_system_sirode_reorder",             (DL_FUNC) &_dust2_dust2_system_sirode_reorder,              2},
     {"_dust2_dust2_system_sirode_rng_state",           (DL_FUNC) &_dust2_dust2_system_sirode_rng_state,            1},
@@ -618,6 +717,11 @@ static const R_CallMethodDef CallEntries[] = {
     {"_dust2_dust2_unfilter_sir_last_state",           (DL_FUNC) &_dust2_dust2_unfilter_sir_last_state,            5},
     {"_dust2_dust2_unfilter_sir_run",                  (DL_FUNC) &_dust2_dust2_unfilter_sir_run,                   7},
     {"_dust2_dust2_unfilter_sir_update_pars",          (DL_FUNC) &_dust2_dust2_unfilter_sir_update_pars,           3},
+    {"_dust2_dust2_unfilter_sirode_alloc",             (DL_FUNC) &_dust2_dust2_unfilter_sirode_alloc,              9},
+    {"_dust2_dust2_unfilter_sirode_last_history",      (DL_FUNC) &_dust2_dust2_unfilter_sirode_last_history,       5},
+    {"_dust2_dust2_unfilter_sirode_last_state",        (DL_FUNC) &_dust2_dust2_unfilter_sirode_last_state,         5},
+    {"_dust2_dust2_unfilter_sirode_run",               (DL_FUNC) &_dust2_dust2_unfilter_sirode_run,                7},
+    {"_dust2_dust2_unfilter_sirode_update_pars",       (DL_FUNC) &_dust2_dust2_unfilter_sirode_update_pars,        3},
     {"_dust2_test_check_dimensions",                   (DL_FUNC) &_dust2_test_check_dimensions,                    3},
     {"_dust2_test_history_",                           (DL_FUNC) &_dust2_test_history_,                            6},
     {"_dust2_test_interpolate_constant1",              (DL_FUNC) &_dust2_test_interpolate_constant1,               3},

--- a/tests/testthat/test-filter.R
+++ b/tests/testthat/test-filter.R
@@ -613,3 +613,15 @@ test_that("can extract a random particle from a nested filter", {
   expect_false(any(is.na(i)))
   expect_gt(length(unique(row(hash1)[i])), 1)
 })
+
+
+test_that("can run continuous-time unfilter", {
+  pars <- list(beta = 0.1, gamma = 0.2, N = 1000, I0 = 10, exp_noise = 1e6)
+  time_start <- 0
+  data <- data.frame(time = c(4, 8, 12, 16), incidence = 1:4)
+  n_particles <- 100
+  expect_error(
+    dust_filter_create(sirode(), time_start, data, n_particles = n_particles),
+    "Can't use 'dust_filter_create()' with continous-time models",
+    fixed = TRUE)
+})

--- a/tests/testthat/test-filter.R
+++ b/tests/testthat/test-filter.R
@@ -615,7 +615,7 @@ test_that("can extract a random particle from a nested filter", {
 })
 
 
-test_that("can run continuous-time unfilter", {
+test_that("can run continuous-time filter", {
   pars <- list(beta = 0.1, gamma = 0.2, N = 1000, I0 = 10, exp_noise = 1e6)
   time_start <- 0
   data <- data.frame(time = c(4, 8, 12, 16), incidence = 1:4)

--- a/tests/testthat/test-sirode.R
+++ b/tests/testthat/test-sirode.R
@@ -100,3 +100,17 @@ test_that("throw nice error on run failure, then prevent access", {
   dust_system_set_state_initial(obj)
   expect_equal(dust_system_time(obj), 0)
 })
+
+
+test_that("can compare to data", {
+  pars <- list(beta = 0.1, gamma = 0.2, N = 1000, I0 = 10, exp_noise = 0.5)
+  obj <- dust_system_create(sirode(), pars, 10, deterministic = TRUE)
+
+  s <- rbind(0, 0, 0, 0, rpois(10, 30) + rnorm(10))
+  dust_system_set_state(obj, s)
+  d <- list(incidence = 30)
+
+  expect_equal(
+    dust_system_compare_data(obj, d),
+    dpois(30, s[5, ], log = TRUE))
+})


### PR DESCRIPTION
~Merge after #77, contains those commits~

More theoretical than practical, though the unfilter works at least.  The filter really needs considerably more work, but it compiles now.

Once this one is in, I'll do some time harmonisation and then we can start on the mixed-time models (SDE approximations) which mean we actually do something worthwhile with the continuous time filter