### PR TITLE
Refactor history internals

### DIFF
--- a/inst/include/dust2/continuous/history.hpp
+++ b/inst/include/dust2/continuous/history.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <deque>
+#include <stdexcept>
 #include <vector>
 #include <dust2/tools.hpp>
 

--- a/inst/include/dust2/continuous/history.hpp
+++ b/inst/include/dust2/continuous/history.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+namespace dust2 {
+namespace ode{
+
+// A single piece of history
+template <typename real_type>
+struct history {
+  real_type t;
+  real_type h;
+  std::vector<real_type> c1;
+  std::vector<real_type> c2;
+  std::vector<real_type> c3;
+  std::vector<real_type> c4;
+  std::vector<real_type> c5;
+
+  history(size_t n_variables) :
+    c1(n_variables),
+    c2(n_variables),
+    c3(n_variables),
+    c4(n_variables),
+    c5(n_variables) {
+  }
+
+  history() {
+  }
+
+  history(real_type t, real_type h, std::vector<real_type> c1, std::vector<real_type> c2, std::vector<real_type> c3, std::vector<real_type> c4, std::vector<real_type> c5) :
+    t(t),
+    h(h),
+    c1(c1),
+    c2(c2),
+    c3(c3),
+    c4(c4),
+    c5(c5) {
+  }
+
+  history subset(std::vector<size_t> index) {
+    return history(t,
+                   h,
+                   tools::subset(c1, index),
+                   tools::subset(c2, index),
+                   tools::subset(c3, index),
+                   tools::subset(c4, index),
+                   tools::subset(c5, index));
+  }
+};
+
+}
+}

--- a/inst/include/dust2/continuous/history.hpp
+++ b/inst/include/dust2/continuous/history.hpp
@@ -128,7 +128,7 @@ public:
 
   template <typename Iter>
   bool interpolate(real_type time, const std::vector<size_t>& index,
-                   Iter result) {
+                   Iter result) const {
     if (data_.empty() || time < data_[0].t) {
       for (size_t i = 0; i < index.size(); ++i) {
         *result = initial_state_[i];

--- a/inst/include/dust2/continuous/history.hpp
+++ b/inst/include/dust2/continuous/history.hpp
@@ -2,6 +2,7 @@
 
 #include <deque>
 #include <vector>
+#include <dust2/tools.hpp>
 
 namespace dust2 {
 namespace ode {

--- a/inst/include/dust2/continuous/history.hpp
+++ b/inst/include/dust2/continuous/history.hpp
@@ -1,11 +1,14 @@
 #pragma once
 
+#include <deque>
+#include <vector>
+
 namespace dust2 {
-namespace ode{
+namespace ode {
 
 // A single piece of history
 template <typename real_type>
-struct history {
+struct history_step {
   real_type t;
   real_type h;
   std::vector<real_type> c1;
@@ -14,7 +17,7 @@ struct history {
   std::vector<real_type> c4;
   std::vector<real_type> c5;
 
-  history(size_t n_variables) :
+  history_step(size_t n_variables) :
     c1(n_variables),
     c2(n_variables),
     c3(n_variables),
@@ -22,10 +25,10 @@ struct history {
     c5(n_variables) {
   }
 
-  history() {
+  history_step() {
   }
 
-  history(real_type t, real_type h, std::vector<real_type> c1, std::vector<real_type> c2, std::vector<real_type> c3, std::vector<real_type> c4, std::vector<real_type> c5) :
+  history_step(real_type t, real_type h, std::vector<real_type> c1, std::vector<real_type> c2, std::vector<real_type> c3, std::vector<real_type> c4, std::vector<real_type> c5) :
     t(t),
     h(h),
     c1(c1),
@@ -35,15 +38,66 @@ struct history {
     c5(c5) {
   }
 
-  history subset(std::vector<size_t> index) {
-    return history(t,
-                   h,
-                   tools::subset(c1, index),
-                   tools::subset(c2, index),
-                   tools::subset(c3, index),
-                   tools::subset(c4, index),
-                   tools::subset(c5, index));
+  history_step subset(std::vector<size_t> index) const {
+    return history_step(t,
+                        h,
+                        tools::subset(c1, index),
+                        tools::subset(c2, index),
+                        tools::subset(c3, index),
+                        tools::subset(c4, index),
+                        tools::subset(c5, index));
   }
+};
+
+template <typename real_type>
+class history {
+public:
+  history(size_t n_state) : n_state_(n_state), n_state_total_(n_state_) {
+  }
+
+  bool empty() const {
+    return data_.empty();
+  }
+
+  size_t size() const {
+    return data_.size();
+  }
+
+  size_t n_state() const {
+    return n_state_;
+  }
+
+  // void set_index(const std::vector<size_t>& index) {
+  //   if (tools::is_trivial_index(index, n_state_total_)) {
+  //     index_.clear();
+  //     n_state_ = n_state_total_;
+  //   } else {
+  //     index_ = index;
+  //     n_state_ = index.size();
+  //   }
+  // }
+
+  void add(const history_step<real_type>& h) {
+    if (index_.empty()) {
+      data_.push_back(h);
+    } else {
+      data_.push_back(h.subset(index_));
+    }
+  }
+
+  void clear() {
+    data_.clear();
+  }
+
+  auto& data() const {
+    return data_;
+  }
+
+private:
+  size_t n_state_;
+  size_t n_state_total_;
+  std::vector<size_t> index_;
+  std::deque<history_step<real_type>> data_;
 };
 
 }

--- a/inst/include/dust2/continuous/history.hpp
+++ b/inst/include/dust2/continuous/history.hpp
@@ -19,6 +19,8 @@ struct history_step {
   std::vector<real_type> c5;
 
   history_step(size_t n_variables) :
+    t(0),
+    h(0),
     c1(n_variables),
     c2(n_variables),
     c3(n_variables),
@@ -26,7 +28,7 @@ struct history_step {
     c5(n_variables) {
   }
 
-  history_step() {
+  history_step() : t(0), h(0) {
   }
 
   history_step(real_type t, real_type h, std::vector<real_type> c1, std::vector<real_type> c2, std::vector<real_type> c3, std::vector<real_type> c4, std::vector<real_type> c5) :

--- a/inst/include/dust2/continuous/history.hpp
+++ b/inst/include/dust2/continuous/history.hpp
@@ -139,7 +139,12 @@ public:
       return false;
     } else {
       const auto it = std::lower_bound(data_.begin(), data_.end(), time,
-                                       [](auto value, auto& h) { value < h.t; });
+                                       [](const auto& h, const auto& value) {
+                                         return value > (h.t + h.h);
+                                       });
+      if (it == data_.end()) {
+        throw std::runtime_error("Failed to locate history element");
+      }
       it->interpolate(time, index, result);
       return true;
     }

--- a/inst/include/dust2/continuous/solver.hpp
+++ b/inst/include/dust2/continuous/solver.hpp
@@ -44,21 +44,21 @@ struct internals {
     last(n_variables),
     history_values(n_variables),
     dydt(n_variables) {
-    reset();
+    reset(last.c1.data());
   }
 
   void save_history() {
     history_values.add(last);
   }
 
-  void reset() {
+  void reset(const real_type * y) {
     step_size = 0;
     error = 0;
     n_steps = 0;
     n_steps_accepted = 0;
     n_steps_rejected = 0;
     step_times.clear();
-    history_values.clear();
+    history_values.reset(y);
   }
 };
 
@@ -229,7 +229,7 @@ public:
   template <typename Rhs>
   void initialise(const real_type t, const real_type* y,
                   ode::internals<real_type>& internals, Rhs rhs) {
-    internals.reset();
+    internals.reset(y);
     if (control_.debug_record_step_times) {
       internals.step_times.push_back(t);
     }

--- a/inst/include/dust2/continuous/solver.hpp
+++ b/inst/include/dust2/continuous/solver.hpp
@@ -39,16 +39,20 @@ struct internals {
   size_t n_steps;
   size_t n_steps_accepted;
   size_t n_steps_rejected;
+  bool save_history_;
 
-  internals(size_t n_variables) :
+  internals(size_t n_variables, bool save_history) :
     last(n_variables),
     history_values(n_variables),
-    dydt(n_variables) {
+    dydt(n_variables),
+    save_history_(save_history) {
     reset(last.c1.data());
   }
 
   void save_history() {
-    history_values.add(last);
+    if (save_history_) {
+      history_values.add(last);
+    }
   }
 
   void reset(const real_type * y) {
@@ -173,9 +177,7 @@ public:
         if (control_.debug_record_step_times) {
           internals.step_times.push_back(truncated ? t_end : t + h);
         }
-        if (control_.save_history) {
-          internals.save_history();
-        }
+        internals.save_history();
         if (!truncated) {
           const auto fac_old =
             std::max(internals.error, static_cast<real_type>(1e-4));

--- a/inst/include/dust2/continuous/solver.hpp
+++ b/inst/include/dust2/continuous/solver.hpp
@@ -309,6 +309,7 @@ private:
   void apply_zero_every(real_type t, real_type* y,
                         const zero_every_type<real_type>& zero_every,
                         ode::internals<real_type>& internals) {
+    // internals is not const because we write to .last.c4
     if (zero_every.empty() || internals.last.h == 0) {
       return;
     }

--- a/inst/include/dust2/continuous/solver.hpp
+++ b/inst/include/dust2/continuous/solver.hpp
@@ -29,38 +29,26 @@ T clamp(T x, T min, T max) {
 // from one particle to another fairly efficiently
 template <typename real_type>
 struct internals {
-  history<real_type> last;
+  history_step<real_type> last;
+  history<real_type> history_values;
 
   std::vector<real_type> dydt;
   std::vector<real_type> step_times;
-  std::vector<history<real_type>> history_values;
   real_type step_size;
   real_type error;
   size_t n_steps;
   size_t n_steps_accepted;
   size_t n_steps_rejected;
-  std::vector<size_t> history_index;
 
   internals(size_t n_variables) :
     last(n_variables),
+    history_values(n_variables),
     dydt(n_variables) {
     reset();
   }
 
-  void set_history_index(const std::vector<size_t>& index) {
-    if (tools::is_trivial_index(index, dydt.size())) {
-      history_index.clear();
-    } else {
-      history_index = index;
-    }
-  }
-
-  void save_history(real_type t, real_type h) {
-    if (history_index.empty()) {
-      history_values.push_back(last);
-    } else {
-      history_values.push_back(last.subset(history_index));
-    }
+  void save_history() {
+    history_values.add(last);
   }
 
   void reset() {
@@ -186,7 +174,7 @@ public:
           internals.step_times.push_back(truncated ? t_end : t + h);
         }
         if (control_.save_history) {
-          internals.save_history(t, h);
+          internals.save_history();
         }
         if (!truncated) {
           const auto fac_old =

--- a/inst/include/dust2/continuous/solver.hpp
+++ b/inst/include/dust2/continuous/solver.hpp
@@ -323,7 +323,7 @@ private:
     }
     for (const auto& el : zero_every) {
       const auto period = el.first;
-      const auto t_last_step = t - internals.last.h;
+      const auto t_last_step = internals.last.t;
       const int n = std::floor(t / period);
       const int m = std::floor(t_last_step / period);
       if (n > m) {
@@ -353,7 +353,7 @@ private:
     for (const auto& el : zero_every) {
       const auto period = el.first;
       if (internals.last.h > period) {
-        const auto t_last_step = t - internals.last.h;
+        const auto t_last_step = internals.last.t;
         const int n = std::ceil(t / period);
         const int m = std::ceil(t_last_step / period);
         if (n > m) {

--- a/inst/include/dust2/continuous/system.hpp
+++ b/inst/include/dust2/continuous/system.hpp
@@ -53,11 +53,12 @@ public:
     control_(control),
 
     state_(n_state_ * n_particles_total_),
-    ode_internals_(n_particles_total_, n_state_ode_),
+    ode_internals_(n_particles_total_,
+                   {n_state_ode_, control_.save_history}),
 
     // For reordering to work:
     state_other_(n_state_ * n_particles_total_),
-    ode_internals_other_(n_particles_total_, n_state_ode_),
+    ode_internals_other_(ode_internals_),
 
     shared_(shared),
     internal_(internal),

--- a/inst/include/dust2/continuous/system.hpp
+++ b/inst/include/dust2/continuous/system.hpp
@@ -479,9 +479,15 @@ private:
     for (size_t group = 0; group < n_groups_; ++group) {
       for (size_t particle = 0; particle < n_particles_; ++particle) {
         const auto thread = tools::thread_index();
-        output_(particle, group, thread);
+        const auto k = n_particles_ * group + particle;
+        try {
+          output_(particle, group, thread);
+        } catch (std::exception const& e) {
+          errors_.capture(e, k);
+        }
       }
     }
+    errors_.report();
     update_output_is_current({}, true);
   }
 

--- a/inst/include/dust2/r/continuous/system.hpp
+++ b/inst/include/dust2/r/continuous/system.hpp
@@ -69,13 +69,13 @@ cpp11::sexp ode_internals_to_sexp(const ode::internals<real_type>& internals,
     "coefficients"_nm = R_NilValue,
     "history"_nm = R_NilValue};
   if (include_coefficients) {
-    auto r_coef = cpp11::writable::doubles_matrix<>(internals.c1.size(), 5);
+    auto r_coef = cpp11::writable::doubles_matrix<>(internals.last.c1.size(), 5);
     auto coef = REAL(r_coef);
-    coef = std::copy(internals.c1.begin(), internals.c1.end(), coef);
-    coef = std::copy(internals.c2.begin(), internals.c2.end(), coef);
-    coef = std::copy(internals.c3.begin(), internals.c3.end(), coef);
-    coef = std::copy(internals.c4.begin(), internals.c4.end(), coef);
-    coef = std::copy(internals.c5.begin(), internals.c5.end(), coef);
+    coef = std::copy(internals.last.c1.begin(), internals.last.c1.end(), coef);
+    coef = std::copy(internals.last.c2.begin(), internals.last.c2.end(), coef);
+    coef = std::copy(internals.last.c3.begin(), internals.last.c3.end(), coef);
+    coef = std::copy(internals.last.c4.begin(), internals.last.c4.end(), coef);
+    coef = std::copy(internals.last.c5.begin(), internals.last.c5.end(), coef);
     ret["coefficients"] = r_coef;
   }
   if (include_history && !internals.history_values.empty()) {

--- a/inst/include/dust2/r/continuous/system.hpp
+++ b/inst/include/dust2/r/continuous/system.hpp
@@ -80,7 +80,7 @@ cpp11::sexp ode_internals_to_sexp(const ode::internals<real_type>& internals,
   }
   if (include_history && !internals.history_values.empty()) {
     const auto n_history_entries = internals.history_values.size();
-    const auto n_history_state = internals.history_values[0].c1.size();
+    const auto n_history_state = internals.history_values.n_state();
     auto r_history_coef =
       cpp11::writable::doubles(n_history_state * 5 * n_history_entries);
     auto r_history_time = cpp11::writable::doubles(n_history_entries);
@@ -88,7 +88,7 @@ cpp11::sexp ode_internals_to_sexp(const ode::internals<real_type>& internals,
     auto history_coef = REAL(r_history_coef);
     auto history_time = REAL(r_history_time);
     auto history_size = REAL(r_history_size);
-    for (auto& h: internals.history_values) {
+    for (auto& h: internals.history_values.data()) {
       *history_time++ = h.t;
       *history_size++ = h.h;
       history_coef = std::copy(h.c1.begin(), h.c1.end(), history_coef);


### PR DESCRIPTION
A bit of refactoring ahead of supporting delays.  This:

* moves history into its own file
* moves interpolation out of the solver and into the history class
* simplifies what we store in the internals
* moves the treatment of output to be more similar to that of rhs (using a private method)
* moves rhs (and output) to use non-static methods that take particle/group/thread as arguments

No changes to tests.