### PR TITLE
New observer interface

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ URL: https://github.com/mrc-ide/dust2, https://mrc-ide.github.io/dust2
 BugReports: https://github.com/mrc-ide/dust2/issues
 Imports:
     cli,
-    monty,
+    monty (>= 0.2.11),
     rlang
 LinkingTo:
     cpp11,
@@ -39,4 +39,4 @@ Suggests:
 VignetteBuilder: knitr
 Config/testthat/edition: 3
 Config/Needs/compile: cpp11, decor, glue, pkgbuild, pkgload
-Remotes: mrc-ide/monty
+Remotes: mrc-ide/monty@mrc-5859

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust2
 Title: Next Generation dust
-Version: 0.1.13
+Version: 0.1.14
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ URL: https://github.com/mrc-ide/dust2, https://mrc-ide.github.io/dust2
 BugReports: https://github.com/mrc-ide/dust2/issues
 Imports:
     cli,
-    monty (>= 0.2.11),
+    monty (>= 0.2.12),
     rlang
 LinkingTo:
     cpp11,
@@ -39,4 +39,4 @@ Suggests:
 VignetteBuilder: knitr
 Config/testthat/edition: 3
 Config/Needs/compile: cpp11, decor, glue, pkgbuild, pkgload
-Remotes: mrc-ide/monty@mrc-5859
+Remotes: mrc-ide/monty

--- a/R/interface-likelihood.R
+++ b/R/interface-likelihood.R
@@ -116,6 +116,11 @@ dust_likelihood_copy <- function(obj, seed = NULL) {
 ##'
 ##' @inheritParams dust_likelihood_run
 ##'
+##' @param index_state Optional index vector to index state by.  This
+##'   is experimental and will play very poorly with providing
+##'   `index_state` when constructing the object (that will likely be
+##'   removed in a version soon)
+##'
 ##' @param select_random_particle Logical, indicating if we should
 ##'   return a history for one randomly selected particle (rather than
 ##'   the entire history).  If this is `TRUE`, the particle will be
@@ -130,7 +135,9 @@ dust_likelihood_copy <- function(obj, seed = NULL) {
 ##'   second (particle) dimension will be dropped.
 ##'
 ##' @export
-dust_likelihood_last_history <- function(obj, index_group = NULL,
+dust_likelihood_last_history <- function(obj,
+                                         index_state = NULL,
+                                         index_group = NULL,
                                          select_random_particle = FALSE) {
   check_is_dust_likelihood(obj)
   if (is.null(obj$ptr)) {

--- a/R/interface-likelihood.R
+++ b/R/interface-likelihood.R
@@ -135,9 +135,7 @@ dust_likelihood_copy <- function(obj, seed = NULL) {
 ##'   second (particle) dimension will be dropped.
 ##'
 ##' @export
-dust_likelihood_last_history <- function(obj,
-                                         index_state = NULL,
-                                         index_group = NULL,
+dust_likelihood_last_history <- function(obj, index_group = NULL,
                                          select_random_particle = FALSE) {
   check_is_dust_likelihood(obj)
   if (is.null(obj$ptr)) {

--- a/R/interface-likelihood.R
+++ b/R/interface-likelihood.R
@@ -116,11 +116,6 @@ dust_likelihood_copy <- function(obj, seed = NULL) {
 ##'
 ##' @inheritParams dust_likelihood_run
 ##'
-##' @param index_state Optional index vector to index state by.  This
-##'   is experimental and will play very poorly with providing
-##'   `index_state` when constructing the object (that will likely be
-##'   removed in a version soon)
-##'
 ##' @param select_random_particle Logical, indicating if we should
 ##'   return a history for one randomly selected particle (rather than
 ##'   the entire history).  If this is `TRUE`, the particle will be

--- a/R/monty.R
+++ b/R/monty.R
@@ -247,8 +247,8 @@ dust_observer <- function(obj, save_state, save_history,
   observe <- function() {
     ret <- list()
     if (save_state) {
-      ret$state <-
-        dust_likelihood_last_state(obj, select_random_particle = TRUE)
+      ret$state <- dust_likelihood_last_state(
+        obj, select_random_particle = TRUE)
     }
 
     if (save_history$enabled) {
@@ -262,8 +262,8 @@ dust_observer <- function(obj, save_state, save_history,
       ## dust_likelihood_last_history which will simplify this, but
       ## that requires slightly more surgery and I've moved it into
       ## another ticket (mrc-5863)
-      history <-
-        dust_likelihood_last_history(obj, select_random_particle = TRUE)
+      history <- dust_likelihood_last_history(
+        obj, select_random_particle = TRUE)
       if (!is.null(save_history$index)) {
         history <- history[save_history$index, , drop = FALSE]
       }

--- a/R/monty.R
+++ b/R/monty.R
@@ -242,24 +242,26 @@ dust_observer <- function(obj, save_state, save_history,
   }
 
   env <- environment()
+  env$uninitialised <- !is.null(save_history$subset)
 
   observe <- function() {
     ret <- list()
     if (save_state) {
-      ret$state <- dust_likelihood_last_state(obj,
-                                              select_random_particle = TRUE)
+      ret$state <-
+        dust_likelihood_last_state(obj, select_random_particle = TRUE)
     }
 
     if (save_history$enabled) {
-      if (is.null(obj$packer_history)) {
-        if (is.null(save_history$subset)) {
-          obj$packer_history <- obj$packer_state
-        } else {
-          tmp <- obj$packer_state$subset(save_history$subset)
-          env$save_history$index <- tmp$index
-          obj$packer_history <- tmp$packer
-        }
+      if (env$uninitialised) {
+        env$save_history$index <-
+          obj$packer_state$subset(save_history$subset)$index
+        env$uninitialised <- FALSE
       }
+
+      ## TODO: we'll create a index_state argument to
+      ## dust_likelihood_last_history which will simplify this, but
+      ## that requires slightly more surgery and I've moved it into
+      ## another ticket (mrc-5863)
       history <-
         dust_likelihood_last_history(obj, select_random_particle = TRUE)
       if (!is.null(save_history$index)) {

--- a/R/monty.R
+++ b/R/monty.R
@@ -71,6 +71,14 @@
 ##'   parameter sets where, once you understand the model, giving up
 ##'   on that parameter set and continuing is the best option.
 ##'
+##' @param save_state Logical, indicating if the state should be saved
+##'   at the time series.
+##'
+##' @param save_history Logical, indicating if particle trajectories
+##'   should be saved.  This can also be a character vector indicating
+##'   the logical compartments, or an integer vector being an index
+##'   into the state.
+##'
 ##' @return A [monty::monty_model] object
 ##'
 ##' @export

--- a/R/monty.R
+++ b/R/monty.R
@@ -110,8 +110,6 @@ dust_likelihood_monty <- function(obj, packer, initial = NULL, domain = NULL,
     save_history <- TRUE
   }
 
-  assert_scalar_logical(save_history) # TODO: make flexible
-
   domain <- monty::monty_domain_expand(domain, packer)
 
   ## We configure saving trajectories on creation I think, which then
@@ -198,6 +196,7 @@ dust_likelihood_monty <- function(obj, packer, initial = NULL, domain = NULL,
           if (is.null(save_history_subset)) {
             obj$packer_history <- obj$packer_state
           } else {
+            browser()
             save_history_index_state <<-
               validate_history_index(save_history_subset, obj$packer_state)
             obj$packer_history <-
@@ -259,44 +258,5 @@ packer_unpack <- function(packer, x) {
     lapply(seq_len(ncol(x)), function(i) packer$unpack(x[, i]))
   } else {
     packer$unpack(x)
-  }
-}
-
-
-
-validate_history_index <- function(subset, packer, call = parent.frame()) {
-  index <- packer$index()
-  if (is.character(subset)) {
-    ret <- match(subset, names(index))
-    err <- is.na(ret)
-    if (any(err)) {
-      cli::cli_abort(
-        "Unknown state value{?s} referenced by observer: {squote(subset[err])}",
-        call = call)
-    }
-  } else {
-    max <- last(last(index))
-    err <- subset < 1 | subset > max
-    if (any(err)) {
-      cli::cli_abort(
-        "Invalid state value{?s} out of range: {as.character(err)}",
-        call = call)
-    }
-    ret <- index
-  }
-  ret
-}
-
-
-## Dirty hack for now, this should go into monty, but deserves its own
-## PR.
-packer_subset <- function(packer, index) {
-  e <- environment(packer$pack)
-  if (is.character(index)) {
-    scalar <- intersect(e$scalar, index)
-    array <- e$array[intersect(names(e$array), index)]
-    monty::monty_packer(scalar, array)
-  } else {
-    monty::monty_packer(packer$parameters[index])
   }
 }

--- a/inst/include/dust2/tools.hpp
+++ b/inst/include/dust2/tools.hpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <cmath>
 #include <numeric>
+#include <vector>
 
 namespace dust2 {
 namespace tools {

--- a/man/dust_likelihood_monty.Rd
+++ b/man/dust_likelihood_monty.Rd
@@ -9,7 +9,9 @@ dust_likelihood_monty(
   packer,
   initial = NULL,
   domain = NULL,
-  failure_is_impossible = FALSE
+  failure_is_impossible = FALSE,
+  save_state = FALSE,
+  save_history = FALSE
 )
 }
 \arguments{
@@ -43,6 +45,14 @@ possible.  However, sometimes you can have integration failures
 with very high parameter values, or just other pathological
 parameter sets where, once you understand the model, giving up
 on that parameter set and continuing is the best option.}
+
+\item{save_state}{Logical, indicating if the state should be saved
+at the time series.}
+
+\item{save_history}{Logical, indicating if particle trajectories
+should be saved.  This can also be a character vector indicating
+the logical compartments, or an integer vector being an index
+into the state.}
 }
 \value{
 A \link[monty:monty_model]{monty::monty_model} object

--- a/scripts/check_headers
+++ b/scripts/check_headers
@@ -24,8 +24,9 @@ files <- dir(path_dust, "\\.hpp$", recursive = TRUE)
 check <- function(f) {
   message(crayon::bold(sprintf("%s...", f)), appendLF = FALSE)
   include <- c(include_r, include_dust, include_monty, include_cpp)
+  dest <- tempfile()
   ans <- suppressWarnings(
-    system2(cc, c(cc_flags, "-O0", "-o/dev/null", "-c", include,
+    system2(cc, c(cc_flags, "-O0", paste0("-o", dest), "-c", include,
                   file.path(path_dust, f)),
             stderr = TRUE, stdout = TRUE))
   ok <- is.null(attr(ans, "status"))

--- a/tests/testthat/test-monty.R
+++ b/tests/testthat/test-monty.R
@@ -227,3 +227,16 @@ test_that("can record both state and trajectories", {
   expect_equal(dim(res$observations$history), c(5, 4, 13, 3))
   expect_equal(res$observations$state, res$observations$history[, 4, , ])
 })
+
+
+test_that("validate request to save history", {
+  expect_equal(validate_save_history(FALSE), list(enabled = FALSE))
+  expect_equal(validate_save_history(TRUE),
+               list(enabled = TRUE, index = NULL, subset = NULL))
+  expect_error(validate_save_history(NULL),
+               "Invalid value for 'save_history'")
+  expect_error(validate_save_history(1:3),
+               "Invalid value for 'save_history'")
+  expect_equal(validate_save_history(c("a", "b")),
+               list(enabled = TRUE, index = NULL, subset = c("a", "b")))
+})

--- a/tests/testthat/test-monty.R
+++ b/tests/testthat/test-monty.R
@@ -135,5 +135,95 @@ test_that("can get trajectories from model", {
 
   expect_equal(names(res$observations), "history")
   expect_equal(dim(res$observations$history), c(5, 4, 27, 3))
-  expect_identical(obj$packer_history, obj$packer_state)
+})
+
+
+test_that("can subset trajectories from model", {
+  pars <- list(beta = 0.1, gamma = 0.2, N = 1000, I0 = 10, exp_noise = 1e6)
+  time_start <- 0
+  data <- data.frame(time = c(4, 8, 12, 16), incidence = 1:4)
+  obj <- dust_filter_create(sir(), time_start, data, n_particles = 100,
+                            seed = 42)
+  packer <- monty::monty_packer(
+    c("beta", "gamma"),
+    fixed = list(N = 1000, I0 = 10, exp_noise = 1e6))
+
+  prior <- monty::monty_dsl({
+    beta ~ Exponential(mean = 0.5)
+    gamma ~ Exponential(mean = 0.5)
+  })
+
+  sampler <- monty::monty_sampler_random_walk(diag(2) * c(0.02, 0.02))
+
+  set.seed(1)
+  m1 <- dust_likelihood_monty(obj, packer, save_history = c("I", "cases_inc"))
+  p1 <- m1 + prior
+  res1 <- monty::monty_sample(p1, sampler, 13, initial = c(.2, .1),
+                              n_chains = 3)
+
+  set.seed(1)
+  m2 <- dust_likelihood_monty(obj, packer, save_history = TRUE)
+  p2 <- m2 + prior
+  res2 <- monty::monty_sample(p2, sampler, 13, initial = c(.2, .1),
+                              n_chains = 3)
+
+  expect_equal(dim(res1$observations$history), c(2, 4, 13, 3))
+  expect_equal(res1$observations$history,
+               res2$observations$history[c(2, 5), , , ])
+  expect_equal(names(res1$observations), "history")
+})
+
+
+test_that("can record final state", {
+  pars <- list(beta = 0.1, gamma = 0.2, N = 1000, I0 = 10, exp_noise = 1e6)
+  time_start <- 0
+  data <- data.frame(time = c(4, 8, 12, 16), incidence = 1:4)
+  obj <- dust_filter_create(sir(), time_start, data, n_particles = 100,
+                            seed = 42)
+  packer <- monty::monty_packer(
+    c("beta", "gamma"),
+    fixed = list(N = 1000, I0 = 10, exp_noise = 1e6))
+
+  prior <- monty::monty_dsl({
+    beta ~ Exponential(mean = 0.5)
+    gamma ~ Exponential(mean = 0.5)
+  })
+
+  sampler <- monty::monty_sampler_random_walk(diag(2) * c(0.02, 0.02))
+
+  set.seed(1)
+  m <- dust_likelihood_monty(obj, packer, save_state = TRUE)
+  expect_true(m$properties$has_observer)
+  res <- monty::monty_sample(m + prior, sampler, 13, n_chains = 3)
+  expect_equal(names(res$observations), "state")
+  expect_equal(dim(res$observations$state), c(5, 13, 3))
+})
+
+
+test_that("can record both state and trajectories", {
+  pars <- list(beta = 0.1, gamma = 0.2, N = 1000, I0 = 10, exp_noise = 1e6)
+  time_start <- 0
+  data <- data.frame(time = c(4, 8, 12, 16), incidence = 1:4)
+  obj <- dust_filter_create(sir(), time_start, data, n_particles = 100,
+                            seed = 42)
+  packer <- monty::monty_packer(
+    c("beta", "gamma"),
+    fixed = list(N = 1000, I0 = 10, exp_noise = 1e6))
+
+  prior <- monty::monty_dsl({
+    beta ~ Exponential(mean = 0.5)
+    gamma ~ Exponential(mean = 0.5)
+  })
+
+  sampler <- monty::monty_sampler_random_walk(diag(2) * c(0.02, 0.02))
+
+  set.seed(1)
+  m <- dust_likelihood_monty(obj, packer, save_state = TRUE,
+                             save_history = TRUE)
+  expect_true(m$properties$has_observer)
+  res <- monty::monty_sample(m + prior, sampler, 13, n_chains = 3)
+  expect_equal(names(res$observations), c("state", "history"))
+  expect_equal(dim(res$observations$state), c(5, 13, 3))
+  expect_equal(dim(res$observations$history), c(5, 4, 13, 3))
+  expect_equal(res$observations$state, res$observations$history[, 4, , ])
 })


### PR DESCRIPTION
This PR adds an observer interface to the dust/monty interface, using new features just added to monty.

The changes to check_headers are unrelated but due to a change in (I think) the C++ toolchain on the gha runners.