### PR TITLE
Environment variable control over debug builds

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust2
 Title: Next Generation dust
-Version: 0.1.10
+Version: 0.1.11
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/R/compile.R
+++ b/R/compile.R
@@ -81,7 +81,6 @@ dust_compile <- function(filename, quiet = NULL, workdir = NULL,
                          debug = NULL, skip_cache = FALSE) {
   quiet <- dust_quiet(quiet)
   debug <- dust_quiet(debug)
-  workdir <- dust_workdir(workdir, hash)
 
   stop_unless_installed(dust_compile_needs())
   config <- parse_metadata(filename, call = environment())
@@ -97,6 +96,8 @@ dust_compile <- function(filename, quiet = NULL, workdir = NULL,
     }
     return(cache$generators[[hash]]$gen)
   }
+
+  workdir <- dust_workdir(workdir, hash)
 
   ## Second round of substitution in here, in order to sub in the work
   ## directory now that we have it:

--- a/R/compile.R
+++ b/R/compile.R
@@ -80,7 +80,7 @@ dust_compile <- function(filename, quiet = NULL, workdir = NULL,
                          compiler_options = NULL, optimisation_level = NULL,
                          debug = NULL, skip_cache = FALSE) {
   quiet <- dust_quiet(quiet)
-  debug <- dust_quiet(debug)
+  debug <- dust_debug(debug)
 
   stop_unless_installed(dust_compile_needs())
   config <- parse_metadata(filename, call = environment())

--- a/R/compile.R
+++ b/R/compile.R
@@ -63,7 +63,8 @@
 ##'   anything in your personal `Makevars`
 ##'
 ##' @param debug Passed to [pkgbuild::compile_dll], this will build a
-##'   debug library.
+##'   debug library. If `NULL` is given, then we take the value from
+##'   `DUST_DEBUG` if set, or `FALSE` otherwise.
 ##'
 ##' @param skip_cache Logical, indicating if the cache of previously
 ##'   compiled systems should be skipped. If `TRUE` then your system will
@@ -77,7 +78,11 @@
 dust_compile <- function(filename, quiet = NULL, workdir = NULL,
                          linking_to = NULL, cpp_std = NULL,
                          compiler_options = NULL, optimisation_level = NULL,
-                         debug = FALSE, skip_cache = FALSE) {
+                         debug = NULL, skip_cache = FALSE) {
+  quiet <- dust_quiet(quiet)
+  debug <- dust_quiet(debug)
+  workdir <- dust_workdir(workdir, hash)
+
   stop_unless_installed(dust_compile_needs())
   config <- parse_metadata(filename, call = environment())
   mangle <- substr(rlang::hash_file(filename), 1, 8)
@@ -92,9 +97,6 @@ dust_compile <- function(filename, quiet = NULL, workdir = NULL,
     }
     return(cache$generators[[hash]]$gen)
   }
-
-  workdir <- dust_workdir(workdir, hash)
-  quiet <- dust_quiet(quiet)
 
   ## Second round of substitution in here, in order to sub in the work
   ## directory now that we have it:
@@ -304,5 +306,14 @@ dust_quiet <- function(quiet, call = parent.frame()) {
     envvar_is_truthy("DUST_QUIET")
   } else {
     assert_scalar_logical(quiet, call = call)
+  }
+}
+
+
+dust_debug <- function(debug, call = parent.frame()) {
+  if (is.null(debug)) {
+    envvar_is_truthy("DUST_DEBUG")
+  } else {
+    assert_scalar_logical(debug, call = call)
   }
 }

--- a/man/dust_compile.Rd
+++ b/man/dust_compile.Rd
@@ -12,7 +12,7 @@ dust_compile(
   cpp_std = NULL,
   compiler_options = NULL,
   optimisation_level = NULL,
-  debug = FALSE,
+  debug = NULL,
   skip_cache = FALSE
 )
 }
@@ -73,7 +73,8 @@ Note that as for \code{compiler_options}, R will apply these \emph{before}
 anything in your personal \code{Makevars}}
 
 \item{debug}{Passed to \link[pkgbuild:compile_dll]{pkgbuild::compile_dll}, this will build a
-debug library.}
+debug library. If \code{NULL} is given, then we take the value from
+\code{DUST_DEBUG} if set, or \code{FALSE} otherwise.}
 
 \item{skip_cache}{Logical, indicating if the cache of previously
 compiled systems should be skipped. If \code{TRUE} then your system will

--- a/tests/testthat/test-compile.R
+++ b/tests/testthat/test-compile.R
@@ -148,3 +148,18 @@ test_that("quiet responds to envvar", {
     expect_false(dust_quiet(FALSE))
   })
 })
+
+
+test_that("debug responds to envvar", {
+  withr::with_envvar(c(DUST_DEBUG = NA_character_), {
+    expect_false(dust_debug(NULL))
+    expect_false(dust_debug(FALSE))
+    expect_true(dust_debug(TRUE))
+    expect_error(dust_debug(1), "Expected 'debug' to be logical")
+  })
+
+  withr::with_envvar(c(DUST_DEBUG = "true"), {
+    expect_true(dust_debug(NULL))
+    expect_false(dust_debug(FALSE))
+  })
+})

--- a/vignettes/details.Rmd
+++ b/vignettes/details.Rmd
@@ -23,4 +23,6 @@ knitr::opts_chunk$set(
 
 If you set this environment variable, then we'll create models here, each with a name in the pattern `dust_<hash>` where `<hash>` is the hash of the generated code.  This means that if your model changes we'll still recompile it.
 
-`DUST_QUIET`: an environment variable which controls the default level of verbosity when compiling dust models.  Set this to a truthy value (e.g., `TRUE`) to change the default.  This can always be overridden by providing a value for the `quiet` argument to `dust_compile` and `dust_package`.
+`DUST_QUIET`: an environment variable which controls the default level of verbosity when compiling dust models.  Set this to a truthy value (e.g., `TRUE`) to change the default.  This can always be overridden by providing a value for the `quiet` argument to [dust_compile()] and [dust_package()].
+
+`DUST_DEBUG`: an environment variable which controls how [pkgload::compile_dll] compiles the C++ code.  Set this to a truthy value (e.g., `TRUE`) to disable optimisation, which allows faster compilation at the cost of slower runtime.  This can be overridden by the `debug` argument to [dust_compile()].


### PR DESCRIPTION
Similar to #90, but for the debug argument (which affects only `dust_compile` and not `dust_package`)