### PR TITLE
Fix check_time/check_time_sequence

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dust2
 Title: Next Generation dust
-Version: 0.3.28
+Version: 0.3.29
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/R/interface.R
+++ b/R/interface.R
@@ -663,7 +663,10 @@ check_time <- function(time, time_control, name = "time",
   assert_scalar_numeric(time, name = name, call = call)
   dt <- time_control$dt
   if (!is.null(dt) && dt > 0) {
-    if (abs(fmod(time, dt)) > sqrt(.Machine$double.eps)) {
+    rem <- fmod(time, dt)
+    err <- abs(rem) > sqrt(.Machine$double.eps) &&
+      abs(rem) < dt - sqrt(.Machine$double.eps)
+    if (err) {
       if (dt == 1) {
         cli::cli_abort(
           "'{name}' must be integer-like, because 'dt' is 1",

--- a/R/interface.R
+++ b/R/interface.R
@@ -693,7 +693,13 @@ check_time_sequence <- function(time, time_control,
   if ((!is.null(dt)) && (dt <= 1)) {
     #rem <- time %% dt # The problem is 10 %% 0.25 = 0, but 10 %% 0.1 = 0.1
     rem <- fmod(time, dt)
-    err <- abs(rem) > sqrt(.Machine$double.eps)
+    ## the second part of the condition here deals with a precision issue
+    ## where e.g. fmod(4.3, 0.1) is very slightly greater than -0.1 (= -dt)
+    ## when we'd expect it to be zero because 4.3 is clearly a multiple of 0.1
+    ## so while the 1st condition would flag it as an error, the 2nd will
+    ## de-flag it
+    err <- abs(rem) > sqrt(.Machine$double.eps) &
+      abs(rem) < dt - sqrt(.Machine$double.eps)
     if (any(err)) {
       i <- which(err)
       detail <- tail_errors(sprintf("'{name}[%d]' (%s) is invalid", i, time[i]))

--- a/inst/include/dust2/discrete/system.hpp
+++ b/inst/include/dust2/discrete/system.hpp
@@ -88,7 +88,7 @@ public:
     if (n_steps % 2 == 1) {
       std::swap(state_, state_next_);
     }
-    time_ = time_ + n_steps * dt_;
+    time_ = time;
   }
 
   void run_to_time(real_type time,
@@ -115,7 +115,7 @@ public:
       }
     }
     errors_.report();
-    time_ = time_ + n_steps * dt_;
+    time_ = time;
   }
 
   void simulate(const std::vector<real_type>& times,

--- a/inst/include/dust2/discrete/system.hpp
+++ b/inst/include/dust2/discrete/system.hpp
@@ -411,7 +411,7 @@ private:
     for (size_t i = 0; i < n_steps; ++i) {
       const auto time_i = time + i * dt;
       for (const auto& el : zero_every) {
-        if (std::fmod(time_i, el.first) == 0) {
+        if (tools::is_evenly_divisible_by(time_i, el.first)) {
           for (const auto j : el.second) {
             state[j] = 0;
           }
@@ -435,7 +435,7 @@ private:
     for (size_t i = 0; i < n_steps; ++i, state_next += stride) {
       const auto time_i = time + i * dt;
       for (const auto& el : zero_every) {
-        if (std::fmod(time_i, el.first) == 0) {
+        if (tools::is_evenly_divisible_by(time_i, el.first)) {
           std::copy_n(state_curr, n_state, state_model);
           state_curr = state_model;
           for (const auto j : el.second) {

--- a/inst/include/dust2/tools.hpp
+++ b/inst/include/dust2/tools.hpp
@@ -21,7 +21,8 @@ inline bool is_evenly_divisible_by(double num, double by) {
   // than sqrt(precision) and is consistent with the maximum expected
   // accumulation of rounding error for pathological choices of dt.
   constexpr double eps = 1e-13;
-  return std::abs(std::fmod(num, by)) < eps;
+  return (std::abs(std::fmod(num, by)) < eps) || 
+    (by - std::abs(std::fmod(num, by)) < eps);
 }
 
 template <typename T, typename U>

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -253,3 +253,22 @@ test_that("system generator objects are immutable", {
     sir[1] <- 1,
     "Cannot write to 'dust_system_generator' objects, they are read-only")
 })
+
+
+test_that("time is checked correctly", {
+  time <- 1.25
+  expect_equal(check_time(time, list(dt = 0.25)), time)
+  time <- 4.3
+  expect_equal(check_time(time, list(dt = 0.1)), time)
+  expect_error(check_time(time, list(dt = 0.25)),
+               "'time' must be a multiple of 'dt' (0.25)",
+               fixed = TRUE)
+  
+  time <- seq(0, 10, by = 0.25)
+  expect_equal(check_time_sequence(time, list(dt = 0.25)), time)
+  time <- seq(0, 10, by = 0.1)
+  expect_equal(check_time_sequence(time, list(dt = 0.1)), time)
+  expect_error(check_time_sequence(time, list(dt = 0.25)),
+               "Values in 'time' must be multiples of 'dt' (0.25)",
+               fixed = TRUE)
+})

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -257,9 +257,9 @@ test_that("system generator objects are immutable", {
 
 test_that("time is checked correctly", {
   time <- 1.25
-  expect_equal(check_time(time, list(dt = 0.25)), time)
+  expect_silent(check_time(time, list(dt = 0.25)))
   time <- 4.3
-  expect_equal(check_time(time, list(dt = 0.1)), time)
+  expect_silent(check_time(time, list(dt = 0.1)))
   expect_error(check_time(time, list(dt = 0.25)),
                "'time' must be a multiple of 'dt' (0.25)",
                fixed = TRUE)

--- a/tests/testthat/test-sir.R
+++ b/tests/testthat/test-sir.R
@@ -135,7 +135,7 @@ test_that("can reset cases daily", {
 })
 
 
-test_that("can reset cases daily with dt = 0.1", {
+test_that("can reset cases daily with dt = 0.01", {
   ## Testing with dt = 0.1 as modulo arithmetic works poorly in C++/R
   ## so we are checking the precision handles this sufficiently
   
@@ -144,9 +144,9 @@ test_that("can reset cases daily with dt = 0.1", {
   
   pars <- list(beta = 1.0, gamma = 0.5, N = 1000, I0 = 10, exp_noise = 1e6)
   obj <- dust_system_create(sir(), pars, n_particles = n_particles,
-                            dt = 0.1, seed = 42)
+                            dt = 0.01, seed = 42)
   dust_system_set_state_initial(obj)
-  t <- seq(0, 5, by = 0.1)
+  t <- seq(0, 20, by = 0.01)
   res <- dust_system_simulate(obj, t)
   
   ## Cumulative cases never decrease:

--- a/tests/testthat/test-sir.R
+++ b/tests/testthat/test-sir.R
@@ -128,10 +128,35 @@ test_that("can reset cases daily", {
   ## Cumulative cases never decrease:
   expect_true(all(diff(t(res[4, , ])) >= 0))
 
-  ## Incidence resets somtimes:
+  ## Incidence resets sometimes:
   expect_true(any(diff(t(res[5, , ])) < 0))
 
   expect_equal(apply(res[5, , ], 1, cumsum), t(res[4, , ]))
+})
+
+
+test_that("can reset cases daily with dt = 0.1", {
+  ## Testing with dt = 0.1 as modulo arithmetic works poorly in C++/R
+  ## so we are checking the precision handles this sufficiently
+  
+  n_time <- 20
+  n_particles <- 100
+  
+  pars <- list(beta = 1.0, gamma = 0.5, N = 1000, I0 = 10, exp_noise = 1e6)
+  obj <- dust_system_create(sir(), pars, n_particles = n_particles,
+                            dt = 0.1, seed = 42)
+  dust_system_set_state_initial(obj)
+  t <- seq(0, 5, by = 0.1)
+  res <- dust_system_simulate(obj, t)
+  
+  ## Cumulative cases never decrease:
+  expect_true(all(diff(t(res[4, , ])) >= 0))
+  
+  ## Incidence resets sometimes:
+  expect_true(any(diff(t(res[5, , ])) < 0))
+  
+  expect_equal(apply(res[5, , t %% 1 == 0], 1, cumsum), 
+               t(res[4, , t %% 1 == 0]))
 })
 
 

--- a/tests/testthat/test-sirode.R
+++ b/tests/testthat/test-sirode.R
@@ -13,13 +13,13 @@ test_that("can run sirode model", {
   expect_equal(cumsum(res[5, , ]), res[4, , ])
   
   
-  ## output at intervals of 0.1 to check zero_every is working correctly
+  ## output at intervals of 0.01 to check zero_every is working correctly
   obj <- dust_system_create(sirode(), pars, n_particles = 1,
                             preserve_particle_dimension = TRUE,
                             ode_control = dust_ode_control(step_size_max = 0.8),
                             deterministic = TRUE)
   dust_system_set_state_initial(obj)
-  t <- seq(0, 10, by = 0.1)
+  t <- seq(0, 10, by = 0.01)
   res <- dust_system_simulate(obj, t)
   
   ## Cumulative cases never decrease:

--- a/tests/testthat/test-sirode.R
+++ b/tests/testthat/test-sirode.R
@@ -11,6 +11,21 @@ test_that("can run sirode model", {
   expect_true(all(diff(res[4, , ]) >= 0))
 
   expect_equal(cumsum(res[5, , ]), res[4, , ])
+  
+  
+  ## output at intervals of 0.1 to check zero_every is working correctly
+  obj <- dust_system_create(sirode(), pars, n_particles = 1,
+                            preserve_particle_dimension = TRUE,
+                            ode_control = dust_ode_control(step_size_max = 0.8),
+                            deterministic = TRUE)
+  dust_system_set_state_initial(obj)
+  t <- seq(0, 10, by = 0.1)
+  res <- dust_system_simulate(obj, t)
+  
+  ## Cumulative cases never decrease:
+  expect_true(all(diff(res[4, , ]) >= 0))
+  
+  expect_equal(cumsum(res[5, , t %% 1]), res[4, , t %% 1])
 })
 
 


### PR DESCRIPTION
There is an issue that sometimes when `time` is checked to see if it is a multiple of `dt`, an error gets thrown unexpectedly

e.g.
```
> check_time(4.3, list(dt = 0.1))
Error:
! 'time' must be a multiple of 'dt' (0.1)
```

Clearly this should not be an error but this arises due to a precision issue: the following ends up being very slightly greater than -0.1 when we'd expect it to be 0

```
> fmod(4.3, 0.1)
[1] -0.1
```

which is because the following is non-zero
```
> 4.3 / 0.1 - 43
[1] -7.105427e-15
```

I've added a second part to the check for whether to throw an error that should avoid erroring in such cases.


There's also that the C++ code needs to handle similar cases - I've switched zero_every to use is_evenly_divisible_by and also have that catch within the precision both "is slightly more than evenly divisible by" and "is slightly less than evenly divisible by" and then we test with sir and sirode