### PR TITLE
More explicit history time saving

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust2
 Title: Next Generation dust
-Version: 0.3.9
+Version: 0.3.10
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/inst/include/dust2/continuous/solver.hpp
+++ b/inst/include/dust2/continuous/solver.hpp
@@ -296,7 +296,8 @@ private:
   void accept(real_type t, real_type h, real_type* y, ode::internals<real_type>& internals) {
     // We might want to only do this bit if we'll actually use the
     // history, but it's pretty cheap really.
-    internals.last.t = t;
+    internals.last.t0 = t;
+    internals.last.t1 = t + h;
     internals.last.h = h;
     for (size_t i = 0; i < n_variables_; ++i) {
       const auto ydiff = y_next_[i] - y[i];
@@ -320,7 +321,7 @@ private:
     }
     for (const auto& el : zero_every) {
       const auto period = el.first;
-      const auto t_last_step = internals.last.t;
+      const auto t_last_step = internals.last.t0;
       const int n = std::floor(t / period);
       const int m = std::floor(t_last_step / period);
       if (n > m) {
@@ -351,7 +352,7 @@ private:
     for (const auto& el : zero_every) {
       const auto period = el.first;
       if (internals.last.h > period) {
-        const auto t_last_step = internals.last.t;
+        const auto t_last_step = internals.last.t0;
         const int n = std::ceil(t / period);
         const int m = std::ceil(t_last_step / period);
         if (n > m) {

--- a/inst/include/dust2/continuous/solver.hpp
+++ b/inst/include/dust2/continuous/solver.hpp
@@ -177,6 +177,7 @@ public:
 
       if (err <= 1) {
         success = true;
+        update_interpolation(t, h, y, internals);
         accept(t, h, y, internals);
         internals.n_steps_accepted++;
         if (control_.debug_record_step_times) {
@@ -293,7 +294,7 @@ public:
   }
 
 private:
-  void accept(real_type t, real_type h, real_type* y, ode::internals<real_type>& internals) {
+  void update_interpolation(real_type t, real_type h, real_type* y, ode::internals<real_type>& internals) {
     // We might want to only do this bit if we'll actually use the
     // history, but it's pretty cheap really.
     internals.last.t0 = t;
@@ -307,7 +308,9 @@ private:
       internals.last.c3[i] = bspl;
       internals.last.c4[i] = -h * k2_[i] + ydiff - bspl;
     }
+  }
 
+  void accept(real_type t, real_type h, real_type* y, ode::internals<real_type>& internals) {
     std::copy_n(k2_.begin(), n_variables_, internals.dydt.begin());
     std::copy_n(y_next_.begin(), n_variables_, y);
   }

--- a/inst/include/dust2/packing.hpp
+++ b/inst/include/dust2/packing.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <algorithm>
 #include <numeric>
 #include <stdexcept>
 #include <string>
@@ -43,7 +42,12 @@ public:
 
   template <typename Iter>
   void copy_offset(Iter it) {
-    std::copy_n(offset_.begin(), data_.size(), it);
+    // Avoiding std::copy and std::copy_n as we get a false positive
+    // warning about memmove here that would be worth looking into
+    // later.
+    for (size_t i = 0; i < data_.size(); ++i, ++it) {
+      *it = offset_[i];
+    }
   }
 
   bool operator!=(const packing& other) const {

--- a/inst/include/dust2/packing.hpp
+++ b/inst/include/dust2/packing.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <numeric>
 #include <stdexcept>
 #include <string>
@@ -42,7 +43,7 @@ public:
 
   template <typename Iter>
   void copy_offset(Iter it) {
-    std::copy(offset_.begin(), offset_.end(), it);
+    std::copy_n(offset_.begin(), data_.size(), it);
   }
 
   bool operator!=(const packing& other) const {

--- a/inst/include/dust2/r/continuous/system.hpp
+++ b/inst/include/dust2/r/continuous/system.hpp
@@ -83,14 +83,17 @@ cpp11::sexp ode_internals_to_sexp(const ode::internals<real_type>& internals,
     const auto n_history_state = internals.history_values.n_state();
     auto r_history_coef =
       cpp11::writable::doubles(n_history_state * 5 * n_history_entries);
-    auto r_history_time = cpp11::writable::doubles(n_history_entries);
-    auto r_history_size = cpp11::writable::doubles(n_history_entries);
+    auto r_history_t0 = cpp11::writable::doubles(n_history_entries);
+    auto r_history_t1 = cpp11::writable::doubles(n_history_entries);
+    auto r_history_h = cpp11::writable::doubles(n_history_entries);
     auto history_coef = REAL(r_history_coef);
-    auto history_time = REAL(r_history_time);
-    auto history_size = REAL(r_history_size);
+    auto history_t0 = REAL(r_history_t0);
+    auto history_t1 = REAL(r_history_t1);
+    auto history_h = REAL(r_history_h);
     for (auto& h: internals.history_values.data()) {
-      *history_time++ = h.t0;
-      *history_size++ = h.h;
+      *history_t0++ = h.t0;
+      *history_t1++ = h.t1;
+      *history_h++ = h.h;
       history_coef = std::copy(h.c1.begin(), h.c1.end(), history_coef);
       history_coef = std::copy(h.c2.begin(), h.c2.end(), history_coef);
       history_coef = std::copy(h.c3.begin(), h.c3.end(), history_coef);
@@ -98,8 +101,9 @@ cpp11::sexp ode_internals_to_sexp(const ode::internals<real_type>& internals,
       history_coef = std::copy(h.c5.begin(), h.c5.end(), history_coef);
     }
     set_array_dims(r_history_coef, {n_history_state, 5, n_history_entries});
-    auto r_history = cpp11::writable::list{"time"_nm = std::move(r_history_time),
-                                           "size"_nm = std::move(r_history_size),
+    auto r_history = cpp11::writable::list{"t0"_nm = std::move(r_history_t0),
+                                           "t1"_nm = std::move(r_history_t1),
+                                           "h"_nm = std::move(r_history_h),
                                            "coefficients"_nm = std::move(r_history_coef)};
     ret["history"] = cpp11::as_sexp(r_history);
   }

--- a/inst/include/dust2/r/continuous/system.hpp
+++ b/inst/include/dust2/r/continuous/system.hpp
@@ -89,7 +89,7 @@ cpp11::sexp ode_internals_to_sexp(const ode::internals<real_type>& internals,
     auto history_time = REAL(r_history_time);
     auto history_size = REAL(r_history_size);
     for (auto& h: internals.history_values.data()) {
-      *history_time++ = h.t;
+      *history_time++ = h.t0;
       *history_size++ = h.h;
       history_coef = std::copy(h.c1.begin(), h.c1.end(), history_coef);
       history_coef = std::copy(h.c2.begin(), h.c2.end(), history_coef);

--- a/tests/testthat/test-logistic.R
+++ b/tests/testthat/test-logistic.R
@@ -348,8 +348,6 @@ test_that("can save step times for debugging", {
 })
 
 
-
-
 test_that("can save history", {
   pars <- list(n = 3, r = c(0.1, 0.2, 0.3), K = rep(100, 3))
   ctl <- dust_ode_control(save_history = TRUE, debug_record_step_times = TRUE)
@@ -364,9 +362,10 @@ test_that("can save history", {
   expect_true("history" %in% names(d))
   history <- d$history[[1]]
   n_steps <- d$n_steps_accepted
-  expect_length(history$time, n_steps)
-  expect_equal(history$time, d$step_times[[1]][-(n_steps + 1)])
-  expect_equal(history$size, diff(d$step_times[[1]]))
+  expect_length(history$t0, n_steps)
+  expect_equal(history$t0, d$step_times[[1]][-(n_steps + 1)])
+  expect_equal(history$t1, d$step_times[[1]][-1])
+  expect_equal(history$h, diff(d$step_times[[1]]))
   expect_equal(history$coefficients[, , n_steps], d$coefficients[[1]])
 })
 


### PR DESCRIPTION
Small maintenance PR that will make #142 a bit easier to read.  This just adds t1 explicitly into the history, and separates out the step acceptance from updating interpolation coefficients