### PR TITLE
Fix restoration of transient unfilter

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust2
 Title: Next Generation dust
-Version: 0.3.24
+Version: 0.3.25
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/R/interface-likelihood.R
+++ b/R/interface-likelihood.R
@@ -127,7 +127,8 @@ dust_likelihood_ensure_initialised <- function(obj, pars) {
     ## to the global environment.  The other way we'd be able to tell
     ## this is if the package is not loaded.
     if (identical(environment(obj$methods$alloc), .GlobalEnv)) {
-      methods <- dust_system_generator_methods(obj$generator)$filter
+      cls <- if (obj$deterministic) "unfilter" else "filter"
+      methods <- dust_system_generator_methods(obj$generator)[[cls]]
       assign("methods", methods, obj)
     }
     index_group <- NULL

--- a/tests/testthat/test-zzz-restore.R
+++ b/tests/testthat/test-zzz-restore.R
@@ -54,11 +54,27 @@ test_that("Can restore model in monty context", {
   s <- monty::monty_sampler_random_walk(diag(2) * c(0.02, 0.02))
   r <- monty::monty_runner_callr(2)
 
-  set.seed(1)
-  res <- monty::monty_sample(m, s, 20, initial = c(0.2, 0.1), runner = r)
+  initial <- c(0.2, 0.1)
 
   set.seed(1)
-  cmp <- monty::monty_sample(m, s, 20, initial = c(0.2, 0.1))
+  res <- monty::monty_sample(m, s, 20, initial = initial, runner = r)
+
+  set.seed(1)
+  cmp <- monty::monty_sample(m, s, 20, initial = initial)
+
+  expect_equal(res, cmp)
+
+  ## And again, with unfilter:
+  obj <- dust_unfilter_create(mysir, time_start, data)
+  m <- dust_likelihood_monty(obj, packer) + prior
+  s <- monty::monty_sampler_random_walk(diag(2) * c(0.02, 0.02))
+  r <- monty::monty_runner_callr(2)
+
+  set.seed(1)
+  res <- monty::monty_sample(m, s, 20, initial = initial, runner = r)
+
+  set.seed(1)
+  cmp <- monty::monty_sample(m, s, 20, initial = initial)
 
   expect_equal(res, cmp)
 })


### PR DESCRIPTION
Another iteration on a theme (see #149 and #138 for some of the previous attempts to fix this).

In #149 we introduced a check to find out if a on-the-fly model (generated with `dust_compile()`, possibly via `odin()`) had been serialised and restored but had lost its environment as a result. Unfortunately the fix there only worked for the stochastic models because we wired up methods using the `filter` element; this PR is a one line fix that gets the appropriate set of methods, allowing deserialisation to work correctly for the unfilter too.

The test here is a standalone version of the same problem as Ed originally observed and generates the same error (about `r_seed` being missing) when run against `main`

Closes #160 