### PR TITLE
Fix handling of events that do not alter variables

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust2
 Title: Next Generation dust
-Version: 0.3.23
+Version: 0.3.24
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/inst/include/dust2/continuous/events.hpp
+++ b/inst/include/dust2/continuous/events.hpp
@@ -29,6 +29,20 @@ bool is_root(const real_type a, const real_type b, const root_type& root) {
   return false;
 }
 
+
+template <typename real_type>
+bool is_root_at_b(const real_type a, const real_type b, const root_type& root) {
+  switch(root) {
+  case root_type::both:
+    return b == 0 && a != 0;
+  case root_type::increase:
+    return b == 0 && a < 0;
+  case root_type::decrease:
+    return b == 0 && a > 0;
+  }
+  return false;
+}
+
 template <typename real_type>
 struct event {
   using test_type = std::function<real_type(const real_type, const real_type*)>;

--- a/inst/include/dust2/continuous/solver.hpp
+++ b/inst/include/dust2/continuous/solver.hpp
@@ -400,7 +400,7 @@ private:
         if (found_any) {
           std::fill(found.begin(), found.end(), false);
         }
-      } else if (!(f_t1 == 0 && f_t0 != 0)) {
+      } else if (!is_root_at_b(f_t0, f_t1, e.root)) {
         // Consider the case where jump to a root *exactly* at t1;
         // this happens in coincident roots and with roots that are
         // based in time, and which we arrange for the solver to stop

--- a/inst/include/dust2/continuous/system.hpp
+++ b/inst/include/dust2/continuous/system.hpp
@@ -520,6 +520,7 @@ private:
           try {
             solver_[i].initialise(time_, y, ode_internals_[k],
                                   rhs_(particle, group, thread));
+            solver_[i].initialise_events(events_[i], ode_internals_[k]);
           } catch (std::exception const& e) {
             errors_.capture(e, k);
           }

--- a/tests/testthat/examples/event-zero.cpp
+++ b/tests/testthat/examples/event-zero.cpp
@@ -65,7 +65,6 @@ public:
     const auto test_y = [&](real_type t, const real_type* y) { return y[0] - shared.value_y; };
     const auto test_z = [&](real_type t, const real_type* y) { return y[0] - shared.value_z; };
     auto no_action = [](const double t, const double sign, double* y) {
-      Rprintf("Triggering action at %f\n", t);
     };
 
     dust2::ode::events_type<real_type> events;

--- a/tests/testthat/examples/event-zero.cpp
+++ b/tests/testthat/examples/event-zero.cpp
@@ -1,0 +1,76 @@
+#include <dust2/common.hpp>
+
+// [[dust2::class(eventzero)]]
+// [[dust2::time_type(continuous)]]
+// [[dust2::parameter(r, rank = 0)]]
+// [[dust2::parameter(value_y, rank = 0)]]
+// [[dust2::parameter(value_z, rank = 0)]]
+// [[dust2::parameter(period_z, rank = 0)]]
+class eventzero {
+public:
+  eventzero() = delete;
+
+  using real_type = double;
+
+  struct shared_state {
+    real_type r;
+    real_type value_y;
+    real_type value_z;
+    real_type period_z;
+ };
+
+  struct internal_state {};
+
+  using rng_state_type = monty::random::generator<real_type>;
+
+  static dust2::packing packing_state(const shared_state& shared) {
+    return dust2::packing{{"y", {}}, {"z", {}}};
+  }
+
+  static auto zero_every(const shared_state& shared) {
+    // Reset 'z' every period_z, but we'l have 'y' accumulate
+    return dust2::zero_every_type<real_type>{{shared.period_z, {1}}};
+  }
+
+  static void initial(real_type time,
+                      const shared_state& shared,
+                      internal_state& internal,
+                      rng_state_type& rng_state,
+                      real_type * state) {
+    state[0] = 0;
+    state[1] = 1;
+  }
+
+  static void rhs(real_type time,
+                  const real_type * state,
+                  const shared_state& shared,
+                  internal_state& internal,
+                  real_type * state_deriv) {
+    state_deriv[0] = time / shared.r;
+    state_deriv[1] = time / shared.r;
+  }
+
+  static shared_state build_shared(cpp11::list pars) {
+    const real_type r = dust2::r::read_real(pars, "r", 1.0);
+    const real_type value_y = dust2::r::read_real(pars, "value_y", 9999.0);
+    const real_type value_z = dust2::r::read_real(pars, "value_z", 9999.0);
+    const real_type period_z = dust2::r::read_real(pars, "period_z", 1.0);
+    return shared_state{r, value_y, value_z, period_z};
+  }
+
+  static void update_shared(cpp11::list pars, shared_state& shared) {
+  }
+
+  static auto events(const shared_state& shared, internal_state& internal) {
+    const auto test_y = [&](real_type t, const real_type* y) { return y[0] - shared.value_y; };
+    const auto test_z = [&](real_type t, const real_type* y) { return y[0] - shared.value_z; };
+    auto no_action = [](const double t, const double sign, double* y) {
+      Rprintf("Triggering action at %f\n", t);
+    };
+
+    dust2::ode::events_type<real_type> events;
+    events.push_back(dust2::ode::event<real_type>("y", {0}, test_y, no_action, dust2::ode::root_type::increase));
+    events.push_back(dust2::ode::event<real_type>("z", {1}, test_z, no_action, dust2::ode::root_type::increase));
+    return events;
+  }
+};

--- a/tests/testthat/test-zzz-events.R
+++ b/tests/testthat/test-zzz-events.R
@@ -82,3 +82,18 @@ test_that("can cope with coincident events", {
     drop(y),
     t * 0.2 + c(0, cumsum(pars$delta))[findInterval(t, pars$t_change) + 1])
 })
+
+
+test_that("allow events that do not alter the root", {
+  ## Solution is x^2 / 2r
+  gen <- dust_compile("examples/event-zero.cpp", quiet = TRUE, debug = TRUE)
+  ctl <- dust_ode_control(debug_record_step_times = TRUE, save_history = TRUE)
+  sys <- dust_system_create(gen, list(value_y = 6.3456), ode_control = ctl)
+  dust_system_run_to_time(sys, 100)
+  expect_equal(dust_system_time(sys), 100)
+  expect_equal(dust_system_state(sys), c(5000, 99.5)) # 100^2/2, (100^2 - 99^2)/2
+
+  info <- dust_system_internals(sys, include_history = TRUE)
+  expect_equal(info$events[[1]]$time, sqrt(2 * 6.3456))
+  expect_lt(info$n_steps, 20)
+})


### PR DESCRIPTION
This was a partial solution to issues seen in daedalus - seen in https://github.com/jameel-institute/daedalus/pull/83

I don't think this was sufficient for a fix there, but it was certainly necessary.  The issue here is that the current version of event tracking assumes that the event changes state in such a way that the event is immediately impossible. We already exclude this possibility for events in time due to use of an inequality, but the current solution does not work for events that do not change a state variable.  In this case, the event can appear bracketed by the step immediately after the event, leading to the solver failing.

This fix keeps track of the last time an event fired and refuses to fire a second event at the exact same time.  This should work generally because multiple events are allowed at the same time already (i.e., if two events trigger at exactly `t_i` then we apply both; then we won't apply another event at `t_i` again).  This might not quite be enough for all situations because if one of the changes triggers a root in a second event, then we should "take" a step of size 0 and apply that event too.

I don't recall what the other issues were, but it's possible that (the now merged PR) https://github.com/mrc-ide/dust2/pull/157 fixes some of these; one in particular was fixing the check as to if an event had actually happened.