### PR TITLE
Allow groups to be named

### DIFF
--- a/R/data.R
+++ b/R/data.R
@@ -66,6 +66,7 @@ dust_filter_data <- function(data, time = NULL, group = NULL) {
   if (is.null(group)) {
     n_groups <- 1
     data <- data[order(data[[time]]), ]
+    groups <- NULL
   } else {
     groups <- unique(data[[group]])
     n_groups <- length(groups)
@@ -77,6 +78,8 @@ dust_filter_data <- function(data, time = NULL, group = NULL) {
           paste("Expected 'data[[\"{group}\"]]' to contain integer values in",
                 "[1, {n_groups}], and contain all those values"))
       }
+    } else if (!is.character(groups)) {
+      cli::cli_abort("Expected 'data[[\"{group}\"]]' to be integer or character")
     }
     ## Detect balance here; this is not super easy, and in particular
     ## not easy to report back errors about. Let's refine the error

--- a/tests/testthat/test-data.R
+++ b/tests/testthat/test-data.R
@@ -104,3 +104,17 @@ test_that("can convert a data.frame with list columns", {
   expect_equal(d2$data[[1]], list(list(x = 1, y = y[[1]])))
   expect_equal(d2$data[[3]], list(list(x = 3, y = y[[3]])))
 })
+
+
+test_that("can use named groups", {
+  data <- cbind(
+    expand.grid(time = 1:4, group = letters[1:3], KEEP.OUT.ATTRS = FALSE,
+                stringsAsFactors = FALSE),
+    data = runif(12))
+  d <- dust_filter_data(data)
+  expect_s3_class(d, c("dust_fulter_data", "data.frame"))
+  expect_equal(attr(d, "time"), "time")
+  expect_equal(attr(d, "group"), "group")
+  expect_equal(attr(d, "n_groups"), 3)
+  expect_equal(attr(d, "groups"), c("a", "b", "c"))
+})

--- a/tests/testthat/test-data.R
+++ b/tests/testthat/test-data.R
@@ -73,7 +73,7 @@ test_that("require group if times duplicate", {
 
 test_that("validate that group is usable", {
   d <- data.frame(time = c(1, 1, 2, 2),
-                  nm = c("a", "a", "b", "b"),
+                  nm = c(TRUE, TRUE, FALSE, FALSE),
                   skip = c(1, 3, 1, 3),
                   imbalanced = c(1, 2, 1, 1))
   expect_error(

--- a/tests/testthat/test-monty.R
+++ b/tests/testthat/test-monty.R
@@ -277,3 +277,33 @@ test_that("validate request to save trajectories", {
   expect_equal(validate_save_trajectories(c("a", "b")),
                list(enabled = TRUE, index = NULL, subset = c("a", "b")))
 })
+
+
+test_that("can use names for groups", {
+  pars <- list(beta = 0.1, gamma = 0.2, N = 1000, I0 = 10, exp_noise = 1e6)
+
+  time_start <- 0
+  data1 <- data.frame(group = rep(1:2, each = 4),
+                      time = rep(c(4, 8, 12, 16), 2),
+                      incidence = c(1:4, 2:5))
+  data2 <- data1
+  data2$group <- letters[data2$group]
+
+  obj1 <- dust_filter_create(sir(), time_start, data1, n_particles = 100,
+                             seed = 42)
+  obj2 <- dust_filter_create(sir(), time_start, data2, n_particles = 100,
+                             seed = 42)
+
+  packer <- monty::monty_packer(
+    c("beta", "gamma"),
+    fixed = list(N = 1000, I0 = 10, exp_noise = 1e6))
+
+  m1 <- dust_likelihood_monty(obj1, packer)
+  m2 <- dust_likelihood_monty(obj2, packer)
+
+  p <- cbind(c(0.2, 0.1), c(0.25, 0.1))
+
+  ll1 <- monty::monty_model_density(m1, p)
+  ll2 <- monty::monty_model_density(m2, p)
+  expect_equal(ll1, ll2)
+})


### PR DESCRIPTION
This PR allows groups to be named; it's debatable if we want integer valued groups because monty's grouped packer does not (yet) support that but with this change at least they agree on one way of recording groups!

Pretty minimal changes required here