### PR TITLE
Allow default construction of dimensions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust2
 Title: Next Generation dust
-Version: 0.2.2
+Version: 0.2.3
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/inst/include/dust2/array.hpp
+++ b/inst/include/dust2/array.hpp
@@ -25,8 +25,20 @@ struct dimensions {
   std::array<size_t, rank_> dim;
   std::array<size_t, rank_> mult;
 
+  dimensions() : rank(rank_) {
+  }
+
   template <typename Iterator>
-  dimensions(Iterator iter) : rank(rank_), size(1) {
+  dimensions(Iterator iter) : rank(rank_) {
+    set(iter);
+  }
+
+  dimensions(std::initializer_list<size_t> dim_) : dimensions(dim_.begin()) {
+  }
+
+  template <typename Iterator>
+  void set(Iterator iter) {
+    size = 1;
     for (size_t i = 0; i < rank; ++i, ++iter) {
       dim[i] = *iter;
       mult[i] = size;
@@ -34,7 +46,8 @@ struct dimensions {
     }
   }
 
-  dimensions(std::initializer_list<size_t> dim_) : dimensions(dim_.begin()) {
+  void set(std::initializer_list<size_t> dim_) {
+    set(dim_.begin());
   }
 };
 

--- a/inst/include/dust2/common.hpp
+++ b/inst/include/dust2/common.hpp
@@ -47,8 +47,10 @@ void read_real_array(cpp11::list args, const dust2::array::dimensions<rank>& dim
                      real_type * dest, const char *name, bool required);
 template <size_t rank>
 dust2::array::dimensions<rank> read_dimensions(cpp11::list args, const char * name);
+template <size_t rank>
+void read_dimensions(cpp11::list args, const char * name, dust2::array::dimensions<rank>& dest);
 template <>
-dust2::array::dimensions<1> read_dimensions(cpp11::list args, const char * name);
+void read_dimensions(cpp11::list args, const char * name, dust2::array::dimensions<1>& dest);
 
 }
 

--- a/inst/include/dust2/r/helpers.hpp
+++ b/inst/include/dust2/r/helpers.hpp
@@ -85,23 +85,32 @@ void check_dimensions(cpp11::sexp value,
   }
 }
 
+template <size_t rank>
+void read_dimensions(cpp11::list args,
+                     const char * name,
+                     dust2::array::dimensions<rank>& dest) {
+  cpp11::sexp value = args[name];
+  check_rank(value, rank, name);
+  auto r_dim = cpp11::as_cpp<cpp11::integers>(value.attr("dim"));
+  dest.set(r_dim.begin());
+}
+
+template <>
+inline void read_dimensions(cpp11::list args,
+                     const char * name,
+                     dust2::array::dimensions<1>& dest) {
+  SEXP value = args[name];
+  check_rank(value, 1, name);
+  const size_t len = LENGTH(value);
+  dest.set({len});
+}
 
 template <size_t rank>
 dust2::array::dimensions<rank> read_dimensions(cpp11::list args,
                                                const char * name) {
-  cpp11::sexp value = args[name];
-  check_rank(value, rank, name);
-  auto r_dim = cpp11::as_cpp<cpp11::integers>(value.attr("dim"));
-  return dust2::array::dimensions<rank>(r_dim.begin());
-}
-
-template <>
-inline dust2::array::dimensions<1> read_dimensions(cpp11::list args,
-                                                   const char * name) {
-  SEXP value = args[name];
-  check_rank(value, 1, name);
-  const size_t len = LENGTH(value);
-  return dust2::array::dimensions<1>{len};
+  dust2::array::dimensions<rank> ret;
+  read_dimensions(args, name, ret);
+  return ret;
 }
 
 inline double to_double(cpp11::sexp x, bool allow_na, const char * name) {


### PR DESCRIPTION
This PR will allow us, in odin, to write:

```
shared_type::dim_type dims;
```

and then fill in dimensions. We can't do this at the moment because we can't default-construct the dimensions, which this PR enables.  It also includes a `set()` method which we can use to set dimensions once we have them