### PR TITLE
Simple event/root finding support

### DIFF
--- a/.covrignore
+++ b/.covrignore
@@ -7,3 +7,4 @@ src/malaria.cpp
 src/sir.cpp
 src/sirode.cpp
 src/walk.cpp
+inst/include/lostturnip.hpp

--- a/.gitattributes
+++ b/.gitattributes
@@ -7,4 +7,4 @@ src/sir.cpp linguist-generated=true
 src/sirode.cpp linguist-generated=true
 src/walk.cpp linguist-generated=true
 R/import-*.R linguist-generated=true
-inst/include/lostturnip.hpp linguist-vendored=true
+inst/include/lostturnip.hpp linguist-vendored=true linguist-generated=true

--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,4 @@ src/sir.cpp linguist-generated=true
 src/sirode.cpp linguist-generated=true
 src/walk.cpp linguist-generated=true
 R/import-*.R linguist-generated=true
+inst/include/lostturnip.hpp linguist-vendored=true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust2
 Title: Next Generation dust
-Version: 0.3.10
+Version: 0.3.11
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,6 +27,7 @@ Suggests:
     callr,
     cpp11,
     decor,
+    deSolve,
     fs,
     glue,
     knitr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,6 @@ Suggests:
     callr,
     cpp11,
     decor,
-    deSolve,
     fs,
     glue,
     knitr,

--- a/R/interface.R
+++ b/R/interface.R
@@ -485,7 +485,10 @@ dust_system_internals <- function(sys, include_coefficients = FALSE,
     error = vnapply(dat, "[[", "error"),
     n_steps = viapply(dat, "[[", "n_steps"),
     n_steps_accepted = viapply(dat, "[[", "n_steps_accepted"),
-    n_steps_rejected = viapply(dat, "[[", "n_steps_rejected"))
+    n_steps_rejected = viapply(dat, "[[", "n_steps_rejected"),
+    events = I(lapply(dat, function(x) {
+      if (is.null(x$events)) NULL else as.data.frame(x$events)
+    })))
   if (include_coefficients) {
     ret$coefficients <- I(lapply(dat, "[[", "coefficients"))
   }

--- a/inst/include/dust2/common.hpp
+++ b/inst/include/dust2/common.hpp
@@ -9,6 +9,7 @@
 #include <dust2/tools.hpp>
 #include <dust2/zero.hpp>
 #include <dust2/continuous/delays.hpp>
+#include <dust2/continuous/events.hpp>
 #include <cpp11/list.hpp>
 
 // In an odd place, we might update that later too

--- a/inst/include/dust2/continuous/events.hpp
+++ b/inst/include/dust2/continuous/events.hpp
@@ -28,7 +28,7 @@ bool is_root(const real_type a, const real_type b, const root_type& root) {
   return false;
 }
 
-template<typename real_type>
+template <typename real_type>
 struct event {
   size_t index;
   real_type value;
@@ -36,8 +36,18 @@ struct event {
   root_type root = root_type::both;
 };
 
-template<typename real_type>
+template <typename real_type>
 using events_type = std::vector<event<real_type>>;
+
+template <typename real_type>
+struct event_history_element {
+  real_type time;
+  size_t index;
+  real_type sign;
+};
+
+template <typename real_type>
+using event_history = std::vector<event_history_element<real_type>>;
 
 }
 }

--- a/inst/include/dust2/continuous/events.hpp
+++ b/inst/include/dust2/continuous/events.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <functional>
+#include <vector>
+
+namespace dust2 {
+namespace ode {
+
+// Do we detect an event when passing through the root as we increase
+// (negative to positive), decrease (positive to negative) or both:
+enum class root_type {
+  both,
+  increase,
+  decrease
+};
+
+// The actual logic for the above
+template <typename real_type>
+bool is_root(const real_type a, const real_type b, const root_type& root) {
+  switch(root) {
+  case root_type::both:
+    return a * b < 0;
+  case root_type::increase:
+    return a < 0 && b > 0;
+  case root_type::decrease:
+    return a > 0 && b < 0;
+  }
+  return false;
+}
+
+template<typename real_type>
+struct event {
+  size_t index;
+  real_type value;
+  std::function<void(real_type, real_type*)> action; // time, y
+  root_type root = root_type::both;
+};
+
+template<typename real_type>
+using events_type = std::vector<event<real_type>>;
+
+}
+}

--- a/inst/include/dust2/continuous/events.hpp
+++ b/inst/include/dust2/continuous/events.hpp
@@ -31,7 +31,7 @@ bool is_root(const real_type a, const real_type b, const root_type& root) {
 template <typename real_type>
 struct event {
   using test_type = std::function<real_type(const real_type, const real_type*)>;
-  using action_type = std::function<void(const real_type, real_type*)>;
+  using action_type = std::function<void(const real_type, const real_type, real_type*)>;
   std::vector<size_t> index;
   root_type root = root_type::both;
   test_type test;

--- a/inst/include/dust2/continuous/events.hpp
+++ b/inst/include/dust2/continuous/events.hpp
@@ -30,10 +30,20 @@ bool is_root(const real_type a, const real_type b, const root_type& root) {
 
 template <typename real_type>
 struct event {
-  size_t index;
-  real_type value;
-  std::function<void(real_type, real_type*)> action; // time, y
+  using test_type = std::function<real_type(const real_type, const real_type*)>;
+  using action_type = std::function<void(const real_type, real_type*)>;
+  std::vector<size_t> index;
   root_type root = root_type::both;
+  test_type test;
+  action_type action;
+
+  event(const std::vector<size_t>& index, test_type test, action_type action, root_type root = root_type::both) :
+    index(index), root(root), test(test), action(action) {
+  }
+
+  event(size_t index, action_type action, root_type root = root_type::both) :
+    event({index}, [](real_type t, const real_type* y) { return y[0]; }, action, root) {
+  }
 };
 
 template <typename real_type>

--- a/inst/include/dust2/continuous/history.hpp
+++ b/inst/include/dust2/continuous/history.hpp
@@ -66,15 +66,6 @@ struct history_step {
     }
   }
 
-  real_type interpolate(real_type time, size_t i) const {
-    // Consider special case for u or v == 0
-    // u == 0: return c1[i]
-    // v == 0: return c1[i] + c2[i]
-    const auto u = (time - t0) / h;
-    const auto v = 1 - u;
-    return c1[i] + u * (c2[i] + v * (c3[i] + u * (c4[i] + v * c5[i])));
-  }
-
   history_step subset(std::vector<size_t> index) const {
     return history_step(t0,
                         t1,

--- a/inst/include/dust2/continuous/history.hpp
+++ b/inst/include/dust2/continuous/history.hpp
@@ -66,6 +66,15 @@ struct history_step {
     }
   }
 
+  real_type interpolate(real_type time, size_t i) const {
+    // Consider special case for u or v == 0
+    // u == 0: return c1[i]
+    // v == 0: return c1[i] + c2[i]
+    const auto u = (time - t0) / h;
+    const auto v = 1 - u;
+    return c1[i] + u * (c2[i] + v * (c3[i] + u * (c4[i] + v * c5[i])));
+  }
+
   history_step subset(std::vector<size_t> index) const {
     return history_step(t0,
                         t1,

--- a/inst/include/dust2/continuous/solver.hpp
+++ b/inst/include/dust2/continuous/solver.hpp
@@ -360,7 +360,7 @@ private:
       }
       if (idx_first < events.size()) {
         internals.last.interpolate(t1, y_next_.data());
-        events[idx_first].action(t1, y_next_.data());
+        events[idx_first].action(t1, sign, y_next_.data());
         // We need to modify the history here so that search will find
         // the right point.
         internals.last.t1 = t1;

--- a/inst/include/dust2/continuous/solver.hpp
+++ b/inst/include/dust2/continuous/solver.hpp
@@ -9,6 +9,7 @@
 #include <dust2/tools.hpp>
 #include <dust2/zero.hpp>
 #include <dust2/continuous/control.hpp>
+#include <dust2/continuous/events.hpp>
 #include <dust2/continuous/history.hpp>
 
 namespace dust2 {

--- a/inst/include/dust2/continuous/system.hpp
+++ b/inst/include/dust2/continuous/system.hpp
@@ -68,7 +68,7 @@ public:
     errors_(n_particles_total_),
     rng_(n_particles_total_, seed, deterministic),
     delays_(do_delays<T>(shared_)),
-    events_(do_events<T>(shared_)),
+    events_(do_events<T>(shared_, internal_)),
     solver_(n_groups_ * n_threads_, {n_state_ode_, control_}),
     output_is_current_(n_groups_),
     requires_initialise_(n_groups_, true) {

--- a/inst/include/dust2/continuous/system.hpp
+++ b/inst/include/dust2/continuous/system.hpp
@@ -8,6 +8,7 @@
 #include <vector>
 #include <dust2/continuous/control.hpp>
 #include <dust2/continuous/delays.hpp>
+#include <dust2/continuous/events.hpp>
 #include <dust2/continuous/solver.hpp>
 #include <dust2/errors.hpp>
 #include <dust2/internals.hpp>
@@ -67,6 +68,7 @@ public:
     errors_(n_particles_total_),
     rng_(n_particles_total_, seed, deterministic),
     delays_(do_delays<T>(shared_)),
+    events_(do_events<T>(shared_)),
     solver_(n_groups_ * n_threads_, {n_state_ode_, control_}),
     output_is_current_(n_groups_),
     requires_initialise_(n_groups_, true) {
@@ -89,7 +91,7 @@ public:
         const auto offset = k * n_state_;
         real_type * y = state_data + offset;
         try {
-          solver_[i].run(time_, time, y, zero_every_[group],
+          solver_[i].run(time_, time, y, zero_every_[group], events_[group],
                          ode_internals_[k],
                          rhs_(particle, group, thread));
         } catch (std::exception const& e) {
@@ -130,7 +132,7 @@ public:
           for (size_t step = 0; step < n_steps; ++step) {
             const real_type t0 = t1;
             t1 = (step == n_steps - 1) ? time : time_ + step * dt_;
-            solver_[i].run(t0, t1, y, zero_every_[group],
+            solver_[i].run(t0, t1, y, zero_every_[group], events_[group],
                            ode_internals_[k],
                            rhs_(particle, group, thread));
             std::copy_n(y, n_state_ode_, y_other);
@@ -389,6 +391,7 @@ private:
   dust2::utils::errors errors_;
   monty::random::prng<rng_state_type> rng_;
   std::vector<ode::delays<real_type>> delays_;
+  std::vector<ode::events_type<real_type>> events_;
   std::vector<ode::solver<real_type>> solver_;
   std::vector<bool> output_is_current_;
   std::vector<bool> requires_initialise_;

--- a/inst/include/dust2/continuous/system.hpp
+++ b/inst/include/dust2/continuous/system.hpp
@@ -91,7 +91,7 @@ public:
         const auto offset = k * n_state_;
         real_type * y = state_data + offset;
         try {
-          solver_[i].run(time_, time, y, zero_every_[group], events_[group],
+          solver_[i].run(time_, time, y, zero_every_[group], events_[i],
                          ode_internals_[k],
                          rhs_(particle, group, thread));
         } catch (std::exception const& e) {
@@ -132,7 +132,7 @@ public:
           for (size_t step = 0; step < n_steps; ++step) {
             const real_type t0 = t1;
             t1 = (step == n_steps - 1) ? time : time_ + step * dt_;
-            solver_[i].run(t0, t1, y, zero_every_[group], events_[group],
+            solver_[i].run(t0, t1, y, zero_every_[group], events_[i],
                            ode_internals_[k],
                            rhs_(particle, group, thread));
             std::copy_n(y, n_state_ode_, y_other);

--- a/inst/include/dust2/properties.hpp
+++ b/inst/include/dust2/properties.hpp
@@ -2,6 +2,7 @@
 
 #include <dust2/packing.hpp>
 #include <dust2/continuous/delays.hpp>
+#include <dust2/continuous/events.hpp>
 #include <dust2/zero.hpp>
 #include <vector>
 
@@ -43,6 +44,11 @@ template <class T, class = void>
 struct test_has_delays: std::false_type {};
 template <class T>
 struct test_has_delays<T, std::void_t<decltype(T::delays)>>: std::true_type {};
+
+template <class T, class = void>
+struct test_has_events: std::false_type {};
+template <class T>
+struct test_has_events<T, std::void_t<decltype(T::events)>>: std::true_type {};
 
 // These test that the signature of rhs and output consume the delays
 // argument. Not especially lovely to read!
@@ -90,6 +96,7 @@ struct properties {
   // Because of the above these are now actual numbers rather than types; we may make this change everywhere...
   static constexpr bool rhs_uses_delays = internals::test_rhs_uses_delays<T>();
   static constexpr bool output_uses_delays = internals::test_output_uses_delays<T>();
+  using has_events = internals::test_has_events<T>;
 };
 
 // wrappers around some uses of member functions that may or may not
@@ -159,6 +166,23 @@ template <typename T, typename std::enable_if<!properties<T>::has_delays::value,
 auto do_delays(const std::vector<typename T::shared_state>& shared) {
   using real_type = typename T::real_type;
   return std::vector<ode::delays<real_type>>(shared.size(), dust2::ode::delays<real_type>{{}});
+}
+
+template <typename T, typename std::enable_if<properties<T>::has_events::value, T>::type* = nullptr>
+auto do_events(const std::vector<typename T::shared_state>& shared) {
+  using real_type = typename T::real_type;
+  std::vector<ode::events_type<real_type>> ret;
+  ret.reserve(shared.size());
+  for (size_t i = 0; i < shared.size(); ++i) {
+    ret.push_back(T::events(shared[i]));
+  }
+  return ret;
+}
+
+template <typename T, typename std::enable_if<!properties<T>::has_events::value, T>::type* = nullptr>
+auto do_events(const std::vector<typename T::shared_state>& shared) {
+  using real_type = typename T::real_type;
+  return std::vector<ode::events_type<real_type>>(shared.size(), dust2::ode::events_type<real_type>{{}});
 }
 
 }

--- a/inst/include/dust2/r/continuous/system.hpp
+++ b/inst/include/dust2/r/continuous/system.hpp
@@ -116,7 +116,7 @@ cpp11::sexp ode_internals_to_sexp(const ode::internals<real_type>& internals,
     auto r_event_sign = cpp11::writable::doubles(n_events);
     for (size_t i = 0; i < n_events; ++i) {
       r_event_time[i] = internals.events[i].time;
-      r_event_index[i] = static_cast<int>(internals.events[i].index);
+      r_event_index[i] = static_cast<int>(internals.events[i].index) + 1;
       r_event_sign[i] = internals.events[i].sign;
     }
     auto r_events = cpp11::writable::list{"time"_nm = std::move(r_event_time),

--- a/inst/include/dust2/r/continuous/system.hpp
+++ b/inst/include/dust2/r/continuous/system.hpp
@@ -67,7 +67,9 @@ cpp11::sexp ode_internals_to_sexp(const ode::internals<real_type>& internals,
     "n_steps_accepted"_nm = cpp11::as_sexp(internals.n_steps_accepted),
     "n_steps_rejected"_nm = cpp11::as_sexp(internals.n_steps_rejected),
     "coefficients"_nm = R_NilValue,
-    "history"_nm = R_NilValue};
+    "history"_nm = R_NilValue,
+    "events"_nm = R_NilValue};
+
   if (include_coefficients) {
     auto r_coef = cpp11::writable::doubles_matrix<>(internals.last.c1.size(), 5);
     auto coef = REAL(r_coef);
@@ -106,6 +108,21 @@ cpp11::sexp ode_internals_to_sexp(const ode::internals<real_type>& internals,
                                            "h"_nm = std::move(r_history_h),
                                            "coefficients"_nm = std::move(r_history_coef)};
     ret["history"] = cpp11::as_sexp(r_history);
+  }
+  if (!internals.events.empty()) {
+    const auto n_events = internals.events.size();
+    auto r_event_time = cpp11::writable::doubles(n_events);
+    auto r_event_index = cpp11::writable::integers(n_events);
+    auto r_event_sign = cpp11::writable::doubles(n_events);
+    for (size_t i = 0; i < n_events; ++i) {
+      r_event_time[i] = internals.events[i].time;
+      r_event_index[i] = static_cast<int>(internals.events[i].index);
+      r_event_sign[i] = internals.events[i].sign;
+    }
+    auto r_events = cpp11::writable::list{"time"_nm = std::move(r_event_time),
+                                          "index"_nm = std::move(r_event_index),
+                                          "sign"_nm = std::move(r_event_sign)};
+    ret["events"] = cpp11::as_sexp(r_events);
   }
   return ret;
 }

--- a/inst/include/lostturnip.hpp
+++ b/inst/include/lostturnip.hpp
@@ -1,0 +1,169 @@
+#pragma once
+#include <cmath>
+#include <limits>
+#include <stdexcept>
+
+namespace lostturnip {
+
+// Declaring these here, rather than within the find_result, as
+// otherwise we get a compiler warning about using experimental cuda
+// features. It will be equivalent though, but does require C++14.
+namespace {
+template <typename real_type>
+constexpr real_type na = std::numeric_limits<real_type>::quiet_NaN();
+
+template <typename real_type>
+constexpr real_type eps = std::numeric_limits<real_type>::epsilon();
+}
+
+template <typename real_type>
+struct result {
+  real_type x;
+  real_type fx;
+  int iterations;
+  bool converged;
+};
+
+// From zeroin.c, in brent.shar
+template <typename real_type, typename F>
+#ifdef __NVCC__
+__host__ __device__
+#endif
+result<real_type> find_result(F f, real_type a, real_type b,
+                              real_type tol, int max_iterations) {
+  real_type fa = f(a);
+  real_type fb = f(b);
+  int iterations = 0;
+  bool converged = false;
+
+  if (fa == 0) {
+    b = a;
+    fb = fa;
+    converged = true;
+  } else if (fb == 0) {
+    converged = true;
+  } else if (fa * fb > 0) {
+    // Same sign; can't find root with this:
+    b = na<real_type>;
+    fb = na<real_type>;
+    converged = false;
+  } else {
+    real_type c = a;
+    real_type fc = fa;   // c = a, f(c) = f(a)
+
+    for (; iterations < max_iterations; ++iterations) { // Main iteration loop
+      // Distance from the last but one to the last approximation
+      const real_type prev_step = b - a;
+
+      // Interpolation step is calculated in the form p/q; division
+      // operations is dlayed until the last moment
+      real_type p;
+      real_type q;
+
+      if (std::abs(fc) < std::abs(fb)) {
+        // Swap data for b to be the best approximation
+        a = b;
+        b = c;
+        c = a;
+        fa = fb;
+        fb = fc;
+        fc = fa;
+      }
+
+      // Actual tolerance
+      const real_type tol_act = 2 * eps<real_type> * std::abs(b) + tol / 2;
+      // Step at this iteration
+      real_type new_step = (c - b) / 2;
+
+      if (std::abs(new_step) <= tol_act || fb == 0) {
+        // Acceptable approximation is found
+        converged = true;
+        break;
+      }
+
+      // increase readability below, avoids many repeated static casts
+      const real_type one = 1;
+
+      // Decide if the interpolation can be tried
+      //
+      // If prev_step was large enough and was in true direction, then
+      // interpolation can be tried
+      if (std::abs(prev_step) >= tol_act && std::abs(fa) > std::abs(fb)) {
+        // interpolation
+        const real_type cb = c - b;
+        if (a == c) {
+          // If we have only two distinct points linear interpolation
+          // can only be applied
+          const real_type t1 = fb / fa;
+          p = cb * t1;
+          q = one - t1;
+        } else {
+          // Quadric inverse interpolation
+          q = fa / fc;
+          const real_type t1 = fb / fc;
+          const real_type t2 = fb / fa;
+          p = t2 * (cb * q * (q - t1) - (b - a) * (t1 - one));
+          q = (q - one) * (t1 - one) * (t2 - one);
+        }
+        if (p > 0) {
+          // p was calculated with the opposite sign; make p positive
+          // and assign possible minus to q
+          q = -q;
+        } else {
+          p = -p;
+        }
+
+        // If b + p / q falls in [b, c] and isn't too large it is
+        // accepted
+        //
+        // If p / q is too large then the bissection procedure can
+        // reduce [b,c] range to more extent
+        if (p < (static_cast<real_type>(0.75) * cb * q - std::abs(tol_act * q) / 2) &&
+            p < std::abs(prev_step * q / 2)) {
+          new_step = p / q;
+        }
+      }
+
+      // Adjust the step to be not less than tolerance
+      if (std::abs(new_step) < tol_act) {
+        new_step = std::copysign(tol_act, new_step);
+      }
+
+      // Save the previous approximation
+      a = b;
+      fa = fb;
+      // Do step to a new approximation
+      b += new_step;
+      fb = f(b);
+      if ((fb > 0 && fc > 0) || (fb < 0 && fc < 0)) {
+        // Adjust c for it to have a sign opposite to that of b
+        c = a;  fc = fa;
+      }
+    }
+  }
+
+#ifdef __CUDA_ARCH__
+  __syncwarp();
+#endif
+  return result<real_type>{b, fb, iterations, converged};
+}
+
+template <typename real_type, typename F>
+#ifdef __NVCC__
+__host__ __device__
+#endif
+real_type find(F f, real_type a, real_type b,
+               real_type tol, int max_iterations) {
+  const auto result = find_result(f, a, b, tol, max_iterations);
+  if (!result.converged) {
+#ifdef __CUDA_ARCH__
+    printf("some error\n");
+    __trap();
+#else
+    throw std::runtime_error("some error");
+#endif
+  }
+  return result.x;
+}
+
+}

--- a/tests/testthat/examples/event.cpp
+++ b/tests/testthat/examples/event.cpp
@@ -44,7 +44,7 @@ public:
   }
 
   static shared_state build_shared(cpp11::list pars) {
-    const real_type g = 9.81;
+    const real_type g = 9.8;
     const real_type height = dust2::r::read_real(pars, "height", 0);
     const real_type velocity = dust2::r::read_real(pars, "velocity", 10);
     const real_type damp = dust2::r::read_real(pars, "damp", 0.9);

--- a/tests/testthat/examples/event.cpp
+++ b/tests/testthat/examples/event.cpp
@@ -59,10 +59,11 @@ public:
     // We can capture 'shared' by scope here, but not internal; that
     // would require a second phase of binding, which would need to be
     // done by the system.
-    dust2::ode::event<real_type> e{0, 0, [&](double t, double* y) {
+    auto action = [&](double t, double* y) {
       y[0] = 0;
       y[1] = -shared.damp * y[1];
-    }};
+    };
+    dust2::ode::event<real_type> e(0, action);
     return dust2::ode::events_type<real_type>({e});
   }
 };

--- a/tests/testthat/examples/event.cpp
+++ b/tests/testthat/examples/event.cpp
@@ -56,10 +56,7 @@ public:
   }
 
   static auto events(const shared_state& shared, internal_state& internal) {
-    // We can capture 'shared' by scope here, but not internal; that
-    // would require a second phase of binding, which would need to be
-    // done by the system.
-    auto action = [&](double t, double* y) {
+    auto action = [&](const double t, const double sign, double* y) {
       y[0] = 0;
       y[1] = -shared.damp * y[1];
     };

--- a/tests/testthat/examples/event.cpp
+++ b/tests/testthat/examples/event.cpp
@@ -55,7 +55,7 @@ public:
     shared.damp = dust2::r::read_real(pars, "damp", shared.damp);
   }
 
-  static auto events(const shared_state& shared) {
+  static auto events(const shared_state& shared, internal_state& internal) {
     // We can capture 'shared' by scope here, but not internal; that
     // would require a second phase of binding, which would need to be
     // done by the system.

--- a/tests/testthat/examples/event.cpp
+++ b/tests/testthat/examples/event.cpp
@@ -1,0 +1,68 @@
+#include <dust2/common.hpp>
+
+// [[dust2::class(bounce)]]
+// [[dust2::time_type(continuous)]]
+// [[dust2::parameter(height, rank = 0)]]
+// [[dust2::parameter(velocity, rank = 0)]]
+class bounce {
+public:
+  bounce() = delete;
+
+  using real_type = double;
+
+  struct shared_state {
+    real_type g;
+    real_type height;
+    real_type velocity;
+    real_type damp;
+  };
+
+  struct internal_state {};
+
+  using rng_state_type = monty::random::generator<real_type>;
+
+  static dust2::packing packing_state(const shared_state& shared) {
+    return dust2::packing{{"height", {}}, {"velocity", {}}};
+  }
+
+  static void initial(real_type time,
+                      const shared_state& shared,
+                      internal_state& internal,
+                      rng_state_type& rng_state,
+                      real_type * state) {
+    state[0] = shared.height;
+    state[1] = shared.velocity;
+  }
+
+  static void rhs(real_type time,
+                  const real_type * state,
+                  const shared_state& shared,
+                  internal_state& internal,
+                  real_type * state_deriv) {
+    state_deriv[0] = state[1];
+    state_deriv[1] = -shared.g;
+  }
+
+  static shared_state build_shared(cpp11::list pars) {
+    const real_type g = 9.81;
+    const real_type height = dust2::r::read_real(pars, "height", 0);
+    const real_type velocity = dust2::r::read_real(pars, "velocity", 10);
+    const real_type damp = dust2::r::read_real(pars, "damp", 0.9);
+    return shared_state{g, height, velocity, damp};
+  }
+
+  static void update_shared(cpp11::list pars, shared_state& shared) {
+    shared.damp = dust2::r::read_real(pars, "damp", shared.damp);
+  }
+
+  static auto events(const shared_state& shared) {
+    // We can capture 'shared' by scope here, but not internal; that
+    // would require a second phase of binding, which would need to be
+    // done by the system.
+    dust2::ode::event<real_type> e{0, 0, [&](double t, double* y) {
+      y[0] = 0;
+      y[1] = -shared.damp * y[1];
+    }};
+    return dust2::ode::events_type<real_type>({e});
+  }
+};

--- a/tests/testthat/helper-dust.R
+++ b/tests/testthat/helper-dust.R
@@ -85,23 +85,12 @@ local_sir_generator <- function() {
 }
 
 
-example_bounce <- function(t) {
-  skip_if_not_installed("deSolve")
-  ball <- function(t, y, parms) {
-    dy1 <- y[2]
-    dy2 <- -9.8
-    list(c(dy1, dy2))
+example_bounce_analytic <- function(t, v0 = 10, damp = 0.9, g = 9.8) {
+  t0 <- 0
+  while (last(t0) < last(t)) {
+    t0 <- c(t0, last(t0) + 2 * v0 * damp^(length(t0) - 1) / g)
   }
-  yini <- c(height = 0, velocity = 10)
-  rootfunc <- function(t, y, parms) {
-    y[1]
-  }
-  eventfunc <- function(t, y, parms) {
-    y[1] <- 0
-    y[2] <- -0.9 * y[2]
-    y
-  }
-  deSolve::ode(times = t, y = yini, func = ball,
-               parms = NULL, rootfunc = rootfunc,
-               events = list(func = eventfunc, root = TRUE))
+  i <- findInterval(t, t0)
+  y <- v0 * damp^(i - 1) * (t - t0[i]) - 0.5 * g * (t - t0[i])^2
+  list(y = y, roots = t0[t0 > 0 & t0 < last(t)])
 }

--- a/tests/testthat/helper-dust.R
+++ b/tests/testthat/helper-dust.R
@@ -83,3 +83,25 @@ local_sir_generator <- function() {
   options(dust.testing.local_sir_generator = gen)
   gen
 }
+
+
+example_bounce <- function(t) {
+  skip_if_not_installed("deSolve")
+  ball <- function(t, y, parms) {
+    dy1 <- y[2]
+    dy2 <- -9.8
+    list(c(dy1, dy2))
+  }
+  yini <- c(height = 0, velocity = 10)
+  rootfunc <- function(t, y, parms) {
+    y[1]
+  }
+  eventfunc <- function(t, y, parms) {
+    y[1] <- 0
+    y[2] <- -0.9 * y[2]
+    y
+  }
+  deSolve::ode(times = t, y = yini, func = ball,
+               parms = NULL, rootfunc = rootfunc,
+               events = list(func = eventfunc, root = TRUE))
+}

--- a/tests/testthat/test-zzz-events.R
+++ b/tests/testthat/test-zzz-events.R
@@ -17,7 +17,7 @@ test_that("can run system with roots and events", {
   r <- info$events[[1]]
   expect_equal(nrow(r), 3)
   expect_equal(r$time, cmp$roots, tolerance = 1e-6)
-  expect_equal(r$index, rep(0L, 3))
+  expect_equal(r$index, rep(1L, 3))
   expect_equal(r$sign, rep(-1, 3))
 
   ## Stop at all roots:

--- a/tests/testthat/test-zzz-events.R
+++ b/tests/testthat/test-zzz-events.R
@@ -1,0 +1,16 @@
+test_that("can run system with roots and events", {
+  gen <- dust_compile("examples/event.cpp", quiet = TRUE, debug = TRUE)
+
+  sys <- dust_system_create(gen)
+  dust_system_set_state_initial(sys)
+  t <- seq(0, 6, length.out = 500)
+  y <- dust_system_simulate(sys, t)
+
+  ## This is realy not great, but at this point I don't know who is
+  ## worse.  Qualitatively we're about right though and I need to go
+  ## through and compare with an analytic solution as here we've got
+  ## two different approximations and a nonlinear system that is
+  ## acumulating error.
+  cmp <- example_bounce(t)
+  expect_equal(y[1, ], cmp[, 2], tolerance = 1e-2)
+})

--- a/tests/testthat/test-zzz-events.R
+++ b/tests/testthat/test-zzz-events.R
@@ -1,19 +1,30 @@
 test_that("can run system with roots and events", {
   gen <- dust_compile("examples/event.cpp", quiet = TRUE, debug = TRUE)
 
-  sys <- dust_system_create(gen)
+  control <- dust_ode_control(debug_record_step_times = TRUE, save_history = TRUE)
+  sys <- dust_system_create(gen, ode_control = control)
   dust_system_set_state_initial(sys)
-  t <- seq(0, 6, length.out = 500)
+
+  ## Use relatively few points for output here as this exacerbates
+  ## problems, even though the solution looks silly.
+  t <- seq(0, 6, length.out = 60)
   y <- dust_system_simulate(sys, t)
+  cmp <- example_bounce_analytic(t)
 
-  info <- dust_system_internals(sys)
-  expect_equal(nrow(info$events[[1]]), 3)
+  info <- dust_system_internals(sys, include_history = TRUE)
 
-  ## This is realy not great, but at this point I don't know who is
-  ## worse.  Qualitatively we're about right though and I need to go
-  ## through and compare with an analytic solution as here we've got
-  ## two different approximations and a nonlinear system that is
-  ## acumulating error.
-  cmp <- example_bounce(t)
-  expect_equal(y[1, ], cmp[, 2], tolerance = 1e-2)
+  ## Find all roots:
+  r <- info$events[[1]]
+  expect_equal(nrow(r, 3))
+  expect_equal(r$time, cmp$roots, tolerance = 1e-6)
+  expect_equal(r$index, rep(0L, 3))
+  expect_equal(r$sign, rep(-1, 3))
+
+  ## Stop at all roots:
+  h <- info$history[[1]]
+  expect_true(all(r$time %in% h$t0))
+  expect_true(all(r$time %in% h$t1))
+
+  ## Overall solution:
+  expect_equal(y[1, ], cmp$y, tolerance = 1e-6)
 })

--- a/tests/testthat/test-zzz-events.R
+++ b/tests/testthat/test-zzz-events.R
@@ -6,6 +6,9 @@ test_that("can run system with roots and events", {
   t <- seq(0, 6, length.out = 500)
   y <- dust_system_simulate(sys, t)
 
+  info <- dust_system_internals(sys)
+  expect_equal(nrow(info$events[[1]]), 3)
+
   ## This is realy not great, but at this point I don't know who is
   ## worse.  Qualitatively we're about right though and I need to go
   ## through and compare with an analytic solution as here we've got

--- a/tests/testthat/test-zzz-events.R
+++ b/tests/testthat/test-zzz-events.R
@@ -15,7 +15,7 @@ test_that("can run system with roots and events", {
 
   ## Find all roots:
   r <- info$events[[1]]
-  expect_equal(nrow(r, 3))
+  expect_equal(nrow(r), 3)
   expect_equal(r$time, cmp$roots, tolerance = 1e-6)
   expect_equal(r$index, rep(0L, 3))
   expect_equal(r$sign, rep(-1, 3))


### PR DESCRIPTION
This PR is fairly large, but some of that is copying in the header from lostturnip (mrc-ide/lostturnip).

The idea is most easily seen in the deSolve docs: https://tpetzoldt.github.io/deSolve-forcing/deSolve-forcing.html - example 3 there.  Suppose we have some system where we want to apply a change to the state of the system when it exactly hits some state - in the included example this is where a bouncing ball hits the ground (`height = 0`) we want to invert and reduce its velocity (so `-v` becomes `v * 0.9`).

We do this by checking at the end of every step if a root is bounded, which occurs if the sign changes over the step.  Then we interpolate within that step using the ODE interpolation to find the time where the event happens and apply some "action" function.

The actions can only change the state, they cannot change parameters, because we make the assumption that parameters are constant and shared among particles.  So likely use of this for some problems will involve augmenting the state with some additional variables that have `d/dt = 0`.  That's fine though because it keeps all mutable state within the state vector.

Other than that there's not a lot more in here:

* the root test and action functions can use `shared` and `internal`, so they can do a bunch of calculation if required
* this means that we hold n_groups * n_threads copies of events, mirroring the structure of `internal`
* we handle the special case where a single variable is of interest by creating a lambda in events.hpp