### PR TITLE
Avoid re-initialising solver where not needed

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust2
 Title: Next Generation dust
-Version: 0.3.27
+Version: 0.3.28
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",


### PR DESCRIPTION
~Builds on #158, as that refactors nearby code (see e8e5dec for an implementation against main).~

This PR aims to improve performance on mixed time models where the `update` function does not usually change the variables. Basically a one-line change making sure that there is any point running initialise before we do it.

Further optimisations to initialise are possible - we are probably also slower with frequent calls to initialise because we may reduce the step size too far after small changes in the state (this is the case in the malaria model I suspect) and additional heuristics there might help.  But that's a bigger and more experimental change