### PR TITLE
Add extra rng state for selecting particle

### DIFF
--- a/R/interface-filter.R
+++ b/R/interface-filter.R
@@ -111,7 +111,7 @@ filter_create <- function(obj, pars) {
 ## This is something that we should tidy up within monty itself,
 ## there are lots of little utilities we could benefit from.
 filter_rng_state <- function(n_particles, n_groups, seed) {
-  n_streams <- max(n_groups, 1) * (1 + n_particles)
+  n_streams <- max(n_groups, 1) * (2 + n_particles)
   monty::monty_rng$new(n_streams = n_streams, seed = seed)$state()
 }
 

--- a/inst/include/dust2/filter.hpp
+++ b/inst/include/dust2/filter.hpp
@@ -30,7 +30,7 @@ public:
     n_state_(sys.n_state()),
     n_particles_(sys.n_particles()),
     n_groups_(sys.n_groups()),
-    rng_(n_groups_, seed, false),
+    rng_(n_groups_ * 2, seed, false),
     ll_(n_groups_, 0),
     ll_step_(n_groups_ * n_particles_, 0),
     trajectories_(n_state_, n_particles_, n_groups_, time_.size()),
@@ -69,7 +69,7 @@ public:
           std::any_of(w, w + n_particles_, [](auto v) { return v != 0; });
         if (reorder_this_group) {
           ll_[i] += details::scale_log_weights<real_type>(n_particles_, w);
-          const auto u = monty::random::random_real<real_type>(rng_.state(i));
+          const auto u = monty::random::random_real<real_type>(rng_.state(2 * i));
           details::resample_weight(n_particles_, w, u, idx);
         } else {
           for (size_t j = 0; j < n_particles_; ++j) {
@@ -124,7 +124,7 @@ public:
   const auto& select_random_particle(std::vector<size_t> index_group) {
     for (auto i : index_group) {
       if (random_particle_[i] == n_particles_) {
-        const auto u = monty::random::random_real<real_type>(rng_.state(i));
+        const auto u = monty::random::random_real<real_type>(rng_.state(2 * i + 1));
         random_particle_[i] = static_cast<size_t>(std::floor(u * n_particles_));
       }
     }

--- a/inst/include/dust2/r/continuous/filter.hpp
+++ b/inst/include/dust2/r/continuous/filter.hpp
@@ -39,9 +39,9 @@ cpp11::sexp dust2_continuous_filter_alloc(cpp11::list r_pars,
   const auto deterministic = false;
 
   // Create all the required rng states across the filter and the
-  // system, in a reasonable way.  We need to make this slightly easier
-  // to do from monty really.  Expand the state to give all the
-  // state required by the filter (n_groups streams worth) and the
+  // system, in a reasonable way.  We need to make this slightly
+  // easier to do from monty really.  Expand the state to give all the
+  // state required by the filter (2 * n_groups streams worth) and the
   // system (n_groups * n_particles worth, though the last bit of
   // expansion could be done by the system itself instead?)
   //
@@ -54,22 +54,22 @@ cpp11::sexp dust2_continuous_filter_alloc(cpp11::list r_pars,
   // filter with multiple groups will stream differently to a filter
   // containing a the first group only.
   //
-  // 2. we take each block of (1+n_particles) states for each group,
-  // giving the first to the filter and the rest to the system.  This
-  // means that we can change the number of groups without affecting
-  // the results, though we can't change the number of particles as
-  // easily.
-  const auto n_streams = n_groups * (n_particles + 1);
+  // 2. we take each block of (2+n_particles) states for each group,
+  // giving the first two to the filter and the rest to the system.
+  // This means that we can change the number of groups without
+  // affecting the results, though we can't change the number of
+  // particles as easily.
+  const auto n_streams = n_groups * (n_particles + 2);
   const auto rng_state = monty::random::prng<rng_state_type>(n_streams, seed, deterministic).export_state();
   const auto rng_len = rng_state_type::size();
   rng_seed_type seed_filter;
   rng_seed_type seed_system;
   for (size_t i = 0; i < n_groups; ++i) {
-    const auto it = rng_state.begin() + i * rng_len * (n_particles + 1);
+    const auto it = rng_state.begin() + i * rng_len * (n_particles + 2);
     seed_filter.insert(seed_filter.end(),
-                       it, it + rng_len);
+                       it, it + 2 * rng_len);
     seed_system.insert(seed_system.end(),
-                       it + rng_len, it + rng_len * (n_particles + 1));
+                       it + 2 * rng_len, it + rng_len * (n_particles + 2));
   }
 
   const auto system = dust2::dust_continuous<T>(shared, internal, time_start, dt, ode_control, n_particles,

--- a/inst/include/dust2/r/discrete/filter.hpp
+++ b/inst/include/dust2/r/discrete/filter.hpp
@@ -40,9 +40,9 @@ cpp11::sexp dust2_discrete_filter_alloc(cpp11::list r_pars,
   const auto deterministic = false;
 
   // Create all the required rng states across the filter and the
-  // system, in a reasonable way.  We need to make this slightly easier
-  // to do from monty really.  Expand the state to give all the
-  // state required by the filter (n_groups streams worth) and the
+  // system, in a reasonable way.  We need to make this slightly
+  // easier to do from monty really.  Expand the state to give all the
+  // state required by the filter (2 * n_groups streams worth) and the
   // system (n_groups * n_particles worth, though the last bit of
   // expansion could be done by the system itself instead?)
   //
@@ -55,22 +55,23 @@ cpp11::sexp dust2_discrete_filter_alloc(cpp11::list r_pars,
   // filter with multiple groups will stream differently to a filter
   // containing a the first group only.
   //
-  // 2. we take each block of (1+n_particles) states for each group,
-  // giving the first to the filter and the rest to the system.  This
-  // means that we can change the number of groups without affecting
-  // the results, though we can't change the number of particles as
-  // easily.
-  const auto n_streams = n_groups * (n_particles + 1);
+  // 2. we take each block of (2+n_particles) states for each group,
+  // giving the first two to the filter and the rest to the system.
+  // This means that we can change the number of groups without
+  // affecting the results, though we can't change the number of
+  // particles as easily.
+  const auto n_streams = n_groups * (n_particles + 2);
   const auto rng_state = monty::random::prng<rng_state_type>(n_streams, seed, deterministic).export_state();
   const auto rng_len = rng_state_type::size();
   rng_seed_type seed_filter;
+  rng_seed_type seed_observer;
   rng_seed_type seed_system;
   for (size_t i = 0; i < n_groups; ++i) {
-    const auto it = rng_state.begin() + i * rng_len * (n_particles + 1);
+    const auto it = rng_state.begin() + i * rng_len * (n_particles + 2);
     seed_filter.insert(seed_filter.end(),
-                       it, it + rng_len);
+                       it, it + 2 * rng_len);
     seed_system.insert(seed_system.end(),
-                      it + rng_len, it + rng_len * (n_particles + 1));
+                      it + 2 * rng_len, it + rng_len * (n_particles + 2));
   }
 
   const auto system = dust2::dust_discrete<T>(shared, internal, time_start, dt, n_particles,

--- a/inst/include/dust2/r/discrete/filter.hpp
+++ b/inst/include/dust2/r/discrete/filter.hpp
@@ -64,7 +64,6 @@ cpp11::sexp dust2_discrete_filter_alloc(cpp11::list r_pars,
   const auto rng_state = monty::random::prng<rng_state_type>(n_streams, seed, deterministic).export_state();
   const auto rng_len = rng_state_type::size();
   rng_seed_type seed_filter;
-  rng_seed_type seed_observer;
   rng_seed_type seed_system;
   for (size_t i = 0; i < n_groups; ++i) {
     const auto it = rng_state.begin() + i * rng_len * (n_particles + 2);

--- a/inst/include/dust2/r/filter.hpp
+++ b/inst/include/dust2/r/filter.hpp
@@ -152,10 +152,10 @@ cpp11::sexp dust2_filter_rng_state(cpp11::sexp ptr) {
   const auto n_bytes_state = n_bytes * n_state;
   cpp11::writable::raws ret(n_bytes * (state_filter.size() + state_system.size()));
   for (size_t i = 0; i < n_groups; ++i) {
-    std::memcpy(RAW(ret) + i * n_bytes_state * (n_particles + 1),
-                state_filter.data() + i * n_state,
-                n_bytes_state);
-    std::memcpy(RAW(ret) + i * n_bytes_state * (n_particles + 1) + n_bytes_state,
+    std::memcpy(RAW(ret) + i * n_bytes_state * (n_particles + 2),
+                state_filter.data() + i * n_state * 2,
+                n_bytes_state * 2);
+    std::memcpy(RAW(ret) + i * n_bytes_state * (n_particles + 2) + 2 * n_bytes_state,
                 state_system.data() + i * n_state * n_particles,
                 n_bytes_state * n_particles);
   }
@@ -171,19 +171,19 @@ cpp11::sexp dust2_filter_set_rng_state(cpp11::sexp ptr, cpp11::sexp r_rng_state)
 
   const auto n_particles = obj->sys.n_particles();
   const auto n_groups = obj->sys.n_groups();
-  const auto n_streams = n_groups * (1 + n_particles);
+  const auto n_streams = n_groups * (2 + n_particles);
   const auto n_state = rng_state_type::size();
   const auto rng_state =
     check_rng_state<rng_state_type>(r_rng_state, n_streams, "rng_state");
 
-  std::vector<rng_int_type> state_filter(n_groups * n_state);
+  std::vector<rng_int_type> state_filter(n_groups * n_state * 2);
   std::vector<rng_int_type> state_system(n_groups * n_particles * n_state);
   for (size_t i = 0; i < n_groups; ++i) {
-    const auto src = rng_state.begin() + i * (1 + n_particles) * n_state;
+    const auto src = rng_state.begin() + i * (2 + n_particles) * n_state;
     std::copy_n(src,
-                n_state,
-                state_filter.begin() + i * n_state);
-    std::copy_n(src + n_state,
+                n_state * 2,
+                state_filter.begin() + i * n_state * 2);
+    std::copy_n(src + 2 * n_state,
                 n_state * n_particles,
                 state_system.begin() + i * n_state * n_particles);
   }

--- a/tests/testthat/helper-dust.R
+++ b/tests/testthat/helper-dust.R
@@ -5,7 +5,7 @@
 filter_manual <- function(generator, pars, time_start, data, dt, n_particles,
                           seed) {
   r <- monty::monty_rng$new(n_streams = 1, seed = seed)
-  seed <- monty::monty_rng$new(n_streams = 1, seed = seed)$jump()$state()
+  seed <- monty::monty_rng$new(n_streams = 1, seed = seed)$jump()$jump()$state()
 
   obj <- dust_system_create(generator, pars, n_particles,
                             time = time_start, dt = dt, seed = seed)


### PR DESCRIPTION
Not long, but a bit of a battle.

This PR adds a second rng state to the filter to select the randomly selected particle.  This means that extracting trajectories from a filter does not affect the steps taken during sampling (which feels like it sticks closer to our general idea of being able to change runners/observers/etc without affecting samples taken).  This affects all the code that interacts with seeding, reading and writing the rng generators, and is generally a bit of a pain