### PR TITLE
Allow internals method for mixed-time systems

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust2
 Title: Next Generation dust
-Version: 0.3.25
+Version: 0.3.26
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/R/interface.R
+++ b/R/interface.R
@@ -888,7 +888,7 @@ dust_system_generator_methods <- function(generator) {
                     "update_pars",
                     "run_to_time", "simulate",
                     "reorder",
-                    if (time_type == "continuous") "internals")
+                    if (time_type != "discrete") "internals")
   methods_compare <- "compare_data"
   methods <- get_methods(c(methods_core, methods_compare), "system", name)
   ok <- !vapply(methods[methods_core], is.null, TRUE)

--- a/tests/testthat/test-malaria.R
+++ b/tests/testthat/test-malaria.R
@@ -49,3 +49,32 @@ test_that("Can compare to data", {
   expect_equal(dust_system_compare_data(sys, d),
                dbinom(d$positive, d$tested, s$Ih, log = TRUE))
 })
+
+test_that("Can get internals from mixed systems", {
+  n_particles <- 10
+  sys <- dust_system_create(
+    malaria(), list(), n_particles = n_particles, dt = 1
+  )
+  dust_system_set_state_initial(sys)
+  t <- seq(0, 20)
+  y <- dust_system_simulate(sys, t)
+
+  expect_no_condition(
+    dust_system_internals(sys)
+  )
+  expect_false(
+    is.null(dust_system_internals(sys))
+  )
+  
+  # same names as continuous system
+  s <- dust_system_create(sirode())
+  expect_identical(
+    names(dust_system_internals(sys)),
+    names(dust_system_internals(s))
+  )
+
+  expect_identical(
+    dust_system_internals(sys)[["particle"]],
+    seq(n_particles)
+  )
+})


### PR DESCRIPTION
This PR allows the `internals` method for mixed-time systems. I've simply disallowed discrete time systems for now.

I've added a couple of very basic tests under `test-malaria.R` as that seemed like the most likely place. Happy to move them. ~~Currently taking on a dev version which can be updated once this is ready to merge.~~