### PR TITLE
Add basic simulate method into system objects

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust2
 Title: Next Generation dust
-Version: 0.3.12
+Version: 0.3.13
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/inst/include/dust2/continuous/system.hpp
+++ b/inst/include/dust2/continuous/system.hpp
@@ -15,6 +15,7 @@
 #include <dust2/packing.hpp>
 #include <dust2/properties.hpp>
 #include <dust2/tools.hpp>
+#include <dust2/trajectories.hpp>
 #include <dust2/zero.hpp>
 #include <monty/random/random.hpp>
 

--- a/inst/include/dust2/continuous/system.hpp
+++ b/inst/include/dust2/continuous/system.hpp
@@ -161,6 +161,15 @@ public:
     throw std::runtime_error("Write run_to_time() with saved history");
   }
 
+  void simulate(const std::vector<real_type>& times,
+                const std::vector<size_t>& index_group,
+                dust2::trajectories<real_type>& history) {
+    for (auto t : times) {
+      run_to_time(t, index_group);
+      history.add(t, state().begin());
+    }
+  }
+
   void set_state_initial(const std::vector<size_t>& index_group) {
     errors_.reset();
     real_type * state_data = state_.data();

--- a/inst/include/dust2/discrete/system.hpp
+++ b/inst/include/dust2/discrete/system.hpp
@@ -117,6 +117,15 @@ public:
     time_ = time_ + n_steps * dt_;
   }
 
+  void simulate(const std::vector<real_type>& times,
+                const std::vector<size_t>& index_group,
+                dust2::trajectories<real_type>& history) {
+    for (auto t : times) {
+      run_to_time(t, index_group);
+      history.add(t, state_.begin());
+    }
+  }
+
   void set_state_initial(const std::vector<size_t>& index_group) {
     errors_.reset();
     real_type * state_data = state_.data();

--- a/inst/include/dust2/discrete/system.hpp
+++ b/inst/include/dust2/discrete/system.hpp
@@ -11,6 +11,7 @@
 #include <dust2/packing.hpp>
 #include <dust2/properties.hpp>
 #include <dust2/tools.hpp>
+#include <dust2/trajectories.hpp>
 #include <dust2/zero.hpp>
 #include <monty/random/random.hpp>
 

--- a/inst/include/dust2/r/system.hpp
+++ b/inst/include/dust2/r/system.hpp
@@ -248,10 +248,8 @@ SEXP dust2_system_simulate(cpp11::sexp ptr,
 
   dust2::trajectories<real_type> h(n_state, n_particles, n_groups, n_times);
   h.set_index_and_reset(index_state, index_group);
-  for (size_t i = 0; i < n_times; ++i) {
-    obj->run_to_time(times[i], index_group);
-    h.add(times[i], obj->state().begin());
-  }
+
+  obj->simulate(times, index_group, h);
 
   // There is an extra copy here vs using the R memory to back the
   // trajectories.  That's an optimisation that would be fairly easy to


### PR DESCRIPTION
A long-forgotten PR; this sets the scene to allow different behaviour for simulation (run-and-save-history) for discrete time and continuous time models, eventually allowing an interpolation-based solution for continuous time models