### PR TITLE
Allow callr to work with temporary models

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust2
 Title: Next Generation dust
-Version: 0.3.17
+Version: 0.3.18
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/R/interface-likelihood.R
+++ b/R/interface-likelihood.R
@@ -122,6 +122,14 @@ dust_likelihood_run <- function(obj, pars, initial = NULL,
 dust_likelihood_ensure_initialised <- function(obj, pars) {
   is_uninitialised <- is.null(obj$ptr)
   if (is_uninitialised) {
+    ## Where deserialisation has happened into an environment where
+    ## the package is not loaded, the environment of the method is set
+    ## to the global environment.  The other way we'd be able to tell
+    ## this is if the package is not loaded.
+    if (identical(environment(obj$methods$alloc), .GlobalEnv)) {
+      methods <- dust_system_generator_methods(obj$generator)$filter
+      assign("methods", methods, obj)
+    }
     index_group <- NULL
     pars <- check_pars(pars, obj$n_groups, index_group,
                        obj$preserve_group_dimension)

--- a/R/monty.R
+++ b/R/monty.R
@@ -226,7 +226,9 @@ dust_likelihood_monty <- function(obj, packer, initial = NULL, domain = NULL,
   }
 
   restore <- function() {
-    rm(list = "ptr", envir = obj)
+    if (!is.null(obj$ptr)) {
+      rm(list = "ptr", envir = obj)
+    }
   }
 
   ## I think that reconstructing the filter here to decouple any

--- a/tests/testthat/test-zzz-restore.R
+++ b/tests/testthat/test-zzz-restore.R
@@ -30,3 +30,35 @@ test_that("can serialise and restore model", {
   res2 <- monty::monty_sample_manual_collect(path)
   expect_equal(res2, res1)
 })
+
+
+test_that("Can restore model in monty context", {
+  mysir <- local_sir_generator()
+
+  pars <- list(beta = 0.1, gamma = 0.2, N = 1000, I0 = 10, exp_noise = 1e6)
+
+  set.seed(1)
+  time_start <- 0
+  data <- data.frame(time = c(4, 8, 12, 16), incidence = 1:4)
+
+  packer <- monty::monty_packer(
+    c("beta", "gamma"),
+    fixed = list(N = 1000, I0 = 10, exp_noise = 1e6))
+  prior <- monty::monty_dsl({
+    beta ~ Exponential(mean = 0.5)
+    gamma ~ Exponential(mean = 0.5)
+  })
+
+  obj <- dust_filter_create(mysir, time_start, data, n_particles = 100)
+  m <- dust_likelihood_monty(obj, packer) + prior
+  s <- monty::monty_sampler_random_walk(diag(2) * c(0.02, 0.02))
+  r <- monty::monty_runner_callr(2)
+
+  set.seed(1)
+  res <- monty::monty_sample(m, s, 20, initial = c(0.2, 0.1), runner = r)
+
+  set.seed(1)
+  cmp <- monty::monty_sample(m, s, 20, initial = c(0.2, 0.1))
+
+  expect_equal(res, cmp)
+})


### PR DESCRIPTION
This PR fixes a long-standing issue that I kept fixing about - using the callr runner (or similar) with a likelihood that comes from a model compiled on-the-fly and not from a package.  This is because even though we can repair the pointer (#138), we don't cope with fixing the methods on the deserialised object.

`readRDS` load the object and sees references to the temporary package, can't find that, and then sets the environment to the global environment.  This is documented in `load`:

>      Objects can be saved with references to namespaces, usually as
>      part of the environment of a function or formula.  Such objects
>      can be loaded even if the namespace is not available: it is
>      replaced by a reference to the global environment with a warning.
>      The warning identifies the first object with such a reference (but
>      there may be more than one).

At the point where we realise that the pointer needs fixing, we also check to see if the environment of the allocation function has been set to the global env.  If so, we load the package and try again.