### PR TITLE
Detect where delays are needed from system

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust2
 Title: Next Generation dust
-Version: 0.3.3
+Version: 0.3.4
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/inst/include/dust2/continuous/delays.hpp
+++ b/inst/include/dust2/continuous/delays.hpp
@@ -21,11 +21,7 @@ using delay_result_type = std::vector<std::vector<real_type>>;
 template <typename real_type>
 class delays {
 public:
-  const bool rhs;
-  const bool output;
-  delays(bool rhs, bool output, std::initializer_list<delay<real_type>> data) :
-    rhs(rhs),
-    output(output),
+  delays(std::initializer_list<delay<real_type>> data) :
     delays_(data),
     index_out_(delays_.size()) {
     std::set<size_t> tmp;
@@ -55,8 +51,8 @@ public:
     return ret;
   }
 
-  real_type step_size_max(real_type h) const {
-    if (rhs) {
+  real_type step_size_max(real_type h, bool used_in_rhs) const {
+    if (used_in_rhs) {
       h = std::accumulate(delays_.begin(), delays_.end(), h,
                           [](auto a, auto b) { return a < b.tau ? a : b.tau; });
     }

--- a/inst/include/dust2/continuous/system.hpp
+++ b/inst/include/dust2/continuous/system.hpp
@@ -463,6 +463,14 @@ private:
         }
       }
       control_.save_history = true;
+      for (size_t group = 0; group < n_groups_; ++group) {
+        const auto step_size_max_group =
+          step_size_max(control_.step_size_max, rhs_uses_delays_);
+        for (size_t thread = 0; thread < n_threads_; ++thread) {
+          const auto i = thread * n_groups_ + group;
+          solver_[i].control().step_size_max = step_size_max_group;
+        }
+      }
     } else {
       delay_result_.resize(n_particles_ * n_groups_);
     }

--- a/inst/include/dust2/continuous/system.hpp
+++ b/inst/include/dust2/continuous/system.hpp
@@ -453,7 +453,8 @@ private:
         for (size_t group = 0; group < n_groups_; ++group, ++k) {
           delay_result_.push_back(delays_[group].result());
           solver_[k].control().step_size_max =
-            delays_[group].step_size_max(control_.step_size_max);
+            delays_[group].step_size_max(control_.step_size_max,
+                                         rhs_uses_delays_);
         }
       }
       for (size_t i = 0, k = 0; i < n_groups_; ++i) {

--- a/inst/include/dust2/continuous/system.hpp
+++ b/inst/include/dust2/continuous/system.hpp
@@ -463,14 +463,6 @@ private:
         }
       }
       control_.save_history = true;
-      for (size_t group = 0; group < n_groups_; ++group) {
-        const auto step_size_max_group =
-          step_size_max(control_.step_size_max, rhs_uses_delays_);
-        for (size_t thread = 0; thread < n_threads_; ++thread) {
-          const auto i = thread * n_groups_ + group;
-          solver_[i].control().step_size_max = step_size_max_group;
-        }
-      }
     } else {
       delay_result_.resize(n_particles_ * n_groups_);
     }

--- a/inst/include/dust2/properties.hpp
+++ b/inst/include/dust2/properties.hpp
@@ -158,7 +158,7 @@ auto do_delays(const std::vector<typename T::shared_state>& shared) {
 template <typename T, typename std::enable_if<!properties<T>::has_delays::value, T>::type* = nullptr>
 auto do_delays(const std::vector<typename T::shared_state>& shared) {
   using real_type = typename T::real_type;
-  return std::vector<ode::delays<real_type>>(shared.size(), dust2::ode::delays<real_type>{false, false, {}});
+  return std::vector<ode::delays<real_type>>(shared.size(), dust2::ode::delays<real_type>{{}});
 }
 
 }

--- a/inst/include/dust2/properties.hpp
+++ b/inst/include/dust2/properties.hpp
@@ -44,6 +44,39 @@ struct test_has_delays: std::false_type {};
 template <class T>
 struct test_has_delays<T, std::void_t<decltype(T::delays)>>: std::true_type {};
 
+// These test that the signature of rhs and output consume the delays
+// argument. Not especially lovely to read!
+template <typename T>
+using test_rhs_signature_uses_delays = std::is_invocable<decltype(T::rhs), typename T::real_type, typename T::real_type*, typename T::shared_state&, typename T::internal_state&, typename dust2::ode::delay_result_type<typename T::real_type>&, typename T::real_type*>;
+
+template <typename T>
+using test_output_signature_uses_delays = std::is_invocable<decltype(T::output), typename T::real_type, typename T::real_type*, typename T::shared_state&, typename T::internal_state&, typename dust2::ode::delay_result_type<typename T::real_type>&>;
+
+// Because not all functions have output, and because I can't work out
+// how to get template checks to short circuit, I have done this with
+// 'if constexpr' which *does* short circuit, getting us a compile
+// time result that checks for all of:
+// * existance of delays
+// * existance of output
+// * an output function that consumes the delay
+template <typename T>
+constexpr bool test_output_uses_delays() {
+  if constexpr (test_has_delays<T>::value && test_has_output<T>::value) {
+    return test_output_signature_uses_delays<T>::value;
+  } else {
+    return false;
+  }
+}
+
+template <typename T>
+constexpr bool test_rhs_uses_delays() {
+  if constexpr (test_has_delays<T>::value) {
+    return test_rhs_signature_uses_delays<T>::value;
+  } else {
+    return false;
+  }
+}
+
 }
 
 template<typename T>
@@ -54,6 +87,9 @@ struct properties {
   using is_mixed_time = typename std::conditional<internals::test_has_rhs<T>::value && internals::test_has_update<T>::value, std::true_type, std::false_type>::type;
   using has_output = typename std::conditional<internals::test_has_rhs<T>::value && internals::test_has_output<T>::value, std::true_type, std::false_type>::type;
   using has_delays = internals::test_has_delays<T>;
+  // Because of the above these are now actual numbers rather than types; we may make this change everywhere...
+  static constexpr bool rhs_uses_delays = internals::test_rhs_uses_delays<T>();
+  static constexpr bool output_uses_delays = internals::test_output_uses_delays<T>();
 };
 
 // wrappers around some uses of member functions that may or may not

--- a/tests/testthat/examples/delay.cpp
+++ b/tests/testthat/examples/delay.cpp
@@ -36,7 +36,7 @@ public:
   }
 
   static auto delays(const shared_state& shared) {
-    return dust2::ode::delays<real_type>(false, true, {{1, {3}}});
+    return dust2::ode::delays<real_type>({{1, {3}}});
   }
 
   static void initial(real_type time,

--- a/tests/testthat/examples/delay.cpp
+++ b/tests/testthat/examples/delay.cpp
@@ -55,7 +55,6 @@ public:
                   const real_type * state,
                   const shared_state& shared,
                   internal_state& internal,
-                  const dust2::ode::delay_result_type<real_type>& delays,
                   real_type * state_deriv) {
     const auto S = state[0];
     const auto I = state[1];

--- a/tests/testthat/test-zzz-compile.R
+++ b/tests/testthat/test-zzz-compile.R
@@ -105,7 +105,7 @@ test_that("can compile a model with delays", {
   dust_system_set_state_initial(cmp)
   y_cmp <- dust_system_simulate(cmp, t)
 
-  gen <- dust_compile("examples/delay.cpp", quiet = TRUE, debug = TRUE)
+  gen <- dust_compile("examples/delay.cpp", quiet = FALSE, debug = TRUE)
   sys <- dust_system_create(gen, list())
   dust_system_set_state_initial(sys)
   y <- dust_system_simulate(sys, t)


### PR DESCRIPTION
This PR works out if `rhs` or `output` will use delays and adds that as a property.  I could not work out how to make that a type, but have gone with a compile-time bool, which feels ok really.  This then removes the `rhs` and `output` argument from `delays` and makes the checks within `system` much nicer.

Merge after #127, contains those commits