### PR TITLE
Fix index of state when running a monty model

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust2
 Title: Next Generation dust
-Version: 0.3.19
+Version: 0.3.20
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",


### PR DESCRIPTION
Thanks for the example and pointer to the right bit of the logic @edknock - but it turns out that this is an issue with both packaged and non-packaged models (which I am happy about as I could not see how it was being triggered).  The issue comes if the filter has ever been initialised!  I've changed the logic around how we work out if the state index needs computing, after having worked out a failing example against the current version - see the added test which should fail for you and passes here.