### PR TITLE
Add name metadata to event

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust2
 Title: Next Generation dust
-Version: 0.3.21
+Version: 0.3.22
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/inst/include/dust2/continuous/events.hpp
+++ b/inst/include/dust2/continuous/events.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <functional>
+#include <string>
 #include <vector>
 
 namespace dust2 {

--- a/inst/include/dust2/continuous/events.hpp
+++ b/inst/include/dust2/continuous/events.hpp
@@ -32,17 +32,18 @@ template <typename real_type>
 struct event {
   using test_type = std::function<real_type(const real_type, const real_type*)>;
   using action_type = std::function<void(const real_type, const real_type, real_type*)>;
+  std::string name;
   std::vector<size_t> index;
   root_type root = root_type::both;
   test_type test;
   action_type action;
 
-  event(const std::vector<size_t>& index, test_type test, action_type action, root_type root = root_type::both) :
-    index(index), root(root), test(test), action(action) {
+  event(std::string name, const std::vector<size_t>& index, test_type test, action_type action, root_type root = root_type::both) :
+    name(name), index(index), root(root), test(test), action(action) {
   }
 
-  event(size_t index, action_type action, root_type root = root_type::both) :
-    event({index}, [](real_type t, const real_type* y) { return y[0]; }, action, root) {
+  event(std::string name, size_t index, action_type action, root_type root = root_type::both) :
+    event(name, {index}, [](real_type t, const real_type* y) { return y[0]; }, action, root) {
   }
 };
 

--- a/inst/include/dust2/continuous/system.hpp
+++ b/inst/include/dust2/continuous/system.hpp
@@ -367,6 +367,15 @@ public:
     return ode_internals_;
   }
 
+  auto event_names(size_t i) const {
+    std::vector<std::string> ret;
+    ret.reserve(events_.size());
+    for (const auto& el : events_[i]) {
+      ret.push_back(el.name);
+    }
+    return ret;
+  }
+
   bool errors_pending() const {
     return errors_.unresolved();
   }

--- a/tests/testthat/examples/event-time.cpp
+++ b/tests/testthat/examples/event-time.cpp
@@ -59,14 +59,16 @@ public:
     const auto n = shared.t_change.size();
     dust2::ode::events_type<real_type> events;
     events.reserve(n);
+    std::string prefix = "event-";
     for (size_t i = 0; i < n; ++i) {
+      const auto name = prefix + std::to_string(i + 1);
       auto test = [&, i](const double t, const real_type* y) {
         return t - shared.t_change[i];
       };
       auto action = [&, i](const double t, const double sign, double* y) {
         y[0] += shared.delta[i];
       };
-      events.push_back(dust2::ode::event<real_type>({}, test, action));
+      events.push_back(dust2::ode::event<real_type>(name, {}, test, action));
     }
     return events;
   }

--- a/tests/testthat/examples/event.cpp
+++ b/tests/testthat/examples/event.cpp
@@ -60,7 +60,7 @@ public:
       y[0] = 0;
       y[1] = -shared.damp * y[1];
     };
-    dust2::ode::event<real_type> e(0, action);
+    dust2::ode::event<real_type> e("bounce", 0, action);
     return dust2::ode::events_type<real_type>({e});
   }
 };

--- a/tests/testthat/test-zzz-events.R
+++ b/tests/testthat/test-zzz-events.R
@@ -16,6 +16,7 @@ test_that("can run system with roots and events", {
   ## Find all roots:
   r <- info$events[[1]]
   expect_equal(nrow(r), 3)
+  expect_equal(r$name, rep("bounce", 3))
   expect_equal(r$time, cmp$roots, tolerance = 1e-6)
   expect_equal(r$index, rep(1L, 3))
   expect_equal(r$sign, rep(-1, 3))
@@ -31,7 +32,7 @@ test_that("can run system with roots and events", {
 
 
 test_that("can run events with events in time", {
-  gen <- dust_compile("examples/event-time.cpp", quiet = FALSE, debug = TRUE)
+  gen <- dust_compile("examples/event-time.cpp", quiet = TRUE, debug = TRUE)
 
   # A mix of times that we will hit exactly and bracket
   pars <- list(r = 0.2, n = 3, t_change = c(2, 5.1234, 7), delta = rnorm(3))
@@ -47,8 +48,10 @@ test_that("can run events with events in time", {
   info <- dust_system_internals(sys, include_history = TRUE)
   expect_equal(
     info$events[[1]],
-    data_frame(time = pars$t_change, index = 1:3, sign = 1)
-  )
+    data_frame(name = sprintf("event-%d", 1:3),
+               time = pars$t_change,
+               index = 1:3,
+               sign = 1))
   expect_equal(
     drop(y),
     t * 0.2 + c(0, cumsum(pars$delta))[findInterval(t, pars$t_change) + 1])
@@ -56,7 +59,7 @@ test_that("can run events with events in time", {
 
 
 test_that("can cope with coincident events", {
-  gen <- dust_compile("examples/event-time.cpp", quiet = FALSE, debug = TRUE)
+  gen <- dust_compile("examples/event-time.cpp", quiet = TRUE, debug = TRUE)
 
   pars <- list(r = 0.2, n = 3, t_change = c(2, 2, 3), delta = c(1, 3, 5))
   control <- dust_ode_control(
@@ -71,8 +74,10 @@ test_that("can cope with coincident events", {
   info <- dust_system_internals(sys, include_history = TRUE)
   expect_equal(
     info$events[[1]],
-    data_frame(time = pars$t_change, index = 1:3, sign = 1)
-  )
+    data_frame(name = sprintf("event-%d", 1:3),
+               time = pars$t_change,
+               index = 1:3,
+               sign = 1))
   expect_equal(
     drop(y),
     t * 0.2 + c(0, cumsum(pars$delta))[findInterval(t, pars$t_change) + 1])


### PR DESCRIPTION
Each event takes as its first argument a `std::string` with a name; at the point where we save out the internals we'll copy that into a character vector.  This is a breaking change to using events, as every event must include a name - it would be easy to make this have a default of `""` but then we have two args with defaults which makes for awkward construction in the absence of keyword arguments.