### PR TITLE
Add one solver per group&thread

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust2
 Title: Next Generation dust
-Version: 0.3.1
+Version: 0.3.2
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",


### PR DESCRIPTION
A bit of a disaster before that would have prevented running ODE systems in parallel.  This follows the same basic structure as internal, with `n_groups * n_threads` solvers