### PR TITLE
Store offset in packing

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust2
 Title: Next Generation dust
-Version: 0.3.6
+Version: 0.3.7
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/R/compile.R
+++ b/R/compile.R
@@ -218,7 +218,7 @@ dust_template_data <- function(name,
        has_adjoint = deparse1(has_adjoint),
        parameters = deparse_df(parameters, 4),
        default_dt = deparse1(default_dt),
-       package = paste0(gsub("[^A-Za-z1-9]", ".", name), mangle %||% ""),
+       package = paste0(gsub("[^A-Za-z0-9]", ".", name), mangle %||% ""),
        linking_to = linking_to,
        cpp_std = cpp_std,
        compiler_options = compiler_options)

--- a/R/compile.R
+++ b/R/compile.R
@@ -218,7 +218,7 @@ dust_template_data <- function(name,
        has_adjoint = deparse1(has_adjoint),
        parameters = deparse_df(parameters, 4),
        default_dt = deparse1(default_dt),
-       package = paste0(name, mangle %||% ""),
+       package = paste0(gsub("[^A-Za-z1-9]", ".", name), mangle %||% ""),
        linking_to = linking_to,
        cpp_std = cpp_std,
        compiler_options = compiler_options)

--- a/inst/include/dust2/packing.hpp
+++ b/inst/include/dust2/packing.hpp
@@ -45,6 +45,11 @@ public:
     return offset_;
   }
 
+  template <typename Iter>
+  void copy_offset(Iter it) {
+    std::copy(offset_.begin(), offset_.end(), it);
+  }
+
   bool operator!=(const packing& other) const {
     return data_ != other.data();
   }

--- a/inst/include/dust2/packing.hpp
+++ b/inst/include/dust2/packing.hpp
@@ -23,7 +23,6 @@ public:
       offset_.push_back(size_);
       size_ += len_i;
     }
-    size_ = std::accumulate(len_.begin(), len_.end(), 0);
   }
 
   packing() : size_(0) {
@@ -39,10 +38,6 @@ public:
 
   auto& data() const {
     return data_;
-  }
-
-  auto& offset() const {
-    return offset_;
   }
 
   template <typename Iter>

--- a/inst/include/dust2/packing.hpp
+++ b/inst/include/dust2/packing.hpp
@@ -26,6 +26,9 @@ public:
     size_ = std::accumulate(len_.begin(), len_.end(), 0);
   }
 
+  packing() {
+  }
+
   auto size() const {
     return size_;
   }

--- a/inst/include/dust2/packing.hpp
+++ b/inst/include/dust2/packing.hpp
@@ -26,7 +26,7 @@ public:
     size_ = std::accumulate(len_.begin(), len_.end(), 0);
   }
 
-  packing() {
+  packing() : size_(0) {
   }
 
   auto size() const {

--- a/inst/include/dust2/packing.hpp
+++ b/inst/include/dust2/packing.hpp
@@ -14,10 +14,14 @@ class packing {
   using mapping_type = std::pair<std::string, std::vector<size_t>>;
 public:
   packing(std::initializer_list<mapping_type> data)
-    : data_(data) {
+    : data_(data), size_(0) {
     len_.reserve(data_.size());
+    offset_.reserve(data_.size());
     for (auto& el : data_) {
-      len_.push_back(tools::prod(el.second));
+      const auto len_i = tools::prod(el.second);
+      len_.push_back(len_i);
+      offset_.push_back(size_);
+      size_ += len_i;
     }
     size_ = std::accumulate(len_.begin(), len_.end(), 0);
   }
@@ -34,6 +38,10 @@ public:
     return data_;
   }
 
+  auto& offset() const {
+    return offset_;
+  }
+
   bool operator!=(const packing& other) const {
     return data_ != other.data();
   }
@@ -41,6 +49,7 @@ public:
 private:
   std::vector<mapping_type> data_;
   std::vector<size_t> len_;
+  std::vector<size_t> offset_;
   size_t size_;
 };
 

--- a/inst/include/dust2/tools.hpp
+++ b/inst/include/dust2/tools.hpp
@@ -61,6 +61,15 @@ inline std::vector<size_t> integer_sequence(size_t n) {
   return ret;
 }
 
+inline std::vector<size_t> integer_sequence(size_t n, size_t offset) {
+  std::vector<size_t> ret;
+  ret.reserve(n);
+  for (size_t i = 0; i < n; ++i) {
+    ret.push_back(i + offset);
+  }
+  return ret;
+}
+
 template <typename T>
 std::vector<T> subset(const std::vector<T>& x, const std::vector<size_t> index) {
   std::vector<T> ret;

--- a/tests/testthat/test-compile.R
+++ b/tests/testthat/test-compile.R
@@ -59,6 +59,15 @@ test_that("can add parameter information", {
 })
 
 
+test_that("can cope with class name containing underscore", {
+  res <- dust_template_data(
+    "my_thing", "my_thing", "discrete", FALSE, FALSE, NULL, NULL)
+  expect_equal(res$class, "my_thing")
+  expect_equal(res$name, "my_thing")
+  expect_equal(res$package, "my.thing")
+})
+
+
 test_that("can select optimisation level", {
   expect_equal(validate_compiler_options(NULL, NULL), "")
   expect_equal(validate_compiler_options("-Xf", NULL), "-Xf")


### PR DESCRIPTION
This PR automatically computes offsets when creating a packing object in C++

It also sneaks in a couple of things for mrc-ide/odin2#123:

* add offset integer_sequence tool
* sanitise package names from classes containing an underscore