### PR TITLE
Repair environment on load

### DIFF
--- a/R/compile.R
+++ b/R/compile.R
@@ -95,6 +95,11 @@ dust_compile <- function(filename, quiet = NULL, workdir = NULL,
 
   workdir <- dust_workdir(workdir, hash)
   quiet <- dust_quiet(quiet)
+
+  ## Second round of substitution in here, in order to sub in the work
+  ## directory now that we have it:
+  res$r <- glue_whisker(res$r, list(path_pkg = workdir))
+
   dir_create(c(workdir, file.path(workdir, c("R", "src"))))
   writelines_if_changed(res$description, workdir, "DESCRIPTION", quiet)
   writelines_if_changed(res$namespace, workdir, "NAMESPACE", quiet)

--- a/R/compile.R
+++ b/R/compile.R
@@ -98,7 +98,8 @@ dust_compile <- function(filename, quiet = NULL, workdir = NULL,
 
   ## Second round of substitution in here, in order to sub in the work
   ## directory now that we have it:
-  res$r <- glue_whisker(res$r, list(path_pkg = workdir))
+  data <- list(path_pkg = gsub("\\", "/", workdir, fixed = TRUE))
+  res$r <- glue_whisker(res$r, data)
 
   dir_create(c(workdir, file.path(workdir, c("R", "src"))))
   writelines_if_changed(res$description, workdir, "DESCRIPTION", quiet)

--- a/R/interface.R
+++ b/R/interface.R
@@ -39,6 +39,8 @@ dust_system_generator <- function(name, time_type, default_dt,
       nms)
   }
 
+  env <- dust_package_env(env)
+
   methods_core <- c("alloc",
                     "state", "set_state", "set_state_initial",
                     "time", "set_time",
@@ -739,4 +741,15 @@ check_time_control <- function(generator, dt, ode_control,
   dt <- check_system_dt(dt, generator, call = call)
   ode_control <- check_system_ode_control(ode_control, generator, call = call)
   list(dt = dt, ode_control = ode_control)
+}
+
+
+dust_package_env <- function(env, quiet = FALSE) {
+  if (is.environment(env)) {
+    env
+  } else if (isNamespaceLoaded(env$name)) {
+    asNamespace(env$name)
+  } else {
+    env <- load_temporary_package(env$path, env$name, quiet)
+  }
 }

--- a/R/interface.R
+++ b/R/interface.R
@@ -700,7 +700,7 @@ is_uncalled_generator <- function(sys) {
   code <- body(sys)
   rlang::is_call(code, "{") &&
     length(code) == 2 &&
-    rlang::is_call(code[[2]], "dust_system")
+    rlang::is_call(code[[2]], "dust_system_generator")
 }
 
 

--- a/R/interface.R
+++ b/R/interface.R
@@ -699,8 +699,8 @@ is_uncalled_generator <- function(sys) {
   }
   code <- body(sys)
   rlang::is_call(code, "{") &&
-    length(code) == 2 &&
-    rlang::is_call(code[[2]], "dust_system_generator")
+    length(code) %in% 2:3 &&
+    rlang::is_call(last(code), "dust_system_generator")
 }
 
 

--- a/R/package.R
+++ b/R/package.R
@@ -80,7 +80,7 @@ dust_package <- function(path, quiet = NULL) {
   }
 
   code_r <- c(dust_header("##"), vcapply(data, "[[", "r"))
-  writelines_if_changed(code_r, path, "R/package.R", quiet)
+  writelines_if_changed(code_r, path, "R/dust.R", quiet)
 
   if (file.exists(file.path(path, "src/Makevars"))) {
     makevars <- read_lines(file.path(path, "src/Makevars"))

--- a/R/package.R
+++ b/R/package.R
@@ -223,7 +223,7 @@ package_generate <- function(filename, call) {
   system <- read_lines(filename)
   data <- dust_template_data(config$name, config$class, config$time_type,
                              config$default_dt)
-  list(r = substitute_dust_template(data, "dust.R"),
+  list(r = substitute_dust_template(data, "package.R"),
        cpp = dust_generate_cpp(system, config, data))
 }
 

--- a/R/package.R
+++ b/R/package.R
@@ -80,7 +80,7 @@ dust_package <- function(path, quiet = NULL) {
   }
 
   code_r <- c(dust_header("##"), vcapply(data, "[[", "r"))
-  writelines_if_changed(code_r, path, "R/dust.R", quiet)
+  writelines_if_changed(code_r, path, "R/package.R", quiet)
 
   if (file.exists(file.path(path, "src/Makevars"))) {
     makevars <- read_lines(file.path(path, "src/Makevars"))

--- a/R/util.R
+++ b/R/util.R
@@ -131,3 +131,8 @@ fmod <- function(n, m) {
 envvar_is_truthy <- function(name) {
   tolower(Sys.getenv(name, "false")) %in% c("t", "true", "1")
 }
+
+
+last <- function(x) {
+  x[[length(x)]]
+}

--- a/inst/template/dust.R
+++ b/inst/template/dust.R
@@ -1,8 +1,5 @@
 {{name}} <- function() {
-  if (isNamespaceLoaded("{{package}}")) {
-    env <- asNamespace("{{package}}")
-  } else {
-    env <- dust2:::load_temporary_package("{{{{path_pkg}}}}", "{{package}}", FALSE)
-  }
-  dust2::dust_system_generator("{{name}}", "{{time_type_property}}", {{default_dt}}, env)
+  package <- list(name = "{{package}}", path = "{{{{path_pkg}}}}")
+  dust2::dust_system_generator("{{name}}", "{{time_type_property}}", {{default_dt}},
+                               package)
 }

--- a/inst/template/dust.R
+++ b/inst/template/dust.R
@@ -1,3 +1,8 @@
 {{name}} <- function() {
-  dust2::dust_system_generator("{{name}}", "{{time_type_property}}", {{default_dt}})
+  if (isNamespaceLoaded("{{package}}")) {
+    env <- asNamespace("{{package}}")
+  } else {
+    env <- dust2:::load_temporary_package("{{{{path_pkg}}}}", "{{package}}", FALSE)
+  }
+  dust2::dust_system_generator("{{name}}", "{{time_type_property}}", {{default_dt}}, env)
 }

--- a/inst/template/package.R
+++ b/inst/template/package.R
@@ -1,0 +1,3 @@
+{{name}} <- function() {
+  dust2::dust_system_generator("{{name}}", "{{time_type_property}}", {{default_dt}})
+}

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -18,6 +18,17 @@ test_that("error if given invalid inputs to dust_system_create", {
     dust_system_create("sir"),
     "Expected 'generator' to be a 'dust_system_generator' object")
 
+  foo <- function() {
+    dust2::dust_system_generator(...)
+  }
+  expect_true(is_uncalled_generator(foo))
+  err <- expect_error(
+    dust_system_create(foo),
+    "Expected 'generator' to be a 'dust_system_generator' object")
+  expect_equal(err$body,
+               c(i = "Did you mean 'foo()' (i.e., with parentheses)"))
+
+  skip_on_covr()
   err <- expect_error(
     dust_system_create(sir),
     "Expected 'generator' to be a 'dust_system_generator' object")

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -18,14 +18,11 @@ test_that("error if given invalid inputs to dust_system_create", {
     dust_system_create("sir"),
     "Expected 'generator' to be a 'dust_system_generator' object")
 
-  foo <- function() {
-    dust_system("foo")
-  }
   err <- expect_error(
-    dust_system_create(foo),
+    dust_system_create(sir),
     "Expected 'generator' to be a 'dust_system_generator' object")
   expect_equal(err$body,
-               c(i = "Did you mean 'foo()' (i.e., with parentheses)"))
+               c(i = "Did you mean 'sir()' (i.e., with parentheses)"))
 })
 
 

--- a/tests/testthat/test-zzz-compile.R
+++ b/tests/testthat/test-zzz-compile.R
@@ -9,6 +9,7 @@ test_that("can compile simple system", {
   expect_s3_class(res, "dust_system_generator")
   expect_equal(res$name, "mysir")
   expect_true(res$properties$has_compare)
+  expect_true(is_uncalled_generator(gen))
 
   obj1 <- dust_system_create(gen(), list(), n_particles = 10, seed = 1)
   dust_system_set_state_initial(obj1)

--- a/tests/testthat/test-zzz-compile.R
+++ b/tests/testthat/test-zzz-compile.R
@@ -9,7 +9,6 @@ test_that("can compile simple system", {
   expect_s3_class(res, "dust_system_generator")
   expect_equal(res$name, "mysir")
   expect_true(res$properties$has_compare)
-  expect_true(is_uncalled_generator(gen))
 
   obj1 <- dust_system_create(gen(), list(), n_particles = 10, seed = 1)
   dust_system_set_state_initial(obj1)
@@ -22,6 +21,9 @@ test_that("can compile simple system", {
   res <- evaluate_promise(dust_compile(filename, quiet = FALSE, debug = TRUE))
   expect_identical(res$result, gen)
   expect_match(res$messages, "Using cached generator")
+
+  skip_on_covr()
+  expect_true(is_uncalled_generator(gen))
 })
 
 

--- a/tests/testthat/test-zzz-compile.R
+++ b/tests/testthat/test-zzz-compile.R
@@ -49,7 +49,7 @@ test_that("can compile into a stable directory", {
                "'src/dust.cpp' is up to date",
                all = FALSE)
   expect_match(cli::ansi_strip(log_txt),
-               "Loading(.+)mysir2",
+               "Loading mysir2",
                all = FALSE)
   expect_false(any(grepl("compiling", log_txt, ignore.case = TRUE)))
 })
@@ -73,5 +73,5 @@ test_that("generators can be serialised and used from other processes", {
       dust2::dust_system_state(dust2::dust_system_create(sys(), list(), 1))
     }, list(tmp), stdout = log, stderr = "2>&1"),
     numeric(5))
-  expect_match(readLines(log), "Loading mysir", all = FALSE)
+  expect_match(cli::ansi_string(readLines(log)), "Loading mysir", all = FALSE)
 })

--- a/tests/testthat/test-zzz-compile.R
+++ b/tests/testthat/test-zzz-compile.R
@@ -45,8 +45,12 @@ test_that("can compile into a stable directory", {
   }, list(filename = filename), env = env, stdout = log, stderr = "2>&1")
 
   log_txt <- readLines(log)
-  expect_match(log_txt, "'src/dust.cpp' is up to date", all = FALSE)
-  expect_match(log_txt, "Loading(.+)mysir2", all = FALSE)
+  expect_match(cli::ansi_strip(log_txt),
+               "'src/dust.cpp' is up to date",
+               all = FALSE)
+  expect_match(cli::ansi_strip(log_txt),
+               "Loading(.+)mysir2",
+               all = FALSE)
   expect_false(any(grepl("compiling", log_txt, ignore.case = TRUE)))
 })
 


### PR DESCRIPTION
This is something we fought against a bit in dust1/mcstate1, because when using callr we won't find code that we've loaded using `pkgload::load_all`.  This PR adds a slightly different bit of R code into the template for throwaway packages (created by `dust_compile`) compared with the more permanent ones created by `dust_compile`.  This means that if a user has done `dust_compile()` on a model and fed that into the callr runner for monty we will load the package namespace and everything should proceed fairly happily.

This is not a big problem for code where we have created a package, installed it and run monty from there.  We don't really solve this for the case where the user is developing a package and trying to use the callr runner; there we'll need them to install that package for callr to work

Closes #92 - contains the same commit 6206dc3 and then we also have the fix for our new template here too