### PR TITLE
More flexible delays

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust2
 Title: Next Generation dust
-Version: 0.3.8
+Version: 0.3.9
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/inst/include/dust2/r/continuous/system.hpp
+++ b/inst/include/dust2/r/continuous/system.hpp
@@ -98,9 +98,9 @@ cpp11::sexp ode_internals_to_sexp(const ode::internals<real_type>& internals,
       history_coef = std::copy(h.c5.begin(), h.c5.end(), history_coef);
     }
     set_array_dims(r_history_coef, {n_history_state, 5, n_history_entries});
-    auto r_history = cpp11::writable::list{"time"_nm = r_history_time,
-                                           "size"_nm = r_history_size,
-                                           "coefficients"_nm = r_history_coef};
+    auto r_history = cpp11::writable::list{"time"_nm = std::move(r_history_time),
+                                           "size"_nm = std::move(r_history_size),
+                                           "coefficients"_nm = std::move(r_history_coef)};
     ret["history"] = cpp11::as_sexp(r_history);
   }
   return ret;

--- a/inst/include/dust2/r/helpers.hpp
+++ b/inst/include/dust2/r/helpers.hpp
@@ -300,7 +300,7 @@ inline void set_array_dims(cpp11::sexp data,
   for (size_t i = 0; i < dims.size(); ++i, ++dim_i) {
     r_dim[i] = *dim_i;
   }
-  data.attr("dim") = r_dim;
+  data.attr("dim") = std::move(r_dim);
 }
 
 template <typename Iter>
@@ -642,7 +642,7 @@ inline cpp11::sexp packing_to_r(const dust2::packing& packing_info) {
     ret[i] = cpp11::writable::integers(data[i].second.begin(),
                                        data[i].second.end());
   }
-  ret.attr("names") = nms;
+  ret.attr("names") = std::move(nms);
   return ret;
 }
 

--- a/tests/testthat/examples/delay.cpp
+++ b/tests/testthat/examples/delay.cpp
@@ -36,7 +36,7 @@ public:
   }
 
   static auto delays(const shared_state& shared) {
-    return dust2::ode::delays<real_type>({{1, {3}}});
+    return dust2::ode::delays<real_type>({{1, {{3, 1}}}});
   }
 
   static void initial(real_type time,
@@ -71,7 +71,8 @@ public:
                      const shared_state& shared,
                      internal_state& internal,
                      const dust2::ode::delay_result_type<real_type>& delays) {
-    state[4] = state[3] - delays[0][0];
+    const auto& delay_I = delays[0].data[0];
+    state[4] = state[3] - delay_I;
   }
 
   static shared_state build_shared(cpp11::list pars) {

--- a/tests/testthat/test-zzz-compile.R
+++ b/tests/testthat/test-zzz-compile.R
@@ -100,7 +100,6 @@ test_that("can run system with more variables than output", {
 
 test_that("can compile a model with delays", {
   skip_for_compilation()
-  pkgload::load_all(compile = FALSE)
   cmp <- dust_system_create(sirode, list())
   t <- seq(0, 100, 4)
   dust_system_set_state_initial(cmp)

--- a/tests/testthat/test-zzz-compile.R
+++ b/tests/testthat/test-zzz-compile.R
@@ -100,6 +100,7 @@ test_that("can run system with more variables than output", {
 
 test_that("can compile a model with delays", {
   skip_for_compilation()
+  pkgload::load_all(compile = FALSE)
   cmp <- dust_system_create(sirode, list())
   t <- seq(0, 100, 4)
   dust_system_set_state_initial(cmp)


### PR DESCRIPTION
This PR changes (in a way that breaks the embryonic odin delay support) how we do most of the bookkeeping for delays, with a view to support the delayed expressions - where we have multiple delayed variables within a delayed group.

* Each delayed variable now gets an `offset` (from the parent state) and a `length`.  From that we can easily compute the index (the sequence `offset...(offset + length - 1)`) rather than having odin do that for us
* We then compute offsets from the delayed variable set
* Use of `std::move` in some headers is just to prevent some compiler warnings that were coming from a possible issue in cpp11's copy constructors. I'm forcing a move rather than a copy here to stop the warning appear!

Imagine we have a model packing vectors: `{A, B, C, D, E, F}`, with length  `s_a, s_b, ...` and offset within the state by `o_a, o_b, ...`; we might create delay `B` and `D` as `{tau, {{o_b, s_b}, {o_d, s_d}}`

* `delay.index` holds `[o_b, o_b + 1, ..., o_b + s_b - 1, o_d, o_d + 1, ...]` which we use when saving coefficients of interpolation while we solve the system
* `delay.offset` holds `[0, s_b]` which is the position within the shorted delayed vector that `B` and `D` can be found