### PR TITLE
Allow stopping at a vector of critical times

### DIFF
--- a/R/interface-continuous.R
+++ b/R/interface-continuous.R
@@ -28,8 +28,8 @@
 ##'   a smaller maximum step size here.
 ##'
 ##' @param critical_times Vector of critical times.  These are times
-##'   where we guarntee that the integration will stop, and which you
-##'   can use for changes parameters.  This can avoid the solver
+##'   where we guarantee that the integration will stop, and which you
+##'   can use for changes to parameters.  This can avoid the solver
 ##'   jumping over short-lived departures from a smooth solution, and
 ##'   prevent the solver having to learn where a sharp change in your
 ##'   target function is.

--- a/R/interface-continuous.R
+++ b/R/interface-continuous.R
@@ -27,6 +27,13 @@
 ##'   your rhs that the solver may skip over by accident, then specify
 ##'   a smaller maximum step size here.
 ##'
+##' @param critical_times Vector of critical times.  These are times
+##'   where we guarntee that the integration will stop, and which you
+##'   can use for changes parameters.  This can avoid the solver
+##'   jumping over short-lived departures from a smooth solution, and
+##'   prevent the solver having to learn where a sharp change in your
+##'   target function is.
+##'
 ##' @param debug_record_step_times Logical, indicating if the step
 ##'   times should be recorded.  This should only be enabled for
 ##'   debugging.  Step times can be retrieved via
@@ -43,8 +50,14 @@
 ##'   this after creation.
 dust_ode_control <- function(max_steps = 10000, atol = 1e-6, rtol = 1e-6,
                              step_size_min = 0, step_size_max = Inf,
+                             critical_times = NULL,
                              debug_record_step_times = FALSE,
                              save_history = FALSE) {
+  if (is.null(critical_times)) {
+    critical_times <- numeric()
+  } else {
+    check_time_sequence(critical_times, NULL)
+  }
   ctl <- list(
     max_steps = assert_scalar_size(
       max_steps, allow_zero = FALSE),
@@ -56,6 +69,7 @@ dust_ode_control <- function(max_steps = 10000, atol = 1e-6, rtol = 1e-6,
       step_size_min, allow_zero = TRUE),
     step_size_max = assert_scalar_positive_numeric(
       step_size_max, allow_zero = TRUE),
+    critical_times = critical_times,
     save_history = assert_scalar_logical(
       save_history),
     debug_record_step_times = assert_scalar_logical(

--- a/inst/include/dust2/continuous/control.hpp
+++ b/inst/include/dust2/continuous/control.hpp
@@ -19,7 +19,7 @@ struct control {
   real_type factor_max = 10.0; // from dopri5.f:281, retard.f:333
   real_type beta = 0.04;
   real_type constant = 0.2 - 0.04 * 0.75; // 0.04 is beta
-  std::vector<double> critical_times;
+  std::vector<real_type> critical_times;
   bool save_history = false;
   bool debug_record_step_times = false;
 

--- a/inst/include/dust2/continuous/control.hpp
+++ b/inst/include/dust2/continuous/control.hpp
@@ -2,6 +2,7 @@
 
 #include <cstddef>
 #include <limits>
+#include <vector>
 
 namespace dust2 {
 namespace ode {

--- a/inst/include/dust2/continuous/control.hpp
+++ b/inst/include/dust2/continuous/control.hpp
@@ -18,16 +18,19 @@ struct control {
   real_type factor_max = 10.0; // from dopri5.f:281, retard.f:333
   real_type beta = 0.04;
   real_type constant = 0.2 - 0.04 * 0.75; // 0.04 is beta
+  std::vector<double> critical_times;
   bool save_history = false;
   bool debug_record_step_times = false;
 
   control(size_t max_steps, real_type atol, real_type rtol,
           real_type step_size_min, real_type step_size_max,
+          std::vector<real_type> critical_times,
           bool save_history,
           bool debug_record_step_times) :
       max_steps(max_steps), atol(atol), rtol(rtol),
       step_size_min(step_size_min),
       step_size_max(step_size_max),
+      critical_times(critical_times),
       save_history(save_history),
       debug_record_step_times(debug_record_step_times) {}
 

--- a/inst/include/dust2/r/continuous/control.hpp
+++ b/inst/include/dust2/r/continuous/control.hpp
@@ -16,11 +16,14 @@ dust2::ode::control<real_type> validate_ode_control(cpp11::list r_time_control) 
     std::max(static_cast<real_type>(dust2::r::read_real(ode_control, "step_size_min")),
              std::numeric_limits<real_type>::epsilon());
   const auto step_size_max = dust2::r::read_real(ode_control, "step_size_max");
+  const auto critical_times =
+    cpp11::as_cpp<std::vector<real_type>>(ode_control["critical_times"]);
   const bool debug_record_step_times =
     dust2::r::read_bool(ode_control, "debug_record_step_times");
   const auto save_history = dust2::r::read_bool(ode_control, "save_history");
   return dust2::ode::control<real_type>(max_steps, atol, rtol, step_size_min,
-                                        step_size_max, save_history,
+                                        step_size_max, critical_times,
+                                        save_history,
                                         debug_record_step_times);
 }
 

--- a/man/dust_ode_control.Rd
+++ b/man/dust_ode_control.Rd
@@ -10,6 +10,7 @@ dust_ode_control(
   rtol = 1e-06,
   step_size_min = 0,
   step_size_max = Inf,
+  critical_times = NULL,
   debug_record_step_times = FALSE,
   save_history = FALSE
 )
@@ -36,6 +37,13 @@ no maximum step size (\code{Inf}) so the solver can take as large a
 step as it wants to.  If you have short-lived fluctuations in
 your rhs that the solver may skip over by accident, then specify
 a smaller maximum step size here.}
+
+\item{critical_times}{Vector of critical times.  These are times
+where we guarntee that the integration will stop, and which you
+can use for changes parameters.  This can avoid the solver
+jumping over short-lived departures from a smooth solution, and
+prevent the solver having to learn where a sharp change in your
+target function is.}
 
 \item{debug_record_step_times}{Logical, indicating if the step
 times should be recorded.  This should only be enabled for


### PR DESCRIPTION
I reached the point where we need this in the odin-monty guide so figured it was an easy add.  Quite pleased with the relatively simple implementation here, using `std::upper_bound` to efficiently find the next relevant point and having a little extra loop within the main time loop.